### PR TITLE
Add Parametric EQ with 120 fps FFT spectrum analyzer

### DIFF
--- a/.github/workflows/gradlew.yml
+++ b/.github/workflows/gradlew.yml
@@ -1,0 +1,132 @@
+name: Gradle CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Gradle task to run (e.g. assembleDebug, lint, test)'
+        required: false
+        default: 'assembleDebug'
+
+concurrency:
+  group: gradle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run lint
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Upload lint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-*.html
+          retention-days: 14
+          if-no-files-found: ignore
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: app/build/reports/tests/testDebugUnitTest
+          retention-days: 14
+          if-no-files-found: ignore
+
+  build:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Gradle task
+        run: ./gradlew ${{ github.event.inputs.task || 'assembleDebug' }} --stacktrace
+
+      - name: Upload debug APK
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: monotrypt-debug-${{ github.sha }}
+          path: app/build/outputs/apk/debug/*.apk
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Signed Release APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_name:
+        description: 'Optional version name suffix for the artifact (e.g. 1.0.1)'
+        required: false
+        default: ''
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build signed release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::Missing required secret: KEYSTORE_BASE64"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/keystore"
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/keystore/release.keystore"
+
+      - name: Write keystore.properties
+        env:
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          [ -z "$KEYSTORE_STORE_PASSWORD" ] && missing+=("KEYSTORE_STORE_PASSWORD")
+          [ -z "$KEYSTORE_KEY_ALIAS" ] && missing+=("KEYSTORE_KEY_ALIAS")
+          [ -z "$KEYSTORE_KEY_PASSWORD" ] && missing+=("KEYSTORE_KEY_PASSWORD")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          cat > keystore.properties <<EOF
+          storeFile=$RUNNER_TEMP/keystore/release.keystore
+          storePassword=$KEYSTORE_STORE_PASSWORD
+          keyAlias=$KEYSTORE_KEY_ALIAS
+          keyPassword=$KEYSTORE_KEY_PASSWORD
+          EOF
+
+      - name: Build signed release APK
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Verify APK signature
+        run: |
+          BUILD_TOOLS=$(ls -d $ANDROID_HOME/build-tools/* | sort -V | tail -n 1)
+          APK=$(ls app/build/outputs/apk/release/*.apk | head -n 1)
+          "$BUILD_TOOLS/apksigner" verify --verbose "$APK"
+
+      - name: Upload signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: monotrypt-release${{ inputs.version_name && format('-{0}', inputs.version_name) || '' }}-${{ github.sha }}
+          path: app/build/outputs/apk/release/*.apk
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Cleanup signing material
+        if: always()
+        run: |
+          rm -f keystore.properties
+          rm -rf "$RUNNER_TEMP/keystore"

--- a/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
@@ -1,0 +1,275 @@
+package tf.monochrome.android.audio.eq
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.util.UnstableApi
+import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.FilterType
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Standalone general-purpose parametric EQ AudioProcessor. Independent of AutoEQ,
+ * so users can chain both (AutoEQ for headphone correction + Parametric for tone shaping).
+ *
+ * Sits in the ExoPlayer pipeline *after* AutoEQ. Uses RBJ Audio EQ Cookbook biquad
+ * filters (peaking, low shelf, high shelf).
+ */
+@Singleton
+@OptIn(UnstableApi::class)
+class ParametricEqProcessor @Inject constructor() : AudioProcessor {
+
+    private var pendingFormat = AudioFormat.NOT_SET
+    private var inputFormat = AudioFormat.NOT_SET
+    private var outputBuffer: ByteBuffer = AudioProcessor.EMPTY_BUFFER
+    private var inputEnded = false
+
+    private var scratchL = FloatArray(0)
+    private var scratchR = FloatArray(0)
+
+    @Volatile private var eqEnabled = false
+    @Volatile private var currentBands: Array<BandState> = emptyArray()
+    @Volatile private var preampLinear = 1f
+
+    private var filtersL = arrayOf<BiquadFilter>()
+    private var filtersR = arrayOf<BiquadFilter>()
+    private var filtersDirty = true
+    private var sampleRate = 44100.0
+
+    fun applyBands(bands: List<EqBand>, preamp: Float, enabled: Boolean) {
+        eqEnabled = enabled
+        preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f)
+        currentBands = bands.map { band ->
+            BandState(
+                freq = band.freq,
+                gain = band.gain,
+                q = band.q,
+                type = band.type,
+                enabled = band.enabled
+            )
+        }.toTypedArray()
+        filtersDirty = true
+    }
+
+    override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT &&
+            inputAudioFormat.encoding != C.ENCODING_PCM_FLOAT) {
+            throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
+        }
+        if (inputAudioFormat.channelCount != 1 && inputAudioFormat.channelCount != 2) {
+            throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
+        }
+        pendingFormat = inputAudioFormat
+        return if (inputAudioFormat.channelCount == 1) {
+            AudioFormat(inputAudioFormat.sampleRate, 2, inputAudioFormat.encoding)
+        } else {
+            inputAudioFormat
+        }
+    }
+
+    override fun isActive(): Boolean =
+        pendingFormat != AudioFormat.NOT_SET || inputFormat != AudioFormat.NOT_SET
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val encoding = inputFormat.encoding
+        val inputChannels = inputFormat.channelCount
+        val bytesPerSample = if (encoding == C.ENCODING_PCM_FLOAT) 4 else 2
+        val frameSize = bytesPerSample * inputChannels
+        val numFrames = inputBuffer.remaining() / frameSize
+        if (numFrames <= 0) return
+
+        if (scratchL.size < numFrames) {
+            scratchL = FloatArray(numFrames)
+            scratchR = FloatArray(numFrames)
+        }
+
+        if (inputChannels == 1) {
+            if (encoding == C.ENCODING_PCM_FLOAT) {
+                val fb = inputBuffer.asFloatBuffer()
+                for (i in 0 until numFrames) {
+                    val s = fb.get(); scratchL[i] = s; scratchR[i] = s
+                }
+            } else {
+                val sb = inputBuffer.asShortBuffer()
+                for (i in 0 until numFrames) {
+                    val s = sb.get().toFloat() / 32768f; scratchL[i] = s; scratchR[i] = s
+                }
+            }
+        } else {
+            if (encoding == C.ENCODING_PCM_FLOAT) {
+                val fb = inputBuffer.asFloatBuffer()
+                for (i in 0 until numFrames) { scratchL[i] = fb.get(); scratchR[i] = fb.get() }
+            } else {
+                val sb = inputBuffer.asShortBuffer()
+                for (i in 0 until numFrames) {
+                    scratchL[i] = sb.get().toFloat() / 32768f
+                    scratchR[i] = sb.get().toFloat() / 32768f
+                }
+            }
+        }
+        inputBuffer.position(inputBuffer.position() + numFrames * frameSize)
+
+        if (eqEnabled) {
+            if (filtersDirty) {
+                rebuildFilters()
+                filtersDirty = false
+            }
+            applyEq(numFrames)
+        }
+
+        val outFrameSize = bytesPerSample * 2
+        val outBytes = numFrames * outFrameSize
+        if (outputBuffer.capacity() < outBytes) {
+            outputBuffer = ByteBuffer.allocateDirect(outBytes).order(ByteOrder.nativeOrder())
+        } else {
+            outputBuffer.clear()
+        }
+        if (encoding == C.ENCODING_PCM_FLOAT) {
+            val fb = outputBuffer.asFloatBuffer()
+            for (i in 0 until numFrames) { fb.put(scratchL[i]); fb.put(scratchR[i]) }
+        } else {
+            val sb = outputBuffer.asShortBuffer()
+            for (i in 0 until numFrames) {
+                sb.put((scratchL[i] * 32768f).toInt().coerceIn(-32768, 32767).toShort())
+                sb.put((scratchR[i] * 32768f).toInt().coerceIn(-32768, 32767).toShort())
+            }
+        }
+        outputBuffer.position(0)
+        outputBuffer.limit(outBytes)
+    }
+
+    override fun getOutput(): ByteBuffer {
+        val buf = outputBuffer
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        return buf
+    }
+
+    override fun isEnded(): Boolean = inputEnded && outputBuffer === AudioProcessor.EMPTY_BUFFER
+    override fun queueEndOfStream() { inputEnded = true }
+
+    override fun flush() {
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        inputEnded = false
+        if (pendingFormat != AudioFormat.NOT_SET) {
+            val formatChanged = inputFormat == AudioFormat.NOT_SET
+                || inputFormat.sampleRate != pendingFormat.sampleRate
+                || inputFormat.encoding != pendingFormat.encoding
+                || inputFormat.channelCount != pendingFormat.channelCount
+            if (formatChanged) {
+                inputFormat = pendingFormat
+                sampleRate = inputFormat.sampleRate.toDouble()
+                filtersDirty = true
+            }
+            pendingFormat = AudioFormat.NOT_SET
+        }
+    }
+
+    override fun reset() {
+        flush()
+        pendingFormat = AudioFormat.NOT_SET
+        inputFormat = AudioFormat.NOT_SET
+        filtersL = emptyArray()
+        filtersR = emptyArray()
+    }
+
+    private fun applyEq(numFrames: Int) {
+        val gain = preampLinear
+        if (gain != 1f) {
+            for (i in 0 until numFrames) {
+                scratchL[i] *= gain
+                scratchR[i] *= gain
+            }
+        }
+        for (i in filtersL.indices) {
+            filtersL[i].processBlock(scratchL, numFrames)
+            filtersR[i].processBlock(scratchR, numFrames)
+        }
+    }
+
+    private fun rebuildFilters() {
+        val bands = currentBands
+        val active = bands.filter { it.enabled && it.gain != 0f }
+        filtersL = Array(active.size) { BiquadFilter() }
+        filtersR = Array(active.size) { BiquadFilter() }
+        for ((i, band) in active.withIndex()) {
+            val type = when (band.type) {
+                FilterType.LOWSHELF -> BiquadType.LOW_SHELF
+                FilterType.HIGHSHELF -> BiquadType.HIGH_SHELF
+                else -> BiquadType.PEAKING
+            }
+            filtersL[i].configure(type, sampleRate, band.freq.toDouble(), band.q.toDouble(), band.gain.toDouble())
+            filtersR[i].configure(type, sampleRate, band.freq.toDouble(), band.q.toDouble(), band.gain.toDouble())
+        }
+    }
+
+    private enum class BiquadType { PEAKING, LOW_SHELF, HIGH_SHELF }
+
+    private class BandState(
+        val freq: Float, val gain: Float, val q: Float,
+        val type: FilterType, val enabled: Boolean
+    )
+
+    private class BiquadFilter {
+        private var b0 = 1f; private var b1 = 0f; private var b2 = 0f
+        private var a1 = 0f; private var a2 = 0f
+        private var z1 = 0f; private var z2 = 0f
+
+        fun configure(type: BiquadType, sr: Double, freq: Double, q: Double, gainDb: Double) {
+            val w0 = 2.0 * Math.PI * freq / sr
+            val cosw0 = cos(w0)
+            val sinw0 = sin(w0)
+            val alpha = sinw0 / (2.0 * q)
+            var nb0: Double; var nb1: Double; var nb2: Double
+            var na0: Double; var na1: Double; var na2: Double
+
+            when (type) {
+                BiquadType.PEAKING -> {
+                    val a = 10.0.pow(gainDb / 40.0)
+                    nb0 = 1.0 + alpha * a; nb1 = -2.0 * cosw0; nb2 = 1.0 - alpha * a
+                    na0 = 1.0 + alpha / a; na1 = -2.0 * cosw0; na2 = 1.0 - alpha / a
+                }
+                BiquadType.LOW_SHELF -> {
+                    val a = 10.0.pow(gainDb / 40.0)
+                    val sq = 2.0 * sqrt(a) * alpha
+                    nb0 = a * ((a + 1) - (a - 1) * cosw0 + sq)
+                    nb1 = 2.0 * a * ((a - 1) - (a + 1) * cosw0)
+                    nb2 = a * ((a + 1) - (a - 1) * cosw0 - sq)
+                    na0 = (a + 1) + (a - 1) * cosw0 + sq
+                    na1 = -2.0 * ((a - 1) + (a + 1) * cosw0)
+                    na2 = (a + 1) + (a - 1) * cosw0 - sq
+                }
+                BiquadType.HIGH_SHELF -> {
+                    val a = 10.0.pow(gainDb / 40.0)
+                    val sq = 2.0 * sqrt(a) * alpha
+                    nb0 = a * ((a + 1) + (a - 1) * cosw0 + sq)
+                    nb1 = -2.0 * a * ((a - 1) + (a + 1) * cosw0)
+                    nb2 = a * ((a + 1) + (a - 1) * cosw0 - sq)
+                    na0 = (a + 1) - (a - 1) * cosw0 + sq
+                    na1 = 2.0 * ((a - 1) - (a + 1) * cosw0)
+                    na2 = (a + 1) - (a - 1) * cosw0 - sq
+                }
+            }
+            b0 = (nb0 / na0).toFloat(); b1 = (nb1 / na0).toFloat(); b2 = (nb2 / na0).toFloat()
+            a1 = (na1 / na0).toFloat(); a2 = (na2 / na0).toFloat()
+            z1 = 0f; z2 = 0f
+        }
+
+        fun processBlock(data: FloatArray, n: Int) {
+            for (i in 0 until n) {
+                val x = data[i]
+                val y = b0 * x + z1
+                z1 = b1 * x - a1 * y + z2
+                z2 = b2 * x - a2 * y
+                data[i] = y
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/audio/eq/SpectrumAnalyzerTap.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/SpectrumAnalyzerTap.kt
@@ -1,0 +1,408 @@
+package tf.monochrome.android.audio.eq
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.util.UnstableApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.log10
+import kotlin.math.log2
+import kotlin.math.max
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Passive FFT spectrum analyzer that taps the audio stream without altering it.
+ *
+ * - Runs a radix-2 Cooley-Tukey FFT on a mono-summed sliding window.
+ * - Emits magnitudes as log-spaced bins at ~120 Hz, pink-noise compensated (+3.5 dB/oct)
+ *   and re-centered so pink noise sits on the 0 dB line.
+ * - Only runs analysis coroutine while [setActive] is true (to save CPU when the EQ editor is closed).
+ */
+@Singleton
+@OptIn(UnstableApi::class)
+class SpectrumAnalyzerTap @Inject constructor() : AudioProcessor {
+
+    companion object {
+        const val FFT_SIZE_LOW = 8192
+        const val FFT_SIZE_HIGH = 16384
+        const val OUTPUT_BINS = 128
+        private const val MIN_FREQ = 20f
+        private const val MAX_FREQ = 20000f
+        private const val PINK_SLOPE_DB_PER_OCT = 3.5f
+        private const val TARGET_FPS = 120
+        private const val FRAME_DELAY_MS = 1000L / TARGET_FPS   // ~8 ms
+        private const val SMOOTHING = 0.35f
+    }
+
+    private var pendingFormat = AudioFormat.NOT_SET
+    private var inputFormat = AudioFormat.NOT_SET
+    private var outputBuffer: ByteBuffer = AudioProcessor.EMPTY_BUFFER
+    private var inputEnded = false
+    private var sampleRate = 48000
+
+    // Active ring buffer (mono samples)
+    @Volatile private var ring: FloatArray = FloatArray(FFT_SIZE_HIGH)
+    @Volatile private var ringWrite = 0
+
+    @Volatile var fftSize: Int = FFT_SIZE_LOW
+        set(value) {
+            val clamped = when {
+                value <= FFT_SIZE_LOW -> FFT_SIZE_LOW
+                else -> FFT_SIZE_HIGH
+            }
+            if (clamped != field) {
+                field = clamped
+                // Reallocate FFT work arrays lazily on next frame
+                _analysisDirty = true
+            }
+        }
+
+    @Volatile private var _analysisDirty = true
+    @Volatile private var analysisActive = false
+
+    private val _spectrumBins = MutableStateFlow(FloatArray(OUTPUT_BINS))
+    val spectrumBins: StateFlow<FloatArray> = _spectrumBins.asStateFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var analysisJob: Job? = null
+
+    /**
+     * Enable/disable the analysis coroutine. Audio pass-through is unaffected.
+     * Pause analysis when the EQ editor is not visible to save CPU.
+     */
+    fun setAnalysisActive(enabled: Boolean) {
+        if (enabled == analysisActive) return
+        analysisActive = enabled
+        if (enabled) {
+            startAnalysis()
+        } else {
+            analysisJob?.cancel()
+            analysisJob = null
+            // Reset bins so the UI doesn't show stale data on re-entry
+            _spectrumBins.value = FloatArray(OUTPUT_BINS)
+        }
+    }
+
+    private fun startAnalysis() {
+        analysisJob?.cancel()
+        analysisJob = scope.launch {
+            // Local FFT work arrays (reallocated on fftSize change)
+            var currentSize = fftSize
+            var window = buildHannWindow(currentSize)
+            var real = FloatArray(currentSize)
+            var imag = FloatArray(currentSize)
+            var twiddleCos = buildTwiddleCos(currentSize)
+            var twiddleSin = buildTwiddleSin(currentSize)
+            var smoothed = FloatArray(OUTPUT_BINS)
+            var binMap = buildBinMap(currentSize, sampleRate, OUTPUT_BINS)
+
+            while (isActive) {
+                // Re-allocate work arrays if size changed
+                if (_analysisDirty || currentSize != fftSize) {
+                    currentSize = fftSize
+                    window = buildHannWindow(currentSize)
+                    real = FloatArray(currentSize)
+                    imag = FloatArray(currentSize)
+                    twiddleCos = buildTwiddleCos(currentSize)
+                    twiddleSin = buildTwiddleSin(currentSize)
+                    binMap = buildBinMap(currentSize, sampleRate, OUTPUT_BINS)
+                    smoothed = FloatArray(OUTPUT_BINS)
+                    _analysisDirty = false
+                }
+
+                // Copy last N samples from ring buffer
+                val n = currentSize
+                val ringLocal = ring
+                val ringLen = ringLocal.size
+                val writeIdx = ringWrite
+                var startIdx = writeIdx - n
+                if (startIdx < 0) startIdx += ringLen
+
+                for (i in 0 until n) {
+                    val idx = (startIdx + i) % ringLen
+                    real[i] = ringLocal[idx] * window[i]
+                    imag[i] = 0f
+                }
+
+                fft(real, imag, twiddleCos, twiddleSin)
+
+                // Compute magnitudes for target log-frequency bins
+                val newBins = FloatArray(OUTPUT_BINS)
+                for (b in 0 until OUTPUT_BINS) {
+                    val fftBin = binMap[b]
+                    if (fftBin <= 0 || fftBin >= n / 2) continue
+                    val re = real[fftBin]
+                    val im = imag[fftBin]
+                    val mag = sqrt(re * re + im * im) / (n / 2f)
+                    // dBFS
+                    val db = if (mag > 1e-9f) 20f * log10(mag) else -120f
+                    newBins[b] = db
+                }
+
+                // Pink compensation & centering
+                val sr = sampleRate
+                for (b in 0 until OUTPUT_BINS) {
+                    val freq = binFrequency(b, sr)
+                    val tilt = PINK_SLOPE_DB_PER_OCT * log2(freq / 1000f)
+                    newBins[b] += tilt
+                }
+
+                // Re-center so midband (200..2000 Hz) average sits at 0 dB
+                var midSum = 0f
+                var midCount = 0
+                for (b in 0 until OUTPUT_BINS) {
+                    val f = binFrequency(b, sr)
+                    if (f in 200f..2000f) {
+                        midSum += newBins[b]
+                        midCount++
+                    }
+                }
+                val centerOffset = if (midCount > 0) midSum / midCount else 0f
+                for (b in 0 until OUTPUT_BINS) {
+                    newBins[b] -= centerOffset
+                }
+
+                // Temporal smoothing
+                val a = SMOOTHING
+                for (b in 0 until OUTPUT_BINS) {
+                    smoothed[b] = smoothed[b] * (1f - a) + newBins[b] * a
+                }
+
+                _spectrumBins.value = smoothed.copyOf()
+
+                delay(FRAME_DELAY_MS)
+            }
+        }
+    }
+
+    // --- AudioProcessor (pure pass-through) ---
+
+    override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT &&
+            inputAudioFormat.encoding != C.ENCODING_PCM_FLOAT) {
+            throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
+        }
+        pendingFormat = inputAudioFormat
+        return inputAudioFormat
+    }
+
+    override fun isActive(): Boolean =
+        pendingFormat != AudioFormat.NOT_SET || inputFormat != AudioFormat.NOT_SET
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val encoding = inputFormat.encoding
+        val channels = inputFormat.channelCount
+        val bytesPerSample = if (encoding == C.ENCODING_PCM_FLOAT) 4 else 2
+        val frameSize = bytesPerSample * channels
+        val numFrames = inputBuffer.remaining() / frameSize
+        if (numFrames <= 0) {
+            outputBuffer = AudioProcessor.EMPTY_BUFFER
+            return
+        }
+
+        val byteCount = numFrames * frameSize
+        val startPos = inputBuffer.position()
+
+        if (analysisActive) {
+            // Mono-sum into ring buffer
+            val ringLocal = ring
+            val ringLen = ringLocal.size
+            var w = ringWrite
+            if (encoding == C.ENCODING_PCM_FLOAT) {
+                val dup = inputBuffer.duplicate().order(inputBuffer.order()).asFloatBuffer()
+                if (channels == 1) {
+                    for (i in 0 until numFrames) {
+                        ringLocal[w] = dup.get()
+                        w++
+                        if (w >= ringLen) w = 0
+                    }
+                } else {
+                    for (i in 0 until numFrames) {
+                        val l = dup.get(); val r = dup.get()
+                        ringLocal[w] = (l + r) * 0.5f
+                        w++
+                        if (w >= ringLen) w = 0
+                    }
+                }
+            } else {
+                val dup = inputBuffer.duplicate().order(inputBuffer.order()).asShortBuffer()
+                if (channels == 1) {
+                    for (i in 0 until numFrames) {
+                        ringLocal[w] = dup.get().toFloat() / 32768f
+                        w++
+                        if (w >= ringLen) w = 0
+                    }
+                } else {
+                    for (i in 0 until numFrames) {
+                        val l = dup.get().toFloat() / 32768f
+                        val r = dup.get().toFloat() / 32768f
+                        ringLocal[w] = (l + r) * 0.5f
+                        w++
+                        if (w >= ringLen) w = 0
+                    }
+                }
+            }
+            ringWrite = w
+        }
+
+        // Pass through — wrap the input slice as-is
+        if (outputBuffer.capacity() < byteCount) {
+            outputBuffer = ByteBuffer.allocateDirect(byteCount).order(ByteOrder.nativeOrder())
+        } else {
+            outputBuffer.clear()
+        }
+        val srcDup = inputBuffer.duplicate().order(inputBuffer.order())
+        srcDup.limit(startPos + byteCount)
+        srcDup.position(startPos)
+        outputBuffer.put(srcDup)
+        outputBuffer.flip()
+        inputBuffer.position(startPos + byteCount)
+    }
+
+    override fun getOutput(): ByteBuffer {
+        val buf = outputBuffer
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        return buf
+    }
+
+    override fun isEnded(): Boolean = inputEnded && outputBuffer === AudioProcessor.EMPTY_BUFFER
+    override fun queueEndOfStream() { inputEnded = true }
+
+    override fun flush() {
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        inputEnded = false
+        if (pendingFormat != AudioFormat.NOT_SET) {
+            val formatChanged = inputFormat == AudioFormat.NOT_SET
+                || inputFormat.sampleRate != pendingFormat.sampleRate
+                || inputFormat.encoding != pendingFormat.encoding
+                || inputFormat.channelCount != pendingFormat.channelCount
+            if (formatChanged) {
+                inputFormat = pendingFormat
+                sampleRate = inputFormat.sampleRate
+                _analysisDirty = true
+            }
+            pendingFormat = AudioFormat.NOT_SET
+        }
+    }
+
+    override fun reset() {
+        flush()
+        pendingFormat = AudioFormat.NOT_SET
+        inputFormat = AudioFormat.NOT_SET
+    }
+
+    // --- Helpers ---
+
+    private fun buildHannWindow(n: Int): FloatArray {
+        val w = FloatArray(n)
+        for (i in 0 until n) {
+            w[i] = (0.5 * (1.0 - cos(2.0 * PI * i / (n - 1)))).toFloat()
+        }
+        return w
+    }
+
+    /**
+     * Precomputed cos twiddle factors: cos(-2pi*k/n) for k in 0 until n/2
+     */
+    private fun buildTwiddleCos(n: Int): FloatArray {
+        val t = FloatArray(n / 2)
+        for (k in 0 until n / 2) {
+            t[k] = cos(-2.0 * PI * k / n).toFloat()
+        }
+        return t
+    }
+
+    /**
+     * Precomputed sin twiddle factors: sin(-2pi*k/n) for k in 0 until n/2
+     */
+    private fun buildTwiddleSin(n: Int): FloatArray {
+        val t = FloatArray(n / 2)
+        for (k in 0 until n / 2) {
+            t[k] = sin(-2.0 * PI * k / n).toFloat()
+        }
+        return t
+    }
+
+    private fun binFrequency(outBin: Int, sr: Int): Float {
+        val logMin = log10(MIN_FREQ)
+        val logMax = log10(max(MIN_FREQ + 1f, minOf(MAX_FREQ, sr / 2f - 1f)))
+        val t = outBin.toFloat() / (OUTPUT_BINS - 1).toFloat()
+        val logF = logMin + t * (logMax - logMin)
+        return Math.pow(10.0, logF.toDouble()).toFloat()
+    }
+
+    private fun buildBinMap(n: Int, sr: Int, outBins: Int): IntArray {
+        val map = IntArray(outBins)
+        val binWidth = sr.toFloat() / n.toFloat()
+        for (b in 0 until outBins) {
+            val freq = binFrequency(b, sr)
+            val fftBin = (freq / binWidth).toInt().coerceIn(1, n / 2 - 1)
+            map[b] = fftBin
+        }
+        return map
+    }
+
+    /**
+     * In-place radix-2 iterative Cooley-Tukey FFT. Size must be a power of 2.
+     * Twiddle tables must be precomputed for n (length n/2, indexing stride n/size per stage).
+     */
+    private fun fft(real: FloatArray, imag: FloatArray, tCos: FloatArray, tSin: FloatArray) {
+        val n = real.size
+        // Bit-reversal permutation
+        var j = 0
+        for (i in 1 until n) {
+            var bit = n shr 1
+            while (j and bit != 0) {
+                j = j xor bit
+                bit = bit shr 1
+            }
+            j = j xor bit
+            if (i < j) {
+                var tmp = real[i]; real[i] = real[j]; real[j] = tmp
+                tmp = imag[i]; imag[i] = imag[j]; imag[j] = tmp
+            }
+        }
+        var size = 2
+        while (size <= n) {
+            val half = size shr 1
+            val tableStep = n / size
+            var k = 0
+            while (k < n) {
+                var tIdx = 0
+                for (m in 0 until half) {
+                    val cosA = tCos[tIdx]
+                    val sinA = tSin[tIdx]
+                    val iEven = k + m
+                    val iOdd = k + m + half
+                    val tre = real[iOdd] * cosA - imag[iOdd] * sinA
+                    val tim = real[iOdd] * sinA + imag[iOdd] * cosA
+                    real[iOdd] = real[iEven] - tre
+                    imag[iOdd] = imag[iEven] - tim
+                    real[iEven] = real[iEven] + tre
+                    imag[iEven] = imag[iEven] + tim
+                    tIdx += tableStep
+                }
+                k += size
+            }
+            size = size shl 1
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/db/MusicDatabase.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/MusicDatabase.kt
@@ -66,7 +66,7 @@ import tf.monochrome.android.data.local.db.ScanStateEntity
         CollectionTrackArtistCrossRef::class,
         CollectionAlbumArtistCrossRef::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 abstract class MusicDatabase : RoomDatabase() {

--- a/app/src/main/java/tf/monochrome/android/data/db/dao/EqPresetDao.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/dao/EqPresetDao.kt
@@ -11,22 +11,24 @@ import tf.monochrome.android.data.db.entity.EqPresetEntity
 
 @Dao
 interface EqPresetDao {
+    // ==================== AutoEQ presets (eqType = 0) ====================
+
     /**
-     * Get all EQ presets (custom + built-in)
+     * Get all AutoEQ presets (custom + built-in)
      */
-    @Query("SELECT * FROM eq_presets ORDER BY isCustom DESC, updatedAt DESC")
+    @Query("SELECT * FROM eq_presets WHERE eqType = 0 ORDER BY isCustom DESC, updatedAt DESC")
     fun getAllPresets(): Flow<List<EqPresetEntity>>
 
     /**
-     * Get all custom user-created presets
+     * Get all custom user-created AutoEQ presets
      */
-    @Query("SELECT * FROM eq_presets WHERE isCustom = 1 ORDER BY updatedAt DESC")
+    @Query("SELECT * FROM eq_presets WHERE isCustom = 1 AND eqType = 0 ORDER BY updatedAt DESC")
     fun getCustomPresets(): Flow<List<EqPresetEntity>>
 
     /**
-     * Get all built-in presets
+     * Get all built-in AutoEQ presets
      */
-    @Query("SELECT * FROM eq_presets WHERE isCustom = 0 ORDER BY name ASC")
+    @Query("SELECT * FROM eq_presets WHERE isCustom = 0 AND eqType = 0 ORDER BY name ASC")
     fun getBuiltInPresets(): Flow<List<EqPresetEntity>>
 
     /**
@@ -66,9 +68,9 @@ interface EqPresetDao {
     suspend fun deletePreset(presetId: String)
 
     /**
-     * Delete all custom presets
+     * Delete all custom AutoEQ presets
      */
-    @Query("DELETE FROM eq_presets WHERE isCustom = 1")
+    @Query("DELETE FROM eq_presets WHERE isCustom = 1 AND eqType = 0")
     suspend fun deleteAllCustomPresets()
 
     /**
@@ -78,26 +80,52 @@ interface EqPresetDao {
     suspend fun presetExists(presetId: String): Boolean
 
     /**
-     * Get count of all presets
+     * Get count of all AutoEQ presets
      */
-    @Query("SELECT COUNT(*) FROM eq_presets")
+    @Query("SELECT COUNT(*) FROM eq_presets WHERE eqType = 0")
     fun getPresetCount(): Flow<Int>
 
     /**
-     * Get count of custom presets
+     * Get count of custom AutoEQ presets
      */
-    @Query("SELECT COUNT(*) FROM eq_presets WHERE isCustom = 1")
+    @Query("SELECT COUNT(*) FROM eq_presets WHERE isCustom = 1 AND eqType = 0")
     fun getCustomPresetCount(): Flow<Int>
 
     /**
-     * Search presets by name
+     * Search AutoEQ presets by name
      */
-    @Query("SELECT * FROM eq_presets WHERE name LIKE '%' || :searchQuery || '%' ORDER BY isCustom DESC, updatedAt DESC")
+    @Query("SELECT * FROM eq_presets WHERE eqType = 0 AND name LIKE '%' || :searchQuery || '%' ORDER BY isCustom DESC, updatedAt DESC")
     fun searchPresets(searchQuery: String): Flow<List<EqPresetEntity>>
 
     /**
-     * Get presets for a specific target curve
+     * Get AutoEQ presets for a specific target curve
      */
-    @Query("SELECT * FROM eq_presets WHERE targetId = :targetId ORDER BY isCustom DESC, updatedAt DESC")
+    @Query("SELECT * FROM eq_presets WHERE eqType = 0 AND targetId = :targetId ORDER BY isCustom DESC, updatedAt DESC")
     fun getPresetsByTarget(targetId: String): Flow<List<EqPresetEntity>>
+
+    // ==================== Parametric EQ presets (eqType = 1) ====================
+
+    /**
+     * Get all Parametric EQ presets (custom + built-in)
+     */
+    @Query("SELECT * FROM eq_presets WHERE eqType = 1 ORDER BY isCustom DESC, updatedAt DESC")
+    fun getAllParametricPresets(): Flow<List<EqPresetEntity>>
+
+    /**
+     * Get custom Parametric EQ presets
+     */
+    @Query("SELECT * FROM eq_presets WHERE isCustom = 1 AND eqType = 1 ORDER BY updatedAt DESC")
+    fun getCustomParametricPresets(): Flow<List<EqPresetEntity>>
+
+    /**
+     * Count of custom Parametric EQ presets
+     */
+    @Query("SELECT COUNT(*) FROM eq_presets WHERE isCustom = 1 AND eqType = 1")
+    fun getCustomParametricPresetCount(): Flow<Int>
+
+    /**
+     * Search Parametric EQ presets by name
+     */
+    @Query("SELECT * FROM eq_presets WHERE eqType = 1 AND name LIKE '%' || :searchQuery || '%' ORDER BY isCustom DESC, updatedAt DESC")
+    fun searchParametricPresets(searchQuery: String): Flow<List<EqPresetEntity>>
 }

--- a/app/src/main/java/tf/monochrome/android/data/db/entity/Entities.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/entity/Entities.kt
@@ -158,7 +158,7 @@ data class CachedLyricsEntity(
 
 @Entity(
     tableName = "eq_presets",
-    indices = [Index("id"), Index("isCustom")]
+    indices = [Index("id"), Index("isCustom"), Index("eqType")]
 )
 @Serializable
 data class EqPresetEntity(
@@ -171,5 +171,6 @@ data class EqPresetEntity(
     val targetName: String = "",
     val isCustom: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    val eqType: Int = 0  // 0 = AutoEQ, 1 = Parametric
 )

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -134,6 +134,12 @@ class PreferencesManager @Inject constructor(
         private val EQ_SELECTED_HEADPHONE_ID = stringPreferencesKey("eq_selected_headphone_id")
         private val EQ_SELECTED_HEADPHONE_NAME = stringPreferencesKey("eq_selected_headphone_name")
 
+        // Parametric EQ (independent of AutoEQ)
+        private val PARAM_EQ_ENABLED = booleanPreferencesKey("param_eq_enabled")
+        private val PARAM_EQ_ACTIVE_PRESET_ID = stringPreferencesKey("param_eq_active_preset_id")
+        private val PARAM_EQ_PREAMP = doublePreferencesKey("param_eq_preamp")
+        private val PARAM_EQ_BANDS_JSON = stringPreferencesKey("param_eq_bands_json")
+
         // Library / Local Media
         private val SCAN_ON_APP_OPEN = booleanPreferencesKey("scan_on_app_open")
         private val MIN_TRACK_DURATION_MS = longPreferencesKey("min_track_duration_ms")
@@ -646,6 +652,40 @@ class PreferencesManager @Inject constructor(
         dataStore.edit {
             it.remove(EQ_SELECTED_HEADPHONE_ID)
             it.remove(EQ_SELECTED_HEADPHONE_NAME)
+        }
+    }
+
+    // --- Parametric EQ (independent of AutoEQ) ---
+    val paramEqEnabled: Flow<Boolean> = dataStore.data.map { it[PARAM_EQ_ENABLED] ?: false }
+    val paramEqActivePresetId: Flow<String?> = dataStore.data.map { it[PARAM_EQ_ACTIVE_PRESET_ID] }
+    val paramEqPreamp: Flow<Double> = dataStore.data.map { it[PARAM_EQ_PREAMP] ?: 0.0 }
+    val paramEqBandsJson: Flow<String?> = dataStore.data.map { it[PARAM_EQ_BANDS_JSON] }
+
+    suspend fun setParamEqEnabled(enabled: Boolean) {
+        dataStore.edit { it[PARAM_EQ_ENABLED] = enabled }
+    }
+
+    suspend fun setParamEqActivePreset(presetId: String?) {
+        dataStore.edit {
+            if (presetId != null) {
+                it[PARAM_EQ_ACTIVE_PRESET_ID] = presetId
+            } else {
+                it.remove(PARAM_EQ_ACTIVE_PRESET_ID)
+            }
+        }
+    }
+
+    suspend fun setParamEqPreamp(preamp: Double) {
+        dataStore.edit { it[PARAM_EQ_PREAMP] = preamp }
+    }
+
+    suspend fun setParamEqBands(bandsJson: String?) {
+        dataStore.edit {
+            if (bandsJson != null) {
+                it[PARAM_EQ_BANDS_JSON] = bandsJson
+            } else {
+                it.remove(PARAM_EQ_BANDS_JSON)
+            }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
@@ -200,7 +200,8 @@ class EqRepository @Inject constructor(
             targetName = targetName,
             isCustom = isCustom,
             createdAt = createdAt,
-            updatedAt = System.currentTimeMillis()
+            updatedAt = System.currentTimeMillis(),
+            eqType = 0  // AutoEQ
         )
     }
 }

--- a/app/src/main/java/tf/monochrome/android/data/repository/ParametricEqRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/ParametricEqRepository.kt
@@ -1,0 +1,70 @@
+package tf.monochrome.android.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import tf.monochrome.android.data.db.dao.EqPresetDao
+import tf.monochrome.android.data.db.entity.EqPresetEntity
+import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.EqPreset
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository for user-created Parametric EQ presets (eqType = 1).
+ * Shares the `eq_presets` table with AutoEQ but is isolated by the eqType filter.
+ */
+@Singleton
+class ParametricEqRepository @Inject constructor(
+    private val eqPresetDao: EqPresetDao
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun getAllPresets(): Flow<List<EqPreset>> =
+        eqPresetDao.getAllParametricPresets().map { list -> list.map { it.toDomain() } }
+
+    suspend fun getPresetById(presetId: String): EqPreset? =
+        eqPresetDao.getPresetById(presetId)?.takeIf { it.eqType == 1 }?.toDomain()
+
+    suspend fun savePreset(preset: EqPreset) {
+        eqPresetDao.insertPreset(preset.toEntity())
+    }
+
+    suspend fun deletePreset(presetId: String) {
+        eqPresetDao.deletePreset(presetId)
+    }
+
+    fun searchPresets(query: String): Flow<List<EqPreset>> =
+        eqPresetDao.searchParametricPresets(query).map { list -> list.map { it.toDomain() } }
+
+    fun getCustomPresetCount(): Flow<Int> = eqPresetDao.getCustomParametricPresetCount()
+
+    private fun EqPresetEntity.toDomain(): EqPreset = EqPreset(
+        id = id,
+        name = name,
+        description = description,
+        bands = try { json.decodeFromString<List<EqBand>>(bandsJson) } catch (_: Exception) { emptyList() },
+        preamp = preamp,
+        targetId = targetId,
+        targetName = targetName,
+        isCustom = isCustom,
+        createdAt = createdAt,
+        updatedAt = updatedAt
+    )
+
+    private fun EqPreset.toEntity(): EqPresetEntity = EqPresetEntity(
+        id = id,
+        name = name,
+        description = description,
+        bandsJson = try { json.encodeToString(bands) } catch (_: Exception) { "[]" },
+        preamp = preamp,
+        targetId = "",
+        targetName = "",
+        isCustom = isCustom,
+        createdAt = createdAt,
+        updatedAt = System.currentTimeMillis(),
+        eqType = 1
+    )
+}

--- a/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
+++ b/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
@@ -34,6 +34,8 @@ import tf.monochrome.android.audio.dsp.DspEngineManager
 import tf.monochrome.android.audio.dsp.MixBusProcessor
 import tf.monochrome.android.audio.dsp.SpatialAudioProcessor
 import tf.monochrome.android.audio.eq.AutoEqProcessor
+import tf.monochrome.android.audio.eq.ParametricEqProcessor
+import tf.monochrome.android.audio.eq.SpectrumAnalyzerTap
 import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.data.repository.LibraryRepository
 import tf.monochrome.android.data.scrobbling.ScrobblingService
@@ -57,6 +59,8 @@ class PlaybackService : MediaSessionService() {
     @Inject lateinit var mixBusProcessor: MixBusProcessor
     @Inject lateinit var dspManager: DspEngineManager
     @Inject lateinit var autoEqProcessor: AutoEqProcessor
+    @Inject lateinit var parametricEqProcessor: ParametricEqProcessor
+    @Inject lateinit var spectrumAnalyzerTap: SpectrumAnalyzerTap
     @Inject lateinit var spatialProcessor: SpatialAudioProcessor
 
     private var mediaSession: MediaSession? = null
@@ -110,6 +114,7 @@ class PlaybackService : MediaSessionService() {
                         applyReplayGain()
                         applyPlaybackSpeed()
                         applyEq()
+                        applyParametricEq()
                     }
                     Player.STATE_BUFFERING, Player.STATE_IDLE -> {
                         // No action needed
@@ -162,6 +167,19 @@ class PlaybackService : MediaSessionService() {
             }
         }
 
+        // Listen to Parametric EQ changes and apply them
+        serviceScope.launch {
+            kotlinx.coroutines.flow.combine(
+                preferences.paramEqEnabled,
+                preferences.paramEqBandsJson,
+                preferences.paramEqPreamp
+            ) { enabled, bandsJson, preamp ->
+                Triple(enabled, bandsJson, preamp)
+            }.collect { (enabled, bandsJson, preamp) ->
+                applyParametricEqSettings(enabled, bandsJson, preamp)
+            }
+        }
+
         // Restore DSP mixer state when the native engine becomes ready
         serviceScope.launch {
             var hasRestored = false
@@ -194,9 +212,11 @@ class PlaybackService : MediaSessionService() {
                         .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
                         .setAudioProcessors(
                             arrayOf(
-                                spatialProcessor,   // Dolby Atmos: multichannel → binaural (first in chain)
-                                mixBusProcessor,    // DSP engine (mixer/effects)
-                                autoEqProcessor,    // AutoEQ (independent, always-on when enabled)
+                                spatialProcessor,       // Dolby Atmos: multichannel → binaural (first in chain)
+                                mixBusProcessor,        // DSP engine (mixer/effects)
+                                autoEqProcessor,        // AutoEQ (independent, always-on when enabled)
+                                parametricEqProcessor,  // Parametric EQ (after AutoEQ, stacks on top)
+                                spectrumAnalyzerTap,    // Passive FFT tap for the Parametric EQ editor visualizer
                                 TeeAudioProcessor(
                                     ProjectMAudioTapProcessor(audioBus)
                                 )
@@ -429,5 +449,34 @@ class PlaybackService : MediaSessionService() {
         } catch (e: Exception) {
             // Gracefully handle EQ application errors
         }
+    }
+
+    /**
+     * Apply current Parametric EQ settings from preferences
+     */
+    private fun applyParametricEq() {
+        serviceScope.launch {
+            try {
+                val enabled = preferences.paramEqEnabled.first()
+                val bandsJson = preferences.paramEqBandsJson.first()
+                val preamp = preferences.paramEqPreamp.first()
+                applyParametricEqSettings(enabled, bandsJson, preamp)
+            } catch (_: Exception) { }
+        }
+    }
+
+    /**
+     * Apply Parametric EQ settings to the standalone ParametricEqProcessor
+     */
+    private fun applyParametricEqSettings(enabled: Boolean, bandsJson: String?, preamp: Double) {
+        try {
+            val bands = if (!bandsJson.isNullOrEmpty()) {
+                val json = Json { ignoreUnknownKeys = true }
+                json.decodeFromString<List<EqBand>>(bandsJson)
+            } else {
+                emptyList()
+            }
+            parametricEqProcessor.applyBands(bands, preamp.toFloat(), enabled)
+        } catch (_: Exception) { }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -73,13 +73,19 @@ fun FrequencyResponseGraph(
     preamp: Float = 0f,
     sampleRate: Float = 48000f,
     onBandDragged: ((bandId: Int, newFreq: Float, newGain: Float) -> Unit)? = null,
+    spectrumBins: FloatArray = FloatArray(0),
+    spectrumColor: Color? = null,
+    centerOnZero: Boolean = false,
+    showLegend: Boolean = true,
 ) {
     val primary = MaterialTheme.colorScheme.primary
 
     // Calculate normalization offset (average gain in 250-2500Hz midband)
-    // This centers the graph around the measurement's midband level, matching SeapEngine
-    val zeroOffset = remember(originalCurve, targetCurve) {
+    // This centers the graph around the measurement's midband level, matching SeapEngine.
+    // For the Parametric EQ editor (no measurement data), centerOnZero forces 0 dB center.
+    val zeroOffset = remember(originalCurve, targetCurve, centerOnZero) {
         when {
+            centerOnZero -> 0f
             originalCurve.isNotEmpty() -> getNormalizationOffset(originalCurve)
             targetCurve.isNotEmpty() -> getNormalizationOffset(targetCurve)
             else -> 75f // Reasonable default for SPL data
@@ -105,19 +111,34 @@ fun FrequencyResponseGraph(
         } else targetCurve
     }
 
-    // Calculate corrected curve (measurement + EQ bands + preamp)
-    val correctedCurve = remember(originalCurve, eqBands, preamp, sampleRate) {
-        if (originalCurve.isEmpty()) emptyList()
-        else originalCurve.map { point ->
-            var correctedGain = point.gain + preamp
-            eqBands.forEach { band ->
-                if (band.enabled) {
-                    correctedGain += AutoEqEngine.calculateBiquadResponse(point.freq, band, sampleRate)
+    // Calculate corrected curve.
+    //  - With measurement: measurement + EQ bands + preamp
+    //  - Without measurement (parametric EQ mode): pure EQ response + preamp around the zero baseline
+    val correctedCurve = remember(originalCurve, eqBands, preamp, sampleRate, zeroOffset) {
+        if (originalCurve.isNotEmpty()) {
+            originalCurve.map { point ->
+                var correctedGain = point.gain + preamp
+                eqBands.forEach { band ->
+                    if (band.enabled) {
+                        correctedGain += AutoEqEngine.calculateBiquadResponse(point.freq, band, sampleRate)
+                    }
                 }
-            }
-            FrequencyPoint(point.freq, correctedGain)
+                FrequencyPoint(point.freq, correctedGain)
+            }.filter { it.gain.isFinite() }
+        } else {
+            // Synthesize a smooth EQ response curve across the log-frequency axis
+            val samples = 256
+            val logMin = log10(MIN_FREQ)
+            val logMax = log10(MAX_FREQ)
+            (0 until samples).map { i ->
+                val freq = 10f.pow(logMin + i.toFloat() / (samples - 1) * (logMax - logMin))
+                var g = preamp + zeroOffset
+                eqBands.forEach { band ->
+                    if (band.enabled) g += AutoEqEngine.calculateBiquadResponse(freq, band, sampleRate)
+                }
+                FrequencyPoint(freq, g)
+            }.filter { it.gain.isFinite() }
         }
-        .filter { it.gain.isFinite() }
     }
 
     var selectedBandId by remember { mutableIntStateOf(-1) }
@@ -185,6 +206,11 @@ fun FrequencyResponseGraph(
 
             // Frequency labels at bottom
             drawFreqLabels(w, h)
+
+            // FFT spectrum behind curves — uses the active theme's primary color
+            if (spectrumBins.isNotEmpty() && spectrumColor != null) {
+                drawSpectrum(spectrumBins, spectrumColor, w, h, minGain, maxGain, zeroOffset)
+            }
 
             // Original measurement curve (bright blue for visibility)
             if (originalCurve.size > 1) {
@@ -282,18 +308,20 @@ fun FrequencyResponseGraph(
             }
         }
 
-        // Legend overlay
-        Row(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .background(Color(0x600A0A0A))
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
-        ) {
-            LegendDot("Original", Color(0xFF4A9EFF))
-            LegendDot("Target (Primary)", Color.White)
-            LegendDot("Corrected", Color(0xFFFF4444))
+        // Legend overlay (hidden in parametric-only mode since there's no measurement/target curve)
+        if (showLegend) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .background(Color(0x600A0A0A))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
+            ) {
+                LegendDot("Original", Color(0xFF4A9EFF))
+                LegendDot("Target (Primary)", Color.White)
+                LegendDot("Corrected", Color(0xFFFF4444))
+            }
         }
     }
 }
@@ -618,6 +646,63 @@ private fun DrawScope.drawDashedCurve(
             pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f))
         )
     )
+}
+
+/**
+ * Render FFT spectrum bins as a filled area below a translucent line.
+ * Bins span MIN_FREQ..MAX_FREQ on a log axis; magnitudes are dB relative to 0 dB center.
+ */
+private fun DrawScope.drawSpectrum(
+    bins: FloatArray,
+    color: Color,
+    width: Float,
+    height: Float,
+    minGain: Float,
+    maxGain: Float,
+    zeroOffset: Float
+) {
+    if (bins.isEmpty()) return
+    val n = bins.size
+    val logMin = log10(MIN_FREQ)
+    val logMax = log10(MAX_FREQ)
+    val zeroY = gainToY(zeroOffset, height, minGain, maxGain)
+        .coerceIn(GRAPH_PADDING_TOP, height - GRAPH_PADDING_BOTTOM)
+
+    val line = Path()
+    val fill = Path()
+    var started = false
+    for (i in 0 until n) {
+        val t = i.toFloat() / (n - 1).toFloat()
+        val freq = 10f.pow(logMin + t * (logMax - logMin))
+        val x = freqToX(freq, width)
+        val gain = (zeroOffset + bins[i]).coerceIn(minGain, maxGain)
+        val y = gainToY(gain, height, minGain, maxGain)
+        if (!started) {
+            line.moveTo(x, y)
+            fill.moveTo(x, zeroY)
+            fill.lineTo(x, y)
+            started = true
+        } else {
+            line.lineTo(x, y)
+            fill.lineTo(x, y)
+        }
+    }
+    // Close fill back to zero line
+    val lastX = freqToX(MAX_FREQ, width)
+    val firstX = freqToX(MIN_FREQ, width)
+    fill.lineTo(lastX, zeroY)
+    fill.lineTo(firstX, zeroY)
+    fill.close()
+
+    drawPath(
+        path = fill,
+        brush = Brush.verticalGradient(
+            colors = listOf(color.copy(alpha = 0.45f), color.copy(alpha = 0.05f)),
+            startY = GRAPH_PADDING_TOP,
+            endY = zeroY
+        )
+    )
+    drawPath(line, color.copy(alpha = 0.75f), style = Stroke(width = 1.5f))
 }
 
 private fun DrawScope.drawFilledCurve(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqEditScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqEditScreen.kt
@@ -1,0 +1,386 @@
+package tf.monochrome.android.ui.eq
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import tf.monochrome.android.audio.eq.SpectrumAnalyzerTap
+import tf.monochrome.android.domain.model.FilterType
+import tf.monochrome.android.ui.components.bounceClick
+import tf.monochrome.android.ui.components.bounceCombinedClick
+
+@Composable
+fun ParametricEqEditScreen(
+    navController: NavController,
+    viewModel: ParametricEqViewModel = hiltViewModel()
+) {
+    val currentBands by viewModel.currentBands.collectAsState()
+    val currentPreamp by viewModel.currentPreamp.collectAsState()
+    val selectedBandId by viewModel.selectedBandId.collectAsState()
+    val spectrumBins by viewModel.spectrumAnalyzer.spectrumBins.collectAsState()
+    val fftSize by viewModel.fftSize.collectAsState()
+
+    val analyzer = viewModel.spectrumAnalyzer
+    DisposableEffect(Unit) {
+        analyzer.setAnalysisActive(true)
+        onDispose { analyzer.setAnalysisActive(false) }
+    }
+
+    val selectedBand = currentBands.find { it.id == selectedBandId }
+    val spectrumColor = MaterialTheme.colorScheme.primary
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+            .verticalScroll(rememberScrollState())
+    ) {
+        // Top bar
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            Text(
+                "EDIT PARAMETRIC EQ",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 2.sp,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { viewModel.resetToFlat() }) {
+                Icon(
+                    Icons.Default.Refresh,
+                    contentDescription = "Reset to flat",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // FFT size toggle (8K / 16K)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "FFT",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                letterSpacing = 1.sp
+            )
+            TabChip(
+                label = "8K",
+                isSelected = fftSize == SpectrumAnalyzerTap.FFT_SIZE_LOW,
+                onClick = { viewModel.setFftSize(SpectrumAnalyzerTap.FFT_SIZE_LOW) }
+            )
+            TabChip(
+                label = "16K",
+                isSelected = fftSize == SpectrumAnalyzerTap.FFT_SIZE_HIGH,
+                onClick = { viewModel.setFftSize(SpectrumAnalyzerTap.FFT_SIZE_HIGH) }
+            )
+        }
+
+        // Interactive graph with live spectrum overlay
+        Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
+            FrequencyResponseGraph(
+                originalCurve = emptyList(),
+                targetCurve = emptyList(),
+                eqBands = currentBands,
+                preamp = currentPreamp,
+                centerOnZero = true,
+                showLegend = false,
+                spectrumBins = spectrumBins,
+                spectrumColor = spectrumColor,
+                onBandDragged = { id, f, g -> viewModel.updateBandByDrag(id, f, g) }
+            )
+        }
+
+        // Band strip with add button
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            SectionLabel("BANDS")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                currentBands.sortedBy { it.freq }.forEach { band ->
+                    BandChip(
+                        label = formatFreq(band.freq),
+                        gainDb = band.gain,
+                        isSelected = band.id == selectedBandId,
+                        onClick = { viewModel.selectBand(band.id) },
+                        onLongPress = { viewModel.removeBand(band.id) }
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(18.dp))
+                        .bounceClick(onClick = { viewModel.addBand() }),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = "Add band",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Selected band detail
+        if (selectedBand != null) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    SectionLabel("BAND ${selectedBand.id + 1}")
+                    Spacer(modifier = Modifier.weight(1f))
+                    IconButton(
+                        onClick = { viewModel.removeBand(selectedBand.id) },
+                        modifier = Modifier.size(28.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Remove band",
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+
+                // Filter type segmented row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    FilterType.values().forEach { type ->
+                        val isSel = selectedBand.type == type
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(18.dp))
+                                .then(
+                                    if (isSel) Modifier.background(MaterialTheme.colorScheme.primary)
+                                    else Modifier.border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(18.dp))
+                                )
+                                .bounceClick(onClick = { viewModel.updateBand(selectedBand.copy(type = type)) })
+                                .padding(vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                when (type) {
+                                    FilterType.PEAKING -> "PEAK"
+                                    FilterType.LOWSHELF -> "LOW-S"
+                                    FilterType.HIGHSHELF -> "HIGH-S"
+                                },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = if (isSel) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
+                                letterSpacing = 1.sp,
+                                fontWeight = if (isSel) FontWeight.Bold else FontWeight.Normal
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Frequency slider (log)
+                ValueSlider(
+                    label = "Frequency",
+                    value = logFreqToSlider(selectedBand.freq),
+                    valueRange = 0f..1f,
+                    display = formatFreq(selectedBand.freq),
+                    onChange = { t ->
+                        val newFreq = sliderToLogFreq(t)
+                        viewModel.updateBand(selectedBand.copy(freq = newFreq))
+                    }
+                )
+
+                // Gain slider
+                ValueSlider(
+                    label = "Gain",
+                    value = selectedBand.gain,
+                    valueRange = -24f..24f,
+                    display = "%+.1f dB".format(selectedBand.gain),
+                    onChange = { viewModel.updateBand(selectedBand.copy(gain = it)) }
+                )
+
+                // Q slider
+                ValueSlider(
+                    label = "Q",
+                    value = selectedBand.q,
+                    valueRange = 0.1f..10f,
+                    display = "%.2f".format(selectedBand.q),
+                    onChange = { viewModel.updateBand(selectedBand.copy(q = it)) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Preamp slider
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
+            SectionLabel("PREAMP")
+            ValueSlider(
+                label = "",
+                value = currentPreamp,
+                valueRange = -24f..24f,
+                display = "%+.1f dB".format(currentPreamp),
+                onChange = { viewModel.setPreamp(it) }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun BandChip(
+    label: String,
+    gainDb: Float,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    onLongPress: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .then(
+                if (isSelected) Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.25f))
+                else Modifier.border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(10.dp))
+            )
+            .bounceCombinedClick(onClick = onClick, onLongClick = onLongPress)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            "%+.1f".format(gainDb),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun ValueSlider(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    display: String,
+    onChange: (Float) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (label.isNotBlank()) {
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    letterSpacing = 1.sp
+                )
+            } else {
+                Spacer(modifier = Modifier.width(1.dp))
+            }
+            Text(
+                display,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium
+            )
+        }
+        Slider(
+            value = value.coerceIn(valueRange.start, valueRange.endInclusive),
+            onValueChange = onChange,
+            valueRange = valueRange,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+private fun logFreqToSlider(freq: Float): Float {
+    val logMin = Math.log10(20.0)
+    val logMax = Math.log10(20000.0)
+    val logF = Math.log10(freq.coerceIn(20f, 20000f).toDouble())
+    return ((logF - logMin) / (logMax - logMin)).toFloat().coerceIn(0f, 1f)
+}
+
+private fun sliderToLogFreq(t: Float): Float {
+    val logMin = Math.log10(20.0)
+    val logMax = Math.log10(20000.0)
+    val logF = logMin + t.coerceIn(0f, 1f) * (logMax - logMin)
+    return Math.pow(10.0, logF).toFloat().coerceIn(20f, 20000f)
+}
+
+private fun formatFreq(freq: Float): String = when {
+    freq >= 1000f -> "%.1fk".format(freq / 1000f).replace(".0k", "k")
+    else -> "${freq.toInt()}"
+}

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -1,0 +1,331 @@
+package tf.monochrome.android.ui.eq
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import tf.monochrome.android.domain.model.EqPreset
+import tf.monochrome.android.ui.components.bounceClick
+import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.navigation.Screen
+
+@Composable
+fun ParametricEqScreen(
+    navController: NavController,
+    viewModel: ParametricEqViewModel = hiltViewModel()
+) {
+    val enabled by viewModel.enabled.collectAsState()
+    val currentBands by viewModel.currentBands.collectAsState()
+    val currentPreamp by viewModel.currentPreamp.collectAsState()
+    val activePreset by viewModel.activePreset.collectAsState()
+    val allPresets by viewModel.allPresets.collectAsState()
+
+    var showSaveDialog by remember { mutableStateOf(false) }
+    var saveName by remember { mutableStateOf("") }
+    var saveDescription by remember { mutableStateOf("") }
+    var presetToDelete by remember { mutableStateOf<EqPreset?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .statusBarsPadding()
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 32.dp)
+        ) {
+            // Title
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 4.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "PARAMETRIC EQ",
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = 2.sp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            "Free-form tone shaping on top of AutoEQ.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(checked = enabled, onCheckedChange = { viewModel.setEnabled(it) })
+                }
+            }
+
+            // Mini preview graph
+            item {
+                Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    FrequencyResponseGraph(
+                        originalCurve = emptyList(),
+                        targetCurve = emptyList(),
+                        eqBands = currentBands,
+                        preamp = currentPreamp,
+                        centerOnZero = true,
+                        showLegend = false
+                    )
+                }
+            }
+
+            // Edit pill button
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(50))
+                            .background(MaterialTheme.colorScheme.primary)
+                            .bounceClick(onClick = { navController.navigate(Screen.ParametricEqEdit.route) })
+                            .padding(vertical = 14.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.Tune,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            "Edit",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            letterSpacing = 2.sp
+                        )
+                    }
+                }
+            }
+
+            // Save-as-preset button
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .liquidGlass(shape = RoundedCornerShape(12.dp))
+                            .bounceClick(onClick = {
+                                saveName = ""
+                                saveDescription = ""
+                                showSaveDialog = true
+                            })
+                            .padding(vertical = 12.dp, horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Save,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Text(
+                            "Save current as profile",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+            }
+
+            // Saved profiles
+            if (allPresets.isNotEmpty()) {
+                item {
+                    Text(
+                        "SAVED PROFILES",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.sp,
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 6.dp)
+                    )
+                }
+
+                items(items = allPresets, key = { it.id }) { preset ->
+                    val isActive = activePreset?.id == preset.id
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .liquidGlass(shape = RoundedCornerShape(10.dp))
+                            .bounceClick(onClick = { viewModel.loadPreset(preset.id) })
+                    ) {
+                        EqProfileMiniGraph(
+                            bands = preset.bands,
+                            preamp = preset.preamp,
+                            modifier = Modifier.fillMaxWidth().padding(2.dp)
+                        )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 14.dp, vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            if (isActive) {
+                                Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = "Active",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    preset.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
+                                    color = if (isActive) MaterialTheme.colorScheme.primary
+                                    else MaterialTheme.colorScheme.onSurface,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    "${preset.bands.size} bands",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            IconButton(
+                                onClick = { presetToDelete = preset },
+                                modifier = Modifier.size(32.dp)
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = "Delete profile",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showSaveDialog) {
+        AlertDialog(
+            onDismissRequest = { showSaveDialog = false },
+            title = { Text("Save Profile") },
+            text = {
+                Column {
+                    OutlinedTextField(
+                        value = saveName,
+                        onValueChange = { saveName = it },
+                        label = { Text("Profile name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = saveDescription,
+                        onValueChange = { saveDescription = it },
+                        label = { Text("Description (optional)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (saveName.isNotBlank()) {
+                        viewModel.saveAsPreset(saveName.trim(), saveDescription.trim())
+                        showSaveDialog = false
+                    }
+                }) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSaveDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    presetToDelete?.let { preset ->
+        AlertDialog(
+            onDismissRequest = { presetToDelete = null },
+            title = { Text("Delete Profile") },
+            text = { Text("Delete \"${preset.name}\"?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deletePreset(preset.id)
+                    presetToDelete = null
+                }) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { presetToDelete = null }) { Text("Cancel") }
+            }
+        )
+    }
+}
+

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -1,0 +1,256 @@
+package tf.monochrome.android.ui.eq
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import tf.monochrome.android.audio.eq.SpectrumAnalyzerTap
+import tf.monochrome.android.data.preferences.PreferencesManager
+import tf.monochrome.android.data.repository.ParametricEqRepository
+import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.EqPreset
+import tf.monochrome.android.domain.model.FilterType
+import javax.inject.Inject
+
+@HiltViewModel
+class ParametricEqViewModel @Inject constructor(
+    private val repository: ParametricEqRepository,
+    private val preferences: PreferencesManager,
+    val spectrumAnalyzer: SpectrumAnalyzerTap
+) : ViewModel() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val _enabled = MutableStateFlow(false)
+    val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
+
+    private val _currentBands = MutableStateFlow<List<EqBand>>(defaultBands())
+    val currentBands: StateFlow<List<EqBand>> = _currentBands.asStateFlow()
+
+    private val _currentPreamp = MutableStateFlow(0f)
+    val currentPreamp: StateFlow<Float> = _currentPreamp.asStateFlow()
+
+    private val _activePreset = MutableStateFlow<EqPreset?>(null)
+    val activePreset: StateFlow<EqPreset?> = _activePreset.asStateFlow()
+
+    private val _allPresets = MutableStateFlow<List<EqPreset>>(emptyList())
+    val allPresets: StateFlow<List<EqPreset>> = _allPresets.asStateFlow()
+
+    private val _selectedBandId = MutableStateFlow(-1)
+    val selectedBandId: StateFlow<Int> = _selectedBandId.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _fftSize = MutableStateFlow(SpectrumAnalyzerTap.FFT_SIZE_LOW)
+    val fftSize: StateFlow<Int> = _fftSize.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            preferences.paramEqEnabled.collect { _enabled.value = it }
+        }
+        viewModelScope.launch {
+            preferences.paramEqPreamp.collect { _currentPreamp.value = it.toFloat() }
+        }
+        viewModelScope.launch {
+            repository.getAllPresets().collect { _allPresets.value = it }
+        }
+        viewModelScope.launch {
+            // Restore bands from persistent storage
+            val bandsJson = preferences.paramEqBandsJson.stateIn(
+                viewModelScope, SharingStarted.Eagerly, null
+            ).value
+            if (!bandsJson.isNullOrBlank()) {
+                try {
+                    val bands = json.decodeFromString<List<EqBand>>(bandsJson)
+                    if (bands.isNotEmpty()) _currentBands.value = bands
+                } catch (_: Exception) { }
+            }
+            val activeId = preferences.paramEqActivePresetId.stateIn(
+                viewModelScope, SharingStarted.Eagerly, null
+            ).value
+            if (activeId != null) {
+                _activePreset.value = repository.getPresetById(activeId)
+            }
+            if (_currentBands.value.isNotEmpty() && _selectedBandId.value < 0) {
+                _selectedBandId.value = _currentBands.value.first().id
+            }
+        }
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        _enabled.value = enabled
+        viewModelScope.launch { preferences.setParamEqEnabled(enabled) }
+    }
+
+    fun toggle() = setEnabled(!_enabled.value)
+
+    fun selectBand(id: Int) {
+        _selectedBandId.value = id
+    }
+
+    fun updateBand(band: EqBand) {
+        val updated = _currentBands.value.map { if (it.id == band.id) band else it }
+        _currentBands.value = updated
+        saveBands(updated)
+    }
+
+    fun updateBandByDrag(bandId: Int, newFreq: Float, newGain: Float) {
+        val updated = _currentBands.value.map { b ->
+            if (b.id == bandId) b.copy(
+                freq = newFreq.coerceIn(20f, 20000f),
+                gain = newGain.coerceIn(-24f, 24f)
+            ) else b
+        }
+        _currentBands.value = updated
+        saveBands(updated)
+    }
+
+    fun setPreamp(preamp: Float) {
+        _currentPreamp.value = preamp
+        viewModelScope.launch { preferences.setParamEqPreamp(preamp.toDouble()) }
+    }
+
+    fun addBand() {
+        val bands = _currentBands.value
+        // Place new band at midpoint of widest gap on the log-frequency axis
+        val sorted = bands.sortedBy { it.freq }
+        var newFreq = 1000f
+        if (sorted.size >= 2) {
+            var bestGap = 0f
+            var bestMid = 1000f
+            for (i in 0 until sorted.size - 1) {
+                val a = Math.log10(sorted[i].freq.toDouble())
+                val b = Math.log10(sorted[i + 1].freq.toDouble())
+                val gap = (b - a).toFloat()
+                if (gap > bestGap) {
+                    bestGap = gap
+                    bestMid = Math.pow(10.0, (a + b) / 2).toFloat()
+                }
+            }
+            newFreq = bestMid.coerceIn(20f, 20000f)
+        } else if (sorted.size == 1) {
+            newFreq = (sorted[0].freq * 2f).coerceIn(20f, 20000f)
+        }
+        val newId = (bands.maxOfOrNull { it.id } ?: -1) + 1
+        val newBand = EqBand(
+            id = newId,
+            type = FilterType.PEAKING,
+            freq = newFreq,
+            gain = 0f,
+            q = 1.0f,
+            enabled = true
+        )
+        val updated = bands + newBand
+        _currentBands.value = updated
+        _selectedBandId.value = newId
+        saveBands(updated)
+    }
+
+    fun removeBand(bandId: Int) {
+        val updated = _currentBands.value.filterNot { it.id == bandId }
+        _currentBands.value = updated
+        if (_selectedBandId.value == bandId) {
+            _selectedBandId.value = updated.firstOrNull()?.id ?: -1
+        }
+        saveBands(updated)
+    }
+
+    fun resetToFlat() {
+        val flat = _currentBands.value.map { it.copy(gain = 0f) }
+        _currentBands.value = flat
+        _currentPreamp.value = 0f
+        saveBands(flat)
+        viewModelScope.launch { preferences.setParamEqPreamp(0.0) }
+    }
+
+    fun loadPreset(presetId: String) {
+        viewModelScope.launch {
+            val preset = repository.getPresetById(presetId) ?: return@launch
+            _activePreset.value = preset
+            _currentBands.value = preset.bands
+            _currentPreamp.value = preset.preamp
+            _selectedBandId.value = preset.bands.firstOrNull()?.id ?: -1
+            preferences.setParamEqActivePreset(presetId)
+            preferences.setParamEqPreamp(preset.preamp.toDouble())
+            saveBands(preset.bands)
+        }
+    }
+
+    fun saveAsPreset(name: String, description: String = "") {
+        viewModelScope.launch {
+            try {
+                val preset = EqPreset(
+                    id = "custom_paramEq_${System.currentTimeMillis()}",
+                    name = name,
+                    description = description,
+                    bands = _currentBands.value,
+                    preamp = _currentPreamp.value,
+                    targetId = "",
+                    targetName = "",
+                    isCustom = true,
+                    createdAt = System.currentTimeMillis(),
+                    updatedAt = System.currentTimeMillis()
+                )
+                repository.savePreset(preset)
+                _activePreset.value = preset
+                preferences.setParamEqActivePreset(preset.id)
+                _error.value = null
+            } catch (e: Exception) {
+                _error.value = "Failed to save preset: ${e.message}"
+            }
+        }
+    }
+
+    fun deletePreset(presetId: String) {
+        viewModelScope.launch {
+            try {
+                repository.deletePreset(presetId)
+                if (_activePreset.value?.id == presetId) {
+                    _activePreset.value = null
+                    preferences.setParamEqActivePreset(null)
+                }
+            } catch (e: Exception) {
+                _error.value = "Failed to delete preset: ${e.message}"
+            }
+        }
+    }
+
+    fun setFftSize(size: Int) {
+        val clamped = when {
+            size <= SpectrumAnalyzerTap.FFT_SIZE_LOW -> SpectrumAnalyzerTap.FFT_SIZE_LOW
+            else -> SpectrumAnalyzerTap.FFT_SIZE_HIGH
+        }
+        _fftSize.value = clamped
+        spectrumAnalyzer.fftSize = clamped
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    private fun saveBands(bands: List<EqBand>) {
+        viewModelScope.launch {
+            try {
+                val bandsJson = json.encodeToString(bands)
+                preferences.setParamEqBands(bandsJson)
+            } catch (e: Exception) {
+                _error.value = "Failed to save bands: ${e.message}"
+            }
+        }
+    }
+
+    private fun defaultBands(): List<EqBand> = listOf(
+        EqBand(id = 0, type = FilterType.PEAKING, freq = 60f, gain = 0f, q = 1.0f),
+        EqBand(id = 1, type = FilterType.PEAKING, freq = 250f, gain = 0f, q = 1.0f),
+        EqBand(id = 2, type = FilterType.PEAKING, freq = 1000f, gain = 0f, q = 1.0f),
+        EqBand(id = 3, type = FilterType.PEAKING, freq = 4000f, gain = 0f, q = 1.0f),
+        EqBand(id = 4, type = FilterType.PEAKING, freq = 12000f, gain = 0f, q = 1.0f)
+    )
+}

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -61,6 +61,8 @@ import tf.monochrome.android.ui.detail.LocalAlbumDetailScreen
 import tf.monochrome.android.ui.detail.LocalArtistDetailScreen
 import tf.monochrome.android.ui.detail.MixScreen
 import tf.monochrome.android.ui.eq.EqualizerScreen
+import tf.monochrome.android.ui.eq.ParametricEqEditScreen
+import tf.monochrome.android.ui.eq.ParametricEqScreen
 import tf.monochrome.android.ui.home.HomeScreen
 import tf.monochrome.android.ui.mixer.MixerScreen
 import tf.monochrome.android.ui.library.LibraryScreen
@@ -98,6 +100,8 @@ sealed class Screen(val route: String) {
         fun createRoute(tab: Int = 0) = "settings?tab=$tab"
     }
     data object Equalizer : Screen("equalizer")
+    data object ParametricEq : Screen("parametric_eq")
+    data object ParametricEqEdit : Screen("parametric_eq_edit")
     data object Profile : Screen("profile")
     data object Stats : Screen("stats")
     data object ListeningStats : Screen("listening_stats")
@@ -241,6 +245,12 @@ fun MonochromeNavHost() {
                 }
                 composable(Screen.Equalizer.route) {
                     EqualizerScreen(navController = navController)
+                }
+                composable(Screen.ParametricEq.route) {
+                    ParametricEqScreen(navController = navController)
+                }
+                composable(Screen.ParametricEqEdit.route) {
+                    ParametricEqEditScreen(navController = navController)
                 }
                 composable(Screen.Mixer.route) {
                     MixerScreen(

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchScreen.kt
@@ -3,7 +3,6 @@ package tf.monochrome.android.ui.search
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -477,7 +477,7 @@ private fun UnifiedSearchTrackItem(
             }
             IconButton(onClick = onLikeClick) {
                 Icon(
-                    imageVector = if (isLiked) Favorite else FavoriteBorder,
+                    imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
                     contentDescription = if (isLiked) "Unlike" else "Like",
                     tint = if (isLiked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -195,6 +195,20 @@ private fun EqualizerTab(navController: NavController, eqViewModel: EqViewModel 
             Text("Open Precision AutoEQ")
         }
 
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedButton(
+            onClick = {
+                navController.navigate("settings?tab=4") {
+                    popUpTo("settings?tab={tab}") { inclusive = true }
+                }
+                navController.navigate("parametric_eq")
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Open Parametric EQ")
+        }
+
         // ─── Saved Profiles ───
         if (allPresets.isNotEmpty()) {
             Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
Introduces a second, general-purpose parametric EQ that runs after AutoEQ
in the audio pipeline so users can stack headphone correction with
free-form tone shaping. Reached from Settings → Audio as a separate entry.

- ParametricEqProcessor: standalone Media3 AudioProcessor using the same
  RBJ biquad implementation as AutoEqProcessor.
- SpectrumAnalyzerTap: passive FFT tap (pass-through AudioProcessor) with
  a hand-rolled radix-2 Cooley-Tukey FFT using precomputed twiddle tables.
  Runs at 120 fps, switchable between 8K/16K FFT sizes. Applies a
  +3.5 dB/octave pink-noise compensation tilt and re-centers to the
  200–2000 Hz midband so pink noise renders as a flat 0 dB line.
  Spectrum renders behind the EQ curve using the active theme's primary
  color. Analysis coroutine only runs while the editor is on-screen.
- ParametricEqEditScreen: Poweramp-style editor with draggable band dots,
  filter-type segmented control (PEAK / LOW-S / HIGH-S), freq/gain/Q
  sliders, band strip with add/long-press-remove, preamp slider, reset.
- ParametricEqScreen: toggle + pill "Edit" button + saved profiles list.
- eq_presets Room table gains an eqType column (0 = AutoEQ, 1 = Parametric)
  with existing DAO queries scoped to type 0 so the AutoEQ UI is unaffected.
- PreferencesManager adds param_eq_* DataStore keys; PlaybackService wires
  the new processors into the audio chain and reactively applies settings.