### PR TITLE
fix(auth): improve email sign-up flow and error messages

### DIFF
--- a/app/src/main/java/tf/monochrome/android/data/auth/SupabaseAuthManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/auth/SupabaseAuthManager.kt
@@ -77,6 +77,9 @@ class SupabaseAuthManager @Inject constructor(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
+    private val _successMessage = MutableStateFlow<String?>(null)
+    val successMessage: StateFlow<String?> = _successMessage.asStateFlow()
+
     /** Restore existing session on app start */
     suspend fun initialize() {
         try {
@@ -90,20 +93,21 @@ class SupabaseAuthManager @Inject constructor(
     }
 
     /**
-     * Start Google OAuth via Supabase implicit flow — generates the OAuth URL,
+     * Start Google OAuth via Supabase PKCE flow — generates the OAuth URL,
      * then opens it in a Custom Tab. The app receives the callback via:
-     *   tf.monotrypt.android://login-callback#access_token=...&refresh_token=...
+     *   tf.monotrypt.android://login-callback?code=...
      */
     suspend fun signInWithGoogle(context: Context) {
         _isSigningIn.value = true
         _errorMessage.value = null
+        _successMessage.value = null
         try {
             val url = auth.getOAuthUrl(Google)
             Log.d("SupabaseAuth", "OAuth URL: $url")
             val customTab = CustomTabsIntent.Builder().build()
             customTab.launchUrl(context, Uri.parse(url))
         } catch (e: Exception) {
-            _errorMessage.value = "Google sign-in failed: ${e.message}"
+            _errorMessage.value = "Google sign-in failed: ${parseAuthError(e)}"
             _isSigningIn.value = false
         }
     }
@@ -164,6 +168,7 @@ class SupabaseAuthManager @Inject constructor(
     suspend fun signInWithEmail(email: String, password: String): Result<UserProfile> {
         _isSigningIn.value = true
         _errorMessage.value = null
+        _successMessage.value = null
         return try {
             auth.signInWith(Email) {
                 this.email = email
@@ -175,26 +180,38 @@ class SupabaseAuthManager @Inject constructor(
             _userProfile.value = profile
             Result.success(profile)
         } catch (e: Exception) {
-            _errorMessage.value = e.message ?: "Login failed"
+            _errorMessage.value = parseAuthError(e)
             Result.failure(e)
         } finally {
             _isSigningIn.value = false
         }
     }
 
-    /** Sign up with email + password, then auto sign-in */
+    /** Sign up with email + password */
     suspend fun signUpWithEmail(email: String, password: String): Result<UserProfile> {
         _isSigningIn.value = true
         _errorMessage.value = null
+        _successMessage.value = null
         return try {
             auth.signUpWith(Email) {
                 this.email = email
                 this.password = password
             }
-            // Auto sign-in after registration
-            signInWithEmail(email, password)
+            // Check if auto-confirmed (session created immediately)
+            val user = auth.currentUserOrNull()
+            if (user != null) {
+                val profile = user.toProfile()
+                _userProfile.value = profile
+                _isSigningIn.value = false
+                Result.success(profile)
+            } else {
+                // Email confirmation required — don't attempt sign-in
+                _isSigningIn.value = false
+                _successMessage.value = "Account created! Check your email for a confirmation link, then sign in."
+                Result.failure(Exception("Email confirmation required"))
+            }
         } catch (e: Exception) {
-            _errorMessage.value = e.message ?: "Sign up failed"
+            _errorMessage.value = parseAuthError(e)
             _isSigningIn.value = false
             Result.failure(e)
         }
@@ -222,6 +239,42 @@ class SupabaseAuthManager @Inject constructor(
 
     fun clearError() {
         _errorMessage.value = null
+    }
+
+    fun clearSuccess() {
+        _successMessage.value = null
+    }
+
+    /** Extract a user-friendly message from Supabase auth exceptions */
+    private fun parseAuthError(e: Exception): String {
+        val msg = e.message ?: return "An unknown error occurred"
+        return when {
+            msg.contains("invalid_credentials", ignoreCase = true) ->
+                "Invalid email or password. Please check your credentials and try again."
+            msg.contains("user_already_exists", ignoreCase = true) ||
+            msg.contains("already registered", ignoreCase = true) ->
+                "An account with this email already exists. Try signing in instead."
+            msg.contains("email_not_confirmed", ignoreCase = true) ->
+                "Please check your email and confirm your account before signing in."
+            msg.contains("weak_password", ignoreCase = true) ->
+                "Password is too weak. Please use at least 8 characters with a mix of letters and numbers."
+            msg.contains("signup_disabled", ignoreCase = true) ->
+                "Account registration is currently disabled."
+            msg.contains("over_request_rate_limit", ignoreCase = true) ||
+            msg.contains("rate_limit", ignoreCase = true) ->
+                "Too many attempts. Please wait a moment and try again."
+            msg.contains("validation_failed", ignoreCase = true) ->
+                "Please enter a valid email address."
+            msg.contains("network", ignoreCase = true) ||
+            msg.contains("timeout", ignoreCase = true) ||
+            msg.contains("Unable to resolve host", ignoreCase = true) ->
+                "Network error. Please check your internet connection and try again."
+            else -> {
+                // Fallback: take just the first line, stripping HTTP details
+                val firstLine = msg.lines().firstOrNull() ?: "Authentication failed"
+                if (firstLine.length > 120) firstLine.take(120) + "…" else firstLine
+            }
+        }
     }
 
     private fun UserInfo.toProfile() = UserProfile(

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
@@ -78,6 +78,7 @@ fun ProfileScreen(
     val userProfile by viewModel.userProfile.collectAsState()
     val isSigningIn by viewModel.isSigningIn.collectAsState()
     val errorMessage by viewModel.errorMessage.collectAsState()
+    val successMessage by viewModel.successMessage.collectAsState()
     val isSyncing by viewModel.isSyncing.collectAsState()
     val syncStatus by viewModel.syncStatus.collectAsState()
     val scope = rememberCoroutineScope()
@@ -152,6 +153,7 @@ fun ProfileScreen(
                     SignedOutView(
                         isLoading = false,
                         errorMessage = errorMessage,
+                        successMessage = successMessage,
                         onSignInWithGoogle = {
                             viewModel.signInWithGoogle(context)
                         },
@@ -161,7 +163,7 @@ fun ProfileScreen(
                         onSignUpWithEmail = { email, password ->
                             viewModel.signUpWithEmail(email, password)
                         },
-                        onClearError = { viewModel.clearError() }
+                        onClearError = { viewModel.clearError(); viewModel.clearSuccess() }
                     )
                 }
             }
@@ -290,6 +292,7 @@ private fun SignedInView(
 private fun SignedOutView(
     isLoading: Boolean,
     errorMessage: String?,
+    successMessage: String?,
     onSignInWithGoogle: () -> Unit,
     onSignInWithEmail: (String, String) -> Unit,
     onSignUpWithEmail: (String, String) -> Unit,
@@ -405,6 +408,25 @@ private fun SignedOutView(
         shape = RoundedCornerShape(12.dp)
     )
 
+    // Success message (e.g. after sign-up requiring email confirmation)
+    if (successMessage != null) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+            ),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Text(
+                text = successMessage,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(12.dp)
+            )
+        }
+    }
+
     // Error message
     if (errorMessage != null) {
         Spacer(modifier = Modifier.height(8.dp))
@@ -416,6 +438,13 @@ private fun SignedOutView(
     }
 
     Spacer(modifier = Modifier.height(16.dp))
+
+    // Switch back to sign-in mode after successful account creation
+    LaunchedEffect(successMessage) {
+        if (successMessage != null && isSignUp) {
+            isSignUp = false
+        }
+    }
 
     // Sign In / Sign Up button
     ElevatedButton(

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
@@ -24,6 +24,7 @@ class ProfileViewModel @Inject constructor(
     val userProfile: StateFlow<UserProfile?> = authManager.userProfile
     val isSigningIn: StateFlow<Boolean> = authManager.isSigningIn
     val errorMessage: StateFlow<String?> = authManager.errorMessage
+    val successMessage: StateFlow<String?> = authManager.successMessage
 
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
@@ -84,5 +85,9 @@ class ProfileViewModel @Inject constructor(
 
     fun clearError() {
         authManager.clearError()
+    }
+
+    fun clearSuccess() {
+        authManager.clearSuccess()
     }
 }


### PR DESCRIPTION
- Fix sign-up to handle email confirmation gracefully instead of blindly attempting auto sign-in (which fails with invalid_credentials)
- Add parseAuthError() to show user-friendly messages instead of raw Supabase HTTP details (URL, headers, etc.)
- Add success message state to show confirmation feedback after sign-up
- Auto-switch to sign-in mode after successful account creation