### PR TITLE
fix(dsp,eq): clamp bus/plugin params and guard biquad against NaN/Inf

### DIFF
--- a/app/src/main/cpp/dsp/dsp_engine.cpp
+++ b/app/src/main/cpp/dsp/dsp_engine.cpp
@@ -34,6 +34,7 @@
 #include "snapins/trance_gate.h"
 #include "snapins/eq_10band.h"
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <sstream>
 #include <android/log.h>
@@ -317,14 +318,22 @@ void DspEngine::process(float* left, float* right, int numFrames) {
 
 // ── Bus control ─────────────────────────────────────────────────────────
 
+// Sanitize: reject NaN/Inf (would poison the real-time atomics and trigger NaN audio).
+static inline float finiteOr(float v, float fallback) {
+    return std::isfinite(v) ? v : fallback;
+}
+
 void DspEngine::setBusGain(int busIndex, float gainDb) {
     if (busIndex < 0 || busIndex >= TOTAL_BUSES) return;
-    buses_[busIndex].gainDb.store(gainDb, std::memory_order_relaxed);
+    const float clamped = std::max(-60.0f, std::min(12.0f, finiteOr(gainDb, 0.0f)));
+    buses_[busIndex].gainDb.store(clamped, std::memory_order_relaxed);
 }
 
 void DspEngine::setBusPan(int busIndex, float pan) {
     if (busIndex < 0 || busIndex >= TOTAL_BUSES) return;
-    buses_[busIndex].pan.store(std::max(-1.0f, std::min(1.0f, pan)), std::memory_order_relaxed);
+    buses_[busIndex].pan.store(
+        std::max(-1.0f, std::min(1.0f, finiteOr(pan, 0.0f))),
+        std::memory_order_relaxed);
 }
 
 void DspEngine::setBusMute(int busIndex, bool muted) {
@@ -555,11 +564,12 @@ void DspEngine::loadStateJson(const std::string& json) {
         if (busStart == std::string::npos) break;
 
         pos = busStart + 8;
-        buses_[busIdx].gainDb.store(readFloat(pos), std::memory_order_relaxed);
+        // Route through setBusGain/setBusPan so clamping + NaN filtering match live edits.
+        setBusGain(busIdx, readFloat(pos));
 
         size_t panPos = json.find("\"pan\":", pos);
         if (panPos != std::string::npos) {
-            buses_[busIdx].pan.store(readFloat(panPos + 6), std::memory_order_relaxed);
+            setBusPan(busIdx, readFloat(panPos + 6));
             pos = panPos + 6;
         }
 
@@ -605,6 +615,7 @@ void DspEngine::loadStateJson(const std::string& json) {
 
                     size_t dwPos = json.find("\"dryWet\":", pos);
                     if (dwPos != std::string::npos && dwPos < json.find("\"params\":", pos)) {
+                        // setDryWet already filters NaN + clamps to [0,1]
                         proc->setDryWet(readFloat(dwPos + 9));
                         pos = dwPos + 9;
                     }
@@ -616,7 +627,12 @@ void DspEngine::loadStateJson(const std::string& json) {
                         while (pos < json.size() && json[pos] != ']') {
                             if (json[pos] == ',' || json[pos] == ' ') { pos++; continue; }
                             float val = readFloat(pos);
-                            proc->setParameter(paramIdx++, val);
+                            // Reject NaN/Inf before reaching per-plugin setParameter (not all
+                            // plugins defensively filter non-finite inputs).
+                            if (std::isfinite(val)) {
+                                proc->setParameter(paramIdx, val);
+                            }
+                            paramIdx++;
                             size_t next = json.find_first_of(",]", pos);
                             if (next == std::string::npos) break;
                             pos = next;

--- a/app/src/main/cpp/dsp/snapin_processor.h
+++ b/app/src/main/cpp/dsp/snapin_processor.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>
 #include <cstdint>
 
 // Plugin type enum — matches SnapinType.kt ordinal
@@ -31,7 +32,10 @@ public:
     void setBypassed(bool b) { bypassed_ = b; }
 
     float getDryWet() const { return dryWet_; }
-    void setDryWet(float v) { dryWet_ = (v < 0.0f) ? 0.0f : (v > 1.0f) ? 1.0f : v; }
+    void setDryWet(float v) {
+        const float safe = std::isfinite(v) ? v : 1.0f;
+        dryWet_ = (safe < 0.0f) ? 0.0f : (safe > 1.0f) ? 1.0f : safe;
+    }
 
 protected:
     double sampleRate_ = 44100.0;

--- a/app/src/main/java/tf/monochrome/android/audio/dsp/DspEngineManager.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/dsp/DspEngineManager.kt
@@ -87,6 +87,21 @@ class DspEngineManager @Inject constructor(
 
     companion object {
         private const val TOTAL_BUSES = 5
+
+        // Parameter bounds — mirror the native clamps in dsp_engine.cpp / snapin_processor.h.
+        // Clamping in Kotlin keeps the StateFlow value in sync with what native actually stores.
+        const val MIN_BUS_GAIN_DB = -60f
+        const val MAX_BUS_GAIN_DB = 12f
+        const val MIN_PAN = -1f
+        const val MAX_PAN = 1f
+        const val MIN_DRY_WET = 0f
+        const val MAX_DRY_WET = 1f
+    }
+
+    private fun sanitizeParam(value: Float): Float {
+        // Plugin parameter ranges vary per processor; the native side clamps to its own range.
+        // Here we only reject NaN/Inf so they never reach the native atomics or StateFlow.
+        return if (value.isFinite()) value else 0f
     }
 
     fun setEnabled(enabled: Boolean) {
@@ -111,16 +126,19 @@ class DspEngineManager @Inject constructor(
     // ── Bus controls ────────────────────────────────────────────────────
 
     fun setBusGain(busIndex: Int, gainDb: Float) {
+        val clamped = (if (gainDb.isFinite()) gainDb else 0f)
+            .coerceIn(MIN_BUS_GAIN_DB, MAX_BUS_GAIN_DB)
         val ptr = processor.getEnginePtr()
-        if (ptr != 0L) processor.nativeSetBusGain(ptr, busIndex, gainDb)
-        updateBus(busIndex) { it.copy(gainDb = gainDb) }
+        if (ptr != 0L) processor.nativeSetBusGain(ptr, busIndex, clamped)
+        updateBus(busIndex) { it.copy(gainDb = clamped) }
         requestSave()
     }
 
     fun setBusPan(busIndex: Int, pan: Float) {
+        val clamped = (if (pan.isFinite()) pan else 0f).coerceIn(MIN_PAN, MAX_PAN)
         val ptr = processor.getEnginePtr()
-        if (ptr != 0L) processor.nativeSetBusPan(ptr, busIndex, pan)
-        updateBus(busIndex) { it.copy(pan = pan) }
+        if (ptr != 0L) processor.nativeSetBusPan(ptr, busIndex, clamped)
+        updateBus(busIndex) { it.copy(pan = clamped) }
         requestSave()
     }
 
@@ -194,14 +212,15 @@ class DspEngineManager @Inject constructor(
     }
 
     fun setParameter(busIndex: Int, slotIndex: Int, paramIndex: Int, value: Float) {
+        val sanitized = sanitizeParam(value)
         val ptr = processor.getEnginePtr()
-        if (ptr != 0L) processor.nativeSetParameter(ptr, busIndex, slotIndex, paramIndex, value)
+        if (ptr != 0L) processor.nativeSetParameter(ptr, busIndex, slotIndex, paramIndex, sanitized)
         updateBus(busIndex) { bus ->
             val plugins = bus.plugins.toMutableList()
             if (slotIndex in plugins.indices) {
                 val plugin = plugins[slotIndex]
                 plugins[slotIndex] = plugin.copy(
-                    parameters = plugin.parameters + (paramIndex to value)
+                    parameters = plugin.parameters + (paramIndex to sanitized)
                 )
             }
             bus.copy(plugins = plugins)
@@ -223,12 +242,14 @@ class DspEngineManager @Inject constructor(
     }
 
     fun setPluginDryWet(busIndex: Int, slotIndex: Int, dryWet: Float) {
+        val clamped = (if (dryWet.isFinite()) dryWet else MAX_DRY_WET)
+            .coerceIn(MIN_DRY_WET, MAX_DRY_WET)
         val ptr = processor.getEnginePtr()
-        if (ptr != 0L) processor.nativeSetPluginDryWet(ptr, busIndex, slotIndex, dryWet)
+        if (ptr != 0L) processor.nativeSetPluginDryWet(ptr, busIndex, slotIndex, clamped)
         updateBus(busIndex) { bus ->
             val plugins = bus.plugins.toMutableList()
             if (slotIndex in plugins.indices) {
-                plugins[slotIndex] = plugins[slotIndex].copy(dryWet = dryWet)
+                plugins[slotIndex] = plugins[slotIndex].copy(dryWet = clamped)
             }
             bus.copy(plugins = plugins)
         }
@@ -279,18 +300,23 @@ class DspEngineManager @Inject constructor(
                     val plugObj = plugEl.jsonObject
                     val typeOrd = plugObj["type"]?.jsonPrimitive?.int ?: 0
                     val bypassed = plugObj["bypassed"]?.jsonPrimitive?.boolean ?: false
-                    val dryWet = plugObj["dryWet"]?.jsonPrimitive?.float ?: 1f
+                    val dryWet = (plugObj["dryWet"]?.jsonPrimitive?.float ?: 1f)
+                        .let { if (it.isFinite()) it else 1f }
+                        .coerceIn(MIN_DRY_WET, MAX_DRY_WET)
                     val params = plugObj["params"]?.jsonArray
-                        ?.mapIndexed { pi, pv -> pi to pv.jsonPrimitive.float }
+                        ?.mapIndexed { pi, pv -> pi to sanitizeParam(pv.jsonPrimitive.float) }
                         ?.toMap() ?: emptyMap()
                     PluginInstance(slotIdx, typeOrd, bypassed, dryWet, params)
                 } ?: emptyList()
 
+                val rawGain = obj["gain"]?.jsonPrimitive?.float ?: 0f
+                val rawPan = obj["pan"]?.jsonPrimitive?.float ?: 0f
                 BusConfig(
                     index = index,
                     name = defaultBusNames.getOrElse(index) { "Bus ${index + 1}" },
-                    gainDb = obj["gain"]?.jsonPrimitive?.float ?: 0f,
-                    pan = obj["pan"]?.jsonPrimitive?.float ?: 0f,
+                    gainDb = (if (rawGain.isFinite()) rawGain else 0f)
+                        .coerceIn(MIN_BUS_GAIN_DB, MAX_BUS_GAIN_DB),
+                    pan = (if (rawPan.isFinite()) rawPan else 0f).coerceIn(MIN_PAN, MAX_PAN),
                     muted = obj["muted"]?.jsonPrimitive?.boolean ?: false,
                     soloed = obj["soloed"]?.jsonPrimitive?.boolean ?: false,
                     inputEnabled = obj["inputEnabled"]?.jsonPrimitive?.boolean ?: (index == 0),

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
 import kotlin.math.pow
@@ -273,8 +274,23 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
                     na2 = (a + 1) - (a - 1) * cosw0 - sq
                 }
             }
-            b0 = (nb0 / na0).toFloat(); b1 = (nb1 / na0).toFloat(); b2 = (nb2 / na0).toFloat()
-            a1 = (na1 / na0).toFloat(); a2 = (na2 / na0).toFloat()
+            if (abs(na0) < 1e-20 || !na0.isFinite()) {
+                // Degenerate coefficient — fall back to passthrough instead of emitting NaN/Inf audio.
+                b0 = 1f; b1 = 0f; b2 = 0f; a1 = 0f; a2 = 0f
+                z1 = 0f; z2 = 0f
+                return
+            }
+            val nb0f = (nb0 / na0).toFloat()
+            val nb1f = (nb1 / na0).toFloat()
+            val nb2f = (nb2 / na0).toFloat()
+            val na1f = (na1 / na0).toFloat()
+            val na2f = (na2 / na0).toFloat()
+            if (!nb0f.isFinite() || !nb1f.isFinite() || !nb2f.isFinite() ||
+                !na1f.isFinite() || !na2f.isFinite()) {
+                b0 = 1f; b1 = 0f; b2 = 0f; a1 = 0f; a2 = 0f
+            } else {
+                b0 = nb0f; b1 = nb1f; b2 = nb2f; a1 = na1f; a2 = na2f
+            }
             z1 = 0f; z2 = 0f
         }
 

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
@@ -9,6 +9,7 @@ import tf.monochrome.android.domain.model.EqBand
 import tf.monochrome.android.domain.model.FilterType
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
@@ -38,30 +39,37 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
     private var scratchL = FloatArray(0)
     private var scratchR = FloatArray(0)
 
-    // EQ state — written from UI thread, read from audio thread
-    @Volatile private var eqEnabled = false
-    @Volatile private var currentBands: Array<BandState> = emptyArray()
-    @Volatile private var preampLinear = 1f
+    // UI-thread writes grouped into one immutable snapshot published atomically so the
+    // audio thread always sees a consistent (enabled, preamp, bands) triple.
+    private data class Snapshot(
+        val enabled: Boolean,
+        val preampLinear: Float,
+        val bands: Array<BandState>
+    )
+
+    private val stateRef = AtomicReference(Snapshot(false, 1f, emptyArray()))
+    private var appliedSnapshot: Snapshot? = null
 
     // Per-band biquad filter state (audio thread only, rebuilt when bands change)
     private var filtersL = arrayOf<BiquadFilter>()
     private var filtersR = arrayOf<BiquadFilter>()
-    private var filtersDirty = true
     private var sampleRate = 44100.0
 
     fun applyBands(bands: List<EqBand>, preamp: Float, enabled: Boolean) {
-        eqEnabled = enabled
-        preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f)
-        currentBands = bands.map { band ->
-            BandState(
-                freq = band.freq,
-                gain = band.gain,
-                q = band.q,
-                type = band.type,
-                enabled = band.enabled
-            )
-        }.toTypedArray()
-        filtersDirty = true
+        val snap = Snapshot(
+            enabled = enabled,
+            preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f),
+            bands = bands.map { band ->
+                BandState(
+                    freq = band.freq,
+                    gain = band.gain,
+                    q = band.q,
+                    type = band.type,
+                    enabled = band.enabled
+                )
+            }.toTypedArray()
+        )
+        stateRef.set(snap)
     }
 
     // ── AudioProcessor implementation ────────────────────────────────────
@@ -127,12 +135,13 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
         inputBuffer.position(inputBuffer.position() + numFrames * frameSize)
 
         // Apply EQ if enabled
-        if (eqEnabled) {
-            if (filtersDirty) {
-                rebuildFilters()
-                filtersDirty = false
+        val snap = stateRef.get()
+        if (snap.enabled) {
+            if (snap !== appliedSnapshot) {
+                rebuildFilters(snap.bands)
+                appliedSnapshot = snap
             }
-            applyEq(numFrames)
+            applyEq(numFrames, snap.preampLinear)
         }
 
         // Interleave output (always stereo)
@@ -177,7 +186,8 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
             if (formatChanged) {
                 inputFormat = pendingFormat
                 sampleRate = inputFormat.sampleRate.toDouble()
-                filtersDirty = true
+                // Force filter rebuild on next block (sample-rate-dependent coefficients).
+                appliedSnapshot = null
             }
             pendingFormat = AudioFormat.NOT_SET
         }
@@ -189,17 +199,16 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
         inputFormat = AudioFormat.NOT_SET
         filtersL = emptyArray()
         filtersR = emptyArray()
+        appliedSnapshot = null
     }
 
     // ── DSP internals ───────────────────────────────────────────────────
 
-    private fun applyEq(numFrames: Int) {
-        // Preamp
-        val gain = preampLinear
-        if (gain != 1f) {
+    private fun applyEq(numFrames: Int, preampLinear: Float) {
+        if (preampLinear != 1f) {
             for (i in 0 until numFrames) {
-                scratchL[i] *= gain
-                scratchR[i] *= gain
+                scratchL[i] *= preampLinear
+                scratchR[i] *= preampLinear
             }
         }
         // Biquad bands
@@ -209,8 +218,7 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
         }
     }
 
-    private fun rebuildFilters() {
-        val bands = currentBands
+    private fun rebuildFilters(bands: Array<BandState>) {
         val active = bands.filter { it.enabled && it.gain != 0f }
         filtersL = Array(active.size) { BiquadFilter() }
         filtersR = Array(active.size) { BiquadFilter() }

--- a/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
@@ -9,6 +9,7 @@ import tf.monochrome.android.domain.model.EqBand
 import tf.monochrome.android.domain.model.FilterType
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.abs
@@ -36,28 +37,37 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
     private var scratchL = FloatArray(0)
     private var scratchR = FloatArray(0)
 
-    @Volatile private var eqEnabled = false
-    @Volatile private var currentBands: Array<BandState> = emptyArray()
-    @Volatile private var preampLinear = 1f
+    // Group the three UI-thread writes into one immutable snapshot published atomically.
+    // The audio thread reads the reference once per block — guaranteed to see a consistent
+    // (enabled, preamp, bands) triple, never a half-updated one.
+    private data class Snapshot(
+        val enabled: Boolean,
+        val preampLinear: Float,
+        val bands: Array<BandState>
+    )
+
+    private val stateRef = AtomicReference(Snapshot(false, 1f, emptyArray()))
+    private var appliedSnapshot: Snapshot? = null
 
     private var filtersL = arrayOf<BiquadFilter>()
     private var filtersR = arrayOf<BiquadFilter>()
-    private var filtersDirty = true
     private var sampleRate = 44100.0
 
     fun applyBands(bands: List<EqBand>, preamp: Float, enabled: Boolean) {
-        eqEnabled = enabled
-        preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f)
-        currentBands = bands.map { band ->
-            BandState(
-                freq = band.freq,
-                gain = band.gain,
-                q = band.q,
-                type = band.type,
-                enabled = band.enabled
-            )
-        }.toTypedArray()
-        filtersDirty = true
+        val snap = Snapshot(
+            enabled = enabled,
+            preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f),
+            bands = bands.map { band ->
+                BandState(
+                    freq = band.freq,
+                    gain = band.gain,
+                    q = band.q,
+                    type = band.type,
+                    enabled = band.enabled
+                )
+            }.toTypedArray()
+        )
+        stateRef.set(snap)
     }
 
     override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
@@ -118,12 +128,13 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
         }
         inputBuffer.position(inputBuffer.position() + numFrames * frameSize)
 
-        if (eqEnabled) {
-            if (filtersDirty) {
-                rebuildFilters()
-                filtersDirty = false
+        val snap = stateRef.get()
+        if (snap.enabled) {
+            if (snap !== appliedSnapshot) {
+                rebuildFilters(snap.bands)
+                appliedSnapshot = snap
             }
-            applyEq(numFrames)
+            applyEq(numFrames, snap.preampLinear)
         }
 
         val outFrameSize = bytesPerSample * 2
@@ -167,7 +178,8 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
             if (formatChanged) {
                 inputFormat = pendingFormat
                 sampleRate = inputFormat.sampleRate.toDouble()
-                filtersDirty = true
+                // Force filter rebuild on next block (sample-rate-dependent coefficients).
+                appliedSnapshot = null
             }
             pendingFormat = AudioFormat.NOT_SET
         }
@@ -179,14 +191,14 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
         inputFormat = AudioFormat.NOT_SET
         filtersL = emptyArray()
         filtersR = emptyArray()
+        appliedSnapshot = null
     }
 
-    private fun applyEq(numFrames: Int) {
-        val gain = preampLinear
-        if (gain != 1f) {
+    private fun applyEq(numFrames: Int, preampLinear: Float) {
+        if (preampLinear != 1f) {
             for (i in 0 until numFrames) {
-                scratchL[i] *= gain
-                scratchR[i] *= gain
+                scratchL[i] *= preampLinear
+                scratchR[i] *= preampLinear
             }
         }
         for (i in filtersL.indices) {
@@ -195,8 +207,7 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
         }
     }
 
-    private fun rebuildFilters() {
-        val bands = currentBands
+    private fun rebuildFilters(bands: Array<BandState>) {
         val active = bands.filter { it.enabled && it.gain != 0f }
         filtersL = Array(active.size) { BiquadFilter() }
         filtersR = Array(active.size) { BiquadFilter() }

--- a/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/ParametricEqProcessor.kt
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.sin
@@ -257,8 +258,23 @@ class ParametricEqProcessor @Inject constructor() : AudioProcessor {
                     na2 = (a + 1) - (a - 1) * cosw0 - sq
                 }
             }
-            b0 = (nb0 / na0).toFloat(); b1 = (nb1 / na0).toFloat(); b2 = (nb2 / na0).toFloat()
-            a1 = (na1 / na0).toFloat(); a2 = (na2 / na0).toFloat()
+            if (abs(na0) < 1e-20 || !na0.isFinite()) {
+                // Degenerate coefficient — fall back to passthrough instead of emitting NaN/Inf audio.
+                b0 = 1f; b1 = 0f; b2 = 0f; a1 = 0f; a2 = 0f
+                z1 = 0f; z2 = 0f
+                return
+            }
+            val nb0f = (nb0 / na0).toFloat()
+            val nb1f = (nb1 / na0).toFloat()
+            val nb2f = (nb2 / na0).toFloat()
+            val na1f = (na1 / na0).toFloat()
+            val na2f = (na2 / na0).toFloat()
+            if (!nb0f.isFinite() || !nb1f.isFinite() || !nb2f.isFinite() ||
+                !na1f.isFinite() || !na2f.isFinite()) {
+                b0 = 1f; b1 = 0f; b2 = 0f; a1 = 0f; a2 = 0f
+            } else {
+                b0 = nb0f; b1 = nb1f; b2 = nb2f; a1 = na1f; a2 = na2f
+            }
             z1 = 0f; z2 = 0f
         }
 

--- a/app/src/main/java/tf/monochrome/android/data/api/HeadphoneAutoEqApi.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HeadphoneAutoEqApi.kt
@@ -135,22 +135,33 @@ class HeadphoneAutoEqApi {
 
     /**
      * Fetch measurement CSV for a specific headphone.
-     * Tries multiple known file names in the first available measurement path.
+     *
+     * `headphoneId` is the normalized (lowercase, underscored) id used for
+     * cache/preferences lookup. `headphoneName` is the original-case display
+     * name. The GitHub raw URLs are case-sensitive, so the fallback paths
+     * need the original name — passing only the lowercased id silently
+     * breaks lookups like "AKG K371" vs "akg k371".
      */
-    suspend fun fetchHeadphoneMeasurement(headphoneId: String): Result<String> =
+    suspend fun fetchHeadphoneMeasurement(
+        headphoneId: String,
+        headphoneName: String = ""
+    ): Result<String> =
         withContext(Dispatchers.IO) {
             try {
-                // Find the headphone in cache to get its path
-                val headphone = cachedHeadphones?.find { it.id == headphoneId }
+                // Cache lookup is case-insensitive so we're tolerant of either
+                // the normalized id or any mixed-case variant the caller passes.
+                val headphone = cachedHeadphones?.find {
+                    it.id.equals(headphoneId, ignoreCase = true) ||
+                        it.name.equals(headphoneName, ignoreCase = true)
+                }
                 val measurement = headphone?.measurements?.firstOrNull()
                 val basePath = measurement?.path
 
                 if (basePath != null) {
                     // Try known measurement file names
-                    val fileNames = listOf(
-                        "$headphone.csv",
-                        "raw.csv",
-                        "${headphone?.name}.csv"
+                    val fileNames = listOfNotNull(
+                        headphone.name.let { "$it.csv" },
+                        "raw.csv"
                     )
                     for (fileName in fileNames) {
                         try {
@@ -163,13 +174,14 @@ class HeadphoneAutoEqApi {
                     }
                 }
 
-                // Fallback: try common patterns
-                val encodedId = headphoneId.replace("_", " ")
+                // Fallback: try common patterns using the original-case name
+                // when available (falls back to de-underscored id if not).
+                val encodedName = headphoneName.ifBlank { headphoneId.replace("_", " ") }
                 val fallbackUrls = listOf(
-                    "$RAW_BASE/results/oratory1990/over-ear/$encodedId/$encodedId.csv",
-                    "$RAW_BASE/results/crinacle/over-ear/$encodedId/$encodedId.csv",
-                    "$RAW_BASE/results/oratory1990/in-ear/$encodedId/$encodedId.csv",
-                    "$RAW_BASE/results/crinacle/in-ear/$encodedId/$encodedId.csv",
+                    "$RAW_BASE/results/oratory1990/over-ear/$encodedName/$encodedName.csv",
+                    "$RAW_BASE/results/crinacle/over-ear/$encodedName/$encodedName.csv",
+                    "$RAW_BASE/results/oratory1990/in-ear/$encodedName/$encodedName.csv",
+                    "$RAW_BASE/results/crinacle/in-ear/$encodedName/$encodedName.csv",
                 )
                 for (url in fallbackUrls) {
                     try {

--- a/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.data.repository
 
+import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -161,24 +162,37 @@ class EqRepository @Inject constructor(
     // ===== Conversion Helpers =====
 
     /**
-     * Convert EqPresetEntity to domain model
+     * Convert EqPresetEntity to domain model.
+     *
+     * If bandsJson fails to decode we no longer silently flatten the preset —
+     * that behavior could quietly wipe a user's tuning on any migration or
+     * format glitch. Instead we log, mark the preset corrupted, and leave
+     * bands empty so the UI can refuse to load it and surface the error.
      */
     private fun EqPresetEntity.toDomain(): EqPreset {
+        var corrupted = false
+        val bands = try {
+            json.decodeFromString<List<EqBand>>(bandsJson)
+        } catch (e: Exception) {
+            Log.e(
+                "EqRepository",
+                "Failed to decode bands for preset '$id' (${e.javaClass.simpleName}: ${e.message})"
+            )
+            corrupted = true
+            emptyList()
+        }
         return EqPreset(
             id = id,
             name = name,
             description = description,
-            bands = try {
-                json.decodeFromString<List<EqBand>>(bandsJson)
-            } catch (e: Exception) {
-                emptyList()
-            },
+            bands = bands,
             preamp = preamp,
             targetId = targetId,
             targetName = targetName,
             isCustom = isCustom,
             createdAt = createdAt,
-            updatedAt = updatedAt
+            updatedAt = updatedAt,
+            isCorrupted = corrupted
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
@@ -82,11 +82,16 @@ class HeadphoneRepository @Inject constructor(
     /**
      * Load measurement data for a specific headphone
      *
-     * @param headphoneId The headphone folder name (e.g., "Apple AirPods Max")
+     * @param headphoneId The normalized (lowercased, underscored) id used for cache lookup.
+     * @param headphoneName The original-case display name, needed for the
+     *   case-sensitive GitHub fallback URLs. Defaults to the id when unknown.
      */
-    fun loadHeadphoneMeasurement(headphoneId: String): Flow<Result<String>> = flow {
+    fun loadHeadphoneMeasurement(
+        headphoneId: String,
+        headphoneName: String = ""
+    ): Flow<Result<String>> = flow {
         try {
-            val result = autoEqApi.fetchHeadphoneMeasurement(headphoneId)
+            val result = autoEqApi.fetchHeadphoneMeasurement(headphoneId, headphoneName)
             emit(result)
         } catch (e: Exception) {
             emit(Result.failure(e))

--- a/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
@@ -429,7 +429,11 @@ data class EqPreset(
     val targetName: String = "",
     val isCustom: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    // Set by EqRepository.toDomain when the stored bandsJson fails to decode.
+    // Loading a corrupted preset would silently flatten the EQ; callers should
+    // refuse to load it and surface the state instead.
+    val isCorrupted: Boolean = false
 )
 
 @Serializable

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
@@ -1,0 +1,16 @@
+package tf.monochrome.android.ui.eq
+
+/**
+ * Shared range constants for the two EQ surfaces.
+ *
+ * AutoEQ bands are capped tighter so the algorithm's own per-band safeBoost
+ * (12/6/3 dB depending on frequency) is the binding constraint. The Parametric
+ * EQ is a tone-shaping tool and intentionally offers more range; callers are
+ * responsible for communicating headroom risk to the user.
+ */
+object EqLimits {
+    const val AUTOEQ_MAX_BAND_DB = 12f
+    const val PARAMETRIC_MAX_BAND_DB = 24f
+    const val MIN_FREQ_HZ = 20f
+    const val MAX_FREQ_HZ = 20000f
+}

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
@@ -13,4 +13,9 @@ object EqLimits {
     const val PARAMETRIC_MAX_BAND_DB = 24f
     const val MIN_FREQ_HZ = 20f
     const val MAX_FREQ_HZ = 20000f
+
+    // Total signal-path headroom for AutoEQ (band gain + preamp). Beyond this,
+    // the biquad cascade drives the ReplayGain limiter into hard clipping at
+    // the band's resonant peak. Preamp is clamped against (TOTAL - peakBand).
+    const val AUTOEQ_MAX_TOTAL_DB = 24f
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -3,9 +3,12 @@ package tf.monochrome.android.ui.eq
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -67,6 +70,11 @@ class EqViewModel @Inject constructor(
 
     private val _isCalculating = MutableStateFlow(false)
     val isCalculating: StateFlow<Boolean> = _isCalculating.asStateFlow()
+
+    // Fires when a band drag exceeded the AutoEQ gain cap and got clamped, so the
+    // UI can surface a transient toast instead of silently discarding the overshoot.
+    private val _bandClampEvents = MutableSharedFlow<Float>(extraBufferCapacity = 1)
+    val bandClampEvents: SharedFlow<Float> = _bandClampEvents.asSharedFlow()
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
@@ -602,9 +610,14 @@ class EqViewModel @Inject constructor(
         val updatedBands = _currentBands.value.toMutableList()
         val index = updatedBands.indexOfFirst { it.id == bandId }
         if (index >= 0) {
+            val cap = EqLimits.AUTOEQ_MAX_BAND_DB
+            val clampedGain = newGain.coerceIn(-cap, cap)
+            if (clampedGain != newGain) {
+                _bandClampEvents.tryEmit(cap)
+            }
             updatedBands[index] = updatedBands[index].copy(
-                freq = newFreq.coerceIn(20f, 20000f),
-                gain = newGain.coerceIn(-12f, 12f)
+                freq = newFreq.coerceIn(EqLimits.MIN_FREQ_HZ, EqLimits.MAX_FREQ_HZ),
+                gain = clampedGain
             )
             _currentBands.value = updatedBands
             saveBandsToPreferences(updatedBands)

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -284,6 +284,10 @@ class EqViewModel @Inject constructor(
     fun loadPreset(presetId: String) {
         viewModelScope.launch {
             val preset = eqRepository.getPresetById(presetId) ?: return@launch
+            if (preset.isCorrupted) {
+                _error.value = "Preset \"${preset.name}\" is corrupted and can't be loaded."
+                return@launch
+            }
             _activePreset.value = preset
             _currentBands.value = preset.bands
             _currentPreamp.value = preset.preamp
@@ -318,12 +322,17 @@ class EqViewModel @Inject constructor(
     }
 
     /**
-     * Update preamp gain
+     * Update preamp gain. Clamped so |preamp| + peakBandGain stays within the
+     * AutoEQ total-headroom budget. Otherwise the filter cascade can clip at
+     * resonant peaks before the downstream limiter engages.
      */
     fun setPreamp(preamp: Float) {
-        _currentPreamp.value = preamp
+        val peakBand = _currentBands.value.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f
+        val headroom = (EqLimits.AUTOEQ_MAX_TOTAL_DB - peakBand).coerceAtLeast(0f)
+        val clamped = preamp.coerceIn(-headroom, headroom)
+        _currentPreamp.value = clamped
         viewModelScope.launch {
-            preferences.setEqPreamp(preamp.toDouble())
+            preferences.setEqPreamp(clamped.toDouble())
         }
     }
 
@@ -525,7 +534,12 @@ class EqViewModel @Inject constructor(
                 _error.value = null
 
                 val headphoneId = headphoneName.replace(" ", "_").lowercase()
-                val measurementResult = headphoneRepository.loadHeadphoneMeasurement(headphoneId)
+                // Pass the original name through so the repo's fallback URLs
+                // can hit case-sensitive GitHub paths like "AKG K371".
+                val measurementResult = headphoneRepository.loadHeadphoneMeasurement(
+                    headphoneId,
+                    headphoneName
+                )
 
                 measurementResult.collect { result ->
                     result.onSuccess { csvData ->

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -46,11 +46,13 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import android.widget.Toast
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -108,6 +110,17 @@ fun EqualizerScreen(
     var presetToDelete by remember { mutableStateOf<tf.monochrome.android.domain.model.EqPreset?>(null) }
 
     val context = LocalContext.current
+
+    // Surface a toast when a band drag hit the AutoEQ cap, so the clamp isn't silent.
+    LaunchedEffect(viewModel) {
+        viewModel.bandClampEvents.collect { cap ->
+            Toast.makeText(
+                context,
+                "Clamped to \u00b1${cap.toInt()} dB (AutoEQ limit)",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
 
     // File picker for measurement import
     val measurementFilePicker = rememberLauncherForActivityResult(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -146,12 +146,15 @@ fun FrequencyResponseGraph(
     var selectedBandId by remember { mutableIntStateOf(-1) }
     var isDragging by remember { mutableStateOf(false) }
 
+    val graphBackground = MaterialTheme.colorScheme.surface
+    val legendBackground = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
+    val legendLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(260.dp)
             .clip(RoundedCornerShape(12.dp))
-            .background(Color(0xFF0A0A0A))
+            .background(graphBackground)
     ) {
         Canvas(
             modifier = Modifier
@@ -325,20 +328,20 @@ fun FrequencyResponseGraph(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
-                    .background(Color(0x600A0A0A))
+                    .background(legendBackground)
                     .padding(horizontal = 12.dp, vertical = 6.dp),
                 horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
             ) {
-                LegendDot("Original", Color(0xFF4A9EFF))
-                LegendDot("Target (Primary)", Color.White)
-                LegendDot("Corrected", Color(0xFFFF4444))
+                LegendDot("Original", Color(0xFF4A9EFF), legendLabelColor)
+                LegendDot("Target (Primary)", Color.White, legendLabelColor)
+                LegendDot("Corrected", Color(0xFFFF4444), legendLabelColor)
             }
         }
     }
 }
 
 @Composable
-private fun LegendDot(label: String, color: Color) {
+private fun LegendDot(label: String, color: Color, labelColor: Color) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -351,7 +354,7 @@ private fun LegendDot(label: String, color: Color) {
         Text(
             label,
             fontSize = 9.sp,
-            color = Color(0xFFB0B0B0)
+            color = labelColor
         )
     }
 }
@@ -372,13 +375,14 @@ fun EqProfileMiniGraph(
 ) {
     if (bands.isEmpty()) return
 
-
+    val miniBackground = MaterialTheme.colorScheme.surface
+    val zeroLineColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(56.dp)
             .clip(RoundedCornerShape(8.dp))
-            .background(Color(0xFF0D0D0D))
+            .background(miniBackground)
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             val w = size.width
@@ -388,7 +392,7 @@ fun EqProfileMiniGraph(
 
             // Zero center line
             drawLine(
-                color = Color(0x20FFFFFF),
+                color = zeroLineColor,
                 start = Offset(0f, midY),
                 end = Offset(w, midY),
                 strokeWidth = 1f

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -76,6 +76,9 @@ fun FrequencyResponseGraph(
     spectrumColor: Color? = null,
     centerOnZero: Boolean = false,
     showLegend: Boolean = true,
+    // Absolute cap used when mapping a drag's Y-pixel back to a gain value.
+    // Defaults to the AutoEQ cap; Parametric EQ callers pass EqLimits.PARAMETRIC_MAX_BAND_DB.
+    maxAbsDragGain: Float = EqLimits.AUTOEQ_MAX_BAND_DB,
 ) {
     val primary = MaterialTheme.colorScheme.primary
 
@@ -184,7 +187,7 @@ fun FrequencyResponseGraph(
                                 val freq = xToFreq(change.position.x, size.width.toFloat())
                                 val gain = yToGain(
                                     change.position.y, size.height.toFloat(),
-                                    minGain, maxGain
+                                    minGain, maxGain, maxAbsDragGain
                                 )
                                 onBandDragged(selectedBandId, freq, gain)
                             }
@@ -363,10 +366,12 @@ fun EqProfileMiniGraph(
     modifier: Modifier = Modifier,
     preamp: Float = 0f,
     sampleRate: Float = 48000f,
+    // ±dB display range. Defaults to the AutoEQ cap; Parametric profile previews pass
+    // EqLimits.PARAMETRIC_MAX_BAND_DB so bigger boosts/cuts aren't clipped off visually.
+    gainRange: Float = EqLimits.AUTOEQ_MAX_BAND_DB,
 ) {
     if (bands.isEmpty()) return
 
-    val gainRange = 12f // ±12 dB display range
 
     Box(
         modifier = modifier
@@ -483,9 +488,16 @@ private fun xToFreq(x: Float, width: Float): Float {
     return 10f.pow(logFreq).coerceIn(MIN_FREQ, MAX_FREQ)
 }
 
-private fun yToGain(y: Float, height: Float, minGain: Float, maxGain: Float): Float {
+private fun yToGain(
+    y: Float,
+    height: Float,
+    minGain: Float,
+    maxGain: Float,
+    maxAbsDragGain: Float = EqLimits.AUTOEQ_MAX_BAND_DB,
+): Float {
     val ratio = ((height - GRAPH_PADDING_BOTTOM) - y) / (height - GRAPH_PADDING_TOP - GRAPH_PADDING_BOTTOM)
-    return (minGain + ratio.coerceIn(0f, 1f) * (maxGain - minGain)).coerceIn(-12f, 12f)
+    return (minGain + ratio.coerceIn(0f, 1f) * (maxGain - minGain))
+        .coerceIn(-maxAbsDragGain, maxAbsDragGain)
 }
 
 private fun findNearestBand(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqEditScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqEditScreen.kt
@@ -168,6 +168,7 @@ fun ParametricEqEditScreen(
                 showLegend = false,
                 spectrumBins = spectrumBins,
                 spectrumColor = spectrumColor,
+                maxAbsDragGain = EqLimits.PARAMETRIC_MAX_BAND_DB,
                 onBandDragged = { id, f, g -> viewModel.updateBandByDrag(id, f, g) }
             )
         }
@@ -286,7 +287,7 @@ fun ParametricEqEditScreen(
                 ValueSlider(
                     label = "Gain",
                     value = selectedBand.gain,
-                    valueRange = -24f..24f,
+                    valueRange = -EqLimits.PARAMETRIC_MAX_BAND_DB..EqLimits.PARAMETRIC_MAX_BAND_DB,
                     display = "%+.1f dB".format(selectedBand.gain),
                     onChange = { viewModel.updateBand(selectedBand.copy(gain = it)) }
                 )
@@ -344,8 +345,11 @@ fun ParametricEqEditScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    if (saveName.isNotBlank()) {
-                        viewModel.saveAsPreset(saveName.trim(), saveDescription.trim())
+                    // Trim before the blank check — "   " should not reach the repository
+                    // as an empty name.
+                    val trimmedName = saveName.trim()
+                    if (trimmedName.isNotEmpty()) {
+                        viewModel.saveAsPreset(trimmedName, saveDescription.trim())
                         showSaveDialog = false
                     }
                 }) { Text("Save") }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -247,15 +247,20 @@ fun ParametricEqScreen(
                                     preset.name,
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
-                                    color = if (isActive) MaterialTheme.colorScheme.primary
-                                    else MaterialTheme.colorScheme.onSurface,
+                                    color = when {
+                                        preset.isCorrupted -> MaterialTheme.colorScheme.error
+                                        isActive -> MaterialTheme.colorScheme.primary
+                                        else -> MaterialTheme.colorScheme.onSurface
+                                    },
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis
                                 )
                                 Text(
-                                    "${preset.bands.size} bands",
+                                    if (preset.isCorrupted) "Corrupted — cannot load"
+                                    else "${preset.bands.size} bands",
                                     style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    color = if (preset.isCorrupted) MaterialTheme.colorScheme.error
+                                    else MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
                             IconButton(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -121,7 +121,8 @@ fun ParametricEqScreen(
                         eqBands = currentBands,
                         preamp = currentPreamp,
                         centerOnZero = true,
-                        showLegend = false
+                        showLegend = false,
+                        maxAbsDragGain = EqLimits.PARAMETRIC_MAX_BAND_DB,
                     )
                 }
             }
@@ -223,6 +224,7 @@ fun ParametricEqScreen(
                         EqProfileMiniGraph(
                             bands = preset.bands,
                             preamp = preset.preamp,
+                            gainRange = EqLimits.PARAMETRIC_MAX_BAND_DB,
                             modifier = Modifier.fillMaxWidth().padding(2.dp)
                         )
                         Row(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -104,8 +104,11 @@ class ParametricEqViewModel @Inject constructor(
     fun updateBandByDrag(bandId: Int, newFreq: Float, newGain: Float) {
         val updated = _currentBands.value.map { b ->
             if (b.id == bandId) b.copy(
-                freq = newFreq.coerceIn(20f, 20000f),
-                gain = newGain.coerceIn(-24f, 24f)
+                freq = newFreq.coerceIn(EqLimits.MIN_FREQ_HZ, EqLimits.MAX_FREQ_HZ),
+                gain = newGain.coerceIn(
+                    -EqLimits.PARAMETRIC_MAX_BAND_DB,
+                    EqLimits.PARAMETRIC_MAX_BAND_DB
+                )
             ) else b
         }
         _currentBands.value = updated

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -176,6 +176,10 @@ class ParametricEqViewModel @Inject constructor(
     fun loadPreset(presetId: String) {
         viewModelScope.launch {
             val preset = repository.getPresetById(presetId) ?: return@launch
+            if (preset.isCorrupted) {
+                _error.value = "Preset \"${preset.name}\" is corrupted and can't be loaded."
+                return@launch
+            }
             _activePreset.value = preset
             _currentBands.value = preset.bands
             _currentPreamp.value = preset.preamp

--- a/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
@@ -1,11 +1,14 @@
 package tf.monochrome.android.ui.main
 
 import android.content.Intent
+import android.graphics.Color as AndroidColor
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import android.view.ViewGroup
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import eightbitlab.com.blurview.BlurTarget
 import androidx.activity.enableEdgeToEdge
@@ -16,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -25,8 +29,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.auth.SupabaseAuthManager
 import tf.monochrome.android.data.preferences.PreferencesManager
+import tf.monochrome.android.player.QueueManager
 import tf.monochrome.android.ui.navigation.MonochromeNavHost
 import tf.monochrome.android.ui.theme.MonochromeTheme
+import tf.monochrome.android.ui.theme.rememberDynamicPalette
 import java.io.File
 import javax.inject.Inject
 import tf.monochrome.android.audio.eq.FrequencyTargets
@@ -38,6 +44,7 @@ class MainActivity : ComponentActivity() {
 
     @Inject lateinit var preferences: PreferencesManager
     @Inject lateinit var supabaseAuthManager: SupabaseAuthManager
+    @Inject lateinit var queueManager: QueueManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -77,6 +84,12 @@ class MainActivity : ComponentActivity() {
             val themeName by preferences.theme.collectAsState(initial = "monochrome_dark")
             val fontScale by preferences.fontScale.collectAsState(initial = 1.0f)
             val customFontPath by preferences.customFontUri.collectAsState(initial = null)
+            val dynamicColorsEnabled by preferences.dynamicColors.collectAsState(initial = false)
+            val currentTrack by queueManager.currentTrack.collectAsState()
+            val dynamicPalette by rememberDynamicPalette(
+                coverUrl = currentTrack?.coverUrl,
+                enabled = dynamicColorsEnabled
+            )
 
             val customFontFamily = remember(customFontPath) {
                 customFontPath?.let { path ->
@@ -99,8 +112,27 @@ class MainActivity : ComponentActivity() {
                 MonochromeTheme(
                     themeName = themeName,
                     fontScale = fontScale,
-                    customFontFamily = customFontFamily
+                    customFontFamily = customFontFamily,
+                    dynamicPalette = dynamicPalette
                 ) {
+                    // Re-apply edge-to-edge with a SystemBarStyle tuned to
+                    // the current theme. Light themes need dark icons so
+                    // they stay legible on white system bars; dark themes
+                    // want light icons on transparent scrims. enableEdgeToEdge
+                    // is idempotent — safe to call on every background change.
+                    val background = MaterialTheme.colorScheme.background
+                    SideEffect {
+                        val isLight = background.luminance() > 0.5f
+                        val style = if (isLight) {
+                            SystemBarStyle.light(AndroidColor.TRANSPARENT, AndroidColor.TRANSPARENT)
+                        } else {
+                            SystemBarStyle.dark(AndroidColor.TRANSPARENT)
+                        }
+                        this@MainActivity.enableEdgeToEdge(
+                            statusBarStyle = style,
+                            navigationBarStyle = style
+                        )
+                    }
                     Surface(
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/BinauralEditor.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/BinauralEditor.kt
@@ -34,17 +34,32 @@ import tf.monochrome.android.audio.dsp.model.PluginInstance
 import tf.monochrome.android.ui.theme.MonoDimens
 
 // ── Binaural-specific colors ───────────────────────────────────────────────
-private object BinauralColors {
-    val bg = Color(0xFF0F1419)
-    val headerBg = Color(0xFF1A1F2B)
-    val surfaceAlt = Color(0xFF16212E)
-    val divider = Color(0xFF2A3548)
-    val textPrimary = Color(0xFFE8EAED)
-    val textSecondary = Color(0xFF8A92A6)
-    val accentCyan = Color(0xFF00D4D4)
-    val accentPurple = Color(0xFFB084CC)
-    val switchEnabled = Color(0xFF00D4D4)
-    val switchDisabled = Color(0xFF4A5568)
+// Neutrals resolve from MaterialTheme so the sheet works on light themes too;
+// the cyan/purple accents are deliberate plugin branding and stay fixed.
+private data class BinauralPalette(
+    val bg: Color,
+    val headerBg: Color,
+    val surfaceAlt: Color,
+    val divider: Color,
+    val textPrimary: Color,
+    val textSecondary: Color,
+    val accentCyan: Color = Color(0xFF00D4D4),
+    val accentPurple: Color = Color(0xFFB084CC),
+    val switchEnabled: Color = Color(0xFF00D4D4),
+    val switchDisabled: Color = Color(0xFF4A5568)
+)
+
+@Composable
+private fun rememberBinauralPalette(): BinauralPalette {
+    val cs = androidx.compose.material3.MaterialTheme.colorScheme
+    return BinauralPalette(
+        bg = cs.surface,
+        headerBg = cs.surfaceVariant,
+        surfaceAlt = cs.surfaceContainerHigh,
+        divider = cs.outlineVariant,
+        textPrimary = cs.onSurface,
+        textSecondary = cs.onSurfaceVariant
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,6 +71,7 @@ fun BinauralEditorSheet(
     onParameterChange: (busIndex: Int, slotIndex: Int, paramIndex: Int, value: Float) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val palette = rememberBinauralPalette()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     // Extract parameter values
@@ -71,7 +87,7 @@ fun BinauralEditorSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
-        containerColor = BinauralColors.bg
+        containerColor = palette.bg
     ) {
         Column(
             modifier = Modifier
@@ -82,7 +98,7 @@ fun BinauralEditorSheet(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(BinauralColors.headerBg)
+                    .background(palette.headerBg)
                     .padding(horizontal = 20.dp, vertical = 16.dp)
             ) {
                 Column {
@@ -90,13 +106,13 @@ fun BinauralEditorSheet(
                         text = "Binaural / Spatial DSP",
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold,
-                        color = BinauralColors.accentCyan,
+                        color = palette.accentCyan,
                         letterSpacing = 1.sp
                     )
                     Text(
                         text = "Multichannel HRTF rendering for Atmos & 3D Audio, crossfeed for stereo",
                         fontSize = 11.sp,
-                        color = BinauralColors.textSecondary,
+                        color = palette.textSecondary,
                         modifier = Modifier.padding(top = 4.dp)
                     )
                 }
@@ -109,14 +125,14 @@ fun BinauralEditorSheet(
                 Text(
                     text = "Mode: Stereo",
                     fontSize = 12.sp,
-                    color = BinauralColors.textSecondary,
+                    color = palette.textSecondary,
                     fontWeight = FontWeight.Medium
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = "Select output format for spatial processing",
                     fontSize = 10.sp,
-                    color = BinauralColors.textSecondary.copy(alpha = 0.7f)
+                    color = palette.textSecondary.copy(alpha = 0.7f)
                 )
             }
 
@@ -134,13 +150,13 @@ fun BinauralEditorSheet(
                     Text(
                         text = "Auto-enable for Spatial Audio",
                         fontSize = 13.sp,
-                        color = BinauralColors.textPrimary,
+                        color = palette.textPrimary,
                         fontWeight = FontWeight.Medium
                     )
                     Text(
                         text = "Automatically activate when Atmos or 3D content is detected",
                         fontSize = 10.sp,
-                        color = BinauralColors.textSecondary,
+                        color = palette.textSecondary,
                         modifier = Modifier.padding(top = 2.dp)
                     )
                 }
@@ -153,10 +169,10 @@ fun BinauralEditorSheet(
                         onParameterChange(busIndex, slotIndex, 0, if (newValue) 1f else 0f)
                     },
                     colors = SwitchDefaults.colors(
-                        checkedThumbColor = BinauralColors.switchEnabled,
-                        checkedTrackColor = BinauralColors.switchEnabled.copy(alpha = 0.3f),
-                        uncheckedThumbColor = BinauralColors.switchDisabled,
-                        uncheckedTrackColor = BinauralColors.switchDisabled.copy(alpha = 0.3f)
+                        checkedThumbColor = palette.switchEnabled,
+                        checkedTrackColor = palette.switchEnabled.copy(alpha = 0.3f),
+                        uncheckedThumbColor = palette.switchDisabled,
+                        uncheckedTrackColor = palette.switchDisabled.copy(alpha = 0.3f)
                     )
                 )
             }
@@ -168,7 +184,7 @@ fun BinauralEditorSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(1.dp)
-                    .background(BinauralColors.divider)
+                    .background(palette.divider)
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -185,13 +201,13 @@ fun BinauralEditorSheet(
                     Text(
                         text = "Crossfeed",
                         fontSize = 13.sp,
-                        color = BinauralColors.textPrimary,
+                        color = palette.textPrimary,
                         fontWeight = FontWeight.Medium
                     )
                     Text(
                         text = "Simulate speaker presentation on headphones",
                         fontSize = 10.sp,
-                        color = BinauralColors.textSecondary,
+                        color = palette.textSecondary,
                         modifier = Modifier.padding(top = 2.dp)
                     )
                 }
@@ -203,10 +219,10 @@ fun BinauralEditorSheet(
                         onParameterChange(busIndex, slotIndex, 1, if (newValue) 1f else 0f)
                     },
                     colors = SwitchDefaults.colors(
-                        checkedThumbColor = BinauralColors.switchEnabled,
-                        checkedTrackColor = BinauralColors.switchEnabled.copy(alpha = 0.3f),
-                        uncheckedThumbColor = BinauralColors.switchDisabled,
-                        uncheckedTrackColor = BinauralColors.switchDisabled.copy(alpha = 0.3f)
+                        checkedThumbColor = palette.switchEnabled,
+                        checkedTrackColor = palette.switchEnabled.copy(alpha = 0.3f),
+                        uncheckedThumbColor = palette.switchDisabled,
+                        uncheckedTrackColor = palette.switchDisabled.copy(alpha = 0.3f)
                     )
                 )
             }
@@ -224,12 +240,12 @@ fun BinauralEditorSheet(
                         Text(
                             text = "Crossfeed Level",
                             fontSize = 12.sp,
-                            color = BinauralColors.textSecondary
+                            color = palette.textSecondary
                         )
                         Text(
                             text = "${crossfeedLevel.toInt()}%",
                             fontSize = 12.sp,
-                            color = BinauralColors.accentCyan,
+                            color = palette.accentCyan,
                             fontWeight = FontWeight.Bold
                         )
                     }
@@ -239,7 +255,7 @@ fun BinauralEditorSheet(
                         onValueChange = { onParameterChange(busIndex, slotIndex, 2, it) },
                         min = 0f,
                         max = 100f,
-                        color = BinauralColors.accentCyan
+                        color = palette.accentCyan
                     )
                 }
             }
@@ -251,7 +267,7 @@ fun BinauralEditorSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(1.dp)
-                    .background(BinauralColors.divider)
+                    .background(palette.divider)
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -261,14 +277,14 @@ fun BinauralEditorSheet(
                 Text(
                     text = "HRTF Preset",
                     fontSize = 12.sp,
-                    color = BinauralColors.textSecondary,
+                    color = palette.textSecondary,
                     fontWeight = FontWeight.Medium
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = "Virtual speaker angle for multichannel rendering",
                     fontSize = 10.sp,
-                    color = BinauralColors.textSecondary.copy(alpha = 0.7f)
+                    color = palette.textSecondary.copy(alpha = 0.7f)
                 )
 
                 Spacer(modifier = Modifier.height(10.dp))
@@ -298,7 +314,7 @@ fun BinauralEditorSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(1.dp)
-                    .background(BinauralColors.divider)
+                    .background(palette.divider)
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -315,13 +331,13 @@ fun BinauralEditorSheet(
                     Text(
                         text = "Stereo Width",
                         fontSize = 13.sp,
-                        color = BinauralColors.textPrimary,
+                        color = palette.textPrimary,
                         fontWeight = FontWeight.Medium
                     )
                     Text(
                         text = "Adjust spatial width (0 = mono, 1 = neutral, 2 = wide)",
                         fontSize = 10.sp,
-                        color = BinauralColors.textSecondary,
+                        color = palette.textSecondary,
                         modifier = Modifier.padding(top = 2.dp)
                     )
                 }
@@ -333,10 +349,10 @@ fun BinauralEditorSheet(
                         onParameterChange(busIndex, slotIndex, 4, if (newValue) 1f else 0f)
                     },
                     colors = SwitchDefaults.colors(
-                        checkedThumbColor = BinauralColors.accentPurple,
-                        checkedTrackColor = BinauralColors.accentPurple.copy(alpha = 0.3f),
-                        uncheckedThumbColor = BinauralColors.switchDisabled,
-                        uncheckedTrackColor = BinauralColors.switchDisabled.copy(alpha = 0.3f)
+                        checkedThumbColor = palette.accentPurple,
+                        checkedTrackColor = palette.accentPurple.copy(alpha = 0.3f),
+                        uncheckedThumbColor = palette.switchDisabled,
+                        uncheckedTrackColor = palette.switchDisabled.copy(alpha = 0.3f)
                     )
                 )
             }
@@ -352,12 +368,12 @@ fun BinauralEditorSheet(
                         Text(
                             text = "Width Amount",
                             fontSize = 12.sp,
-                            color = BinauralColors.textSecondary
+                            color = palette.textSecondary
                         )
                         Text(
                             text = "%.2f".format(widthAmount),
                             fontSize = 12.sp,
-                            color = BinauralColors.accentPurple,
+                            color = palette.accentPurple,
                             fontWeight = FontWeight.Bold
                         )
                     }
@@ -367,7 +383,7 @@ fun BinauralEditorSheet(
                         onValueChange = { onParameterChange(busIndex, slotIndex, 5, it) },
                         min = 0f,
                         max = 2f,
-                        color = BinauralColors.accentPurple
+                        color = palette.accentPurple
                     )
                 }
             }
@@ -384,12 +400,13 @@ private fun PresetButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val palette = rememberBinauralPalette()
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .background(
-                if (isSelected) BinauralColors.accentCyan.copy(alpha = 0.25f)
-                else BinauralColors.surfaceAlt
+                if (isSelected) palette.accentCyan.copy(alpha = 0.25f)
+                else palette.surfaceAlt
             )
             .padding(vertical = 8.dp, horizontal = 6.dp),
         contentAlignment = Alignment.Center
@@ -398,7 +415,7 @@ private fun PresetButton(
             text = label,
             fontSize = 10.sp,
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
-            color = if (isSelected) BinauralColors.accentCyan else BinauralColors.textSecondary
+            color = if (isSelected) palette.accentCyan else palette.textSecondary
         )
     }
 }
@@ -412,6 +429,7 @@ private fun HorizontalSlider(
     color: Color,
     modifier: Modifier = Modifier
 ) {
+    val palette = rememberBinauralPalette()
     val fraction = (value - min) / (max - min)
 
     Box(
@@ -419,7 +437,7 @@ private fun HorizontalSlider(
             .fillMaxWidth()
             .height(4.dp)
             .clip(RoundedCornerShape(2.dp))
-            .background(BinauralColors.divider)
+            .background(palette.divider)
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/BusStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/BusStrip.kt
@@ -185,7 +185,7 @@ private fun LevelMeter(
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(3.dp))
-            .background(Color(0xFF1A1A1A)),
+            .background(MaterialTheme.colorScheme.surfaceContainer),
         horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
     ) {
         MeterBar(fraction = fracL, clipping = clipL, modifier = Modifier.weight(1f).fillMaxHeight())
@@ -206,7 +206,7 @@ private fun MeterBar(
                 .fillMaxWidth()
                 .fillMaxHeight()
                 .clip(RoundedCornerShape(2.dp))
-                .background(Color(0xFF2A2A2A))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
         )
         // Filled level (grows from bottom)
         Box(

--- a/app/src/main/java/tf/monochrome/android/ui/theme/Color.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/theme/Color.kt
@@ -126,17 +126,32 @@ val MintCard = Color(0xFF1E3328)
 val MintOutline = Color(0xFF284736)
 
 // White Theme
+// True light theme — dark text on light surfaces. All secondary/tertiary
+// tokens must pair with dark `on*` colors; reusing the dark-theme
+// MonoTextSecondary/MonoTextTertiary with white `on*` is a WCAG violation.
 val WhitePrimary = Color(0xFF000000)
 val WhiteBackground = Color(0xFFFFFFFF)
 val WhiteSurface = Color(0xFFF5F5F5)
 val WhiteSurfaceVariant = Color(0xFFEBEBEB)
 val WhiteCard = Color(0xFFFAFAFA)
 val WhiteOutline = Color(0xFFE0E0E0)
+// Light-theme accents: desaturated slate primary, charcoal secondary,
+// near-black tertiary — all contrast ≥4.5:1 against WhiteOnSecondary.
+val WhiteSecondary = Color(0xFF424242)       // charcoal
+val WhiteTertiary = Color(0xFF1F1F1F)        // near-black
+val WhiteOnSecondary = Color(0xFFFFFFFF)     // white text on charcoal
+val WhiteOnSurfaceVariant = Color(0xFF4A4A4A) // readable secondary text on #EBEBEB
 
 // Clear Theme
+// Clear is intentionally translucent so surfaces let the background (album
+// art, visualizer, etc.) bleed through. ClearSurface used to be fully
+// transparent (0x00000000) which made Material cards invisible — any
+// composable painting onto colorScheme.surface would render nothing.
+// 0x40000000 keeps the smoky look while guaranteeing ≥25% opacity so
+// surface bounds stay legible against bright backdrops.
 val ClearPrimary = Color(0xFFFFFFFF)
 val ClearBackground = Color(0xFF000000)
-val ClearSurface = Color(0x00000000)
+val ClearSurface = Color(0x40000000)
 val ClearSurfaceVariant = Color(0x15FFFFFF)
 val ClearCard = Color(0x0AFFFFFF)
 val ClearOutline = Color(0x22FFFFFF)

--- a/app/src/main/java/tf/monochrome/android/ui/theme/DynamicColorExtractor.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/theme/DynamicColorExtractor.kt
@@ -1,0 +1,111 @@
+package tf.monochrome.android.ui.theme
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.palette.graphics.Palette
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import coil3.toBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Colors extracted from album art. Overrides a subset of the active color
+ * scheme when the user has dynamic colors enabled — we intentionally only
+ * touch primary/secondary slots so the rest of the chosen theme's hierarchy
+ * (backgrounds, text-on-surface, outlines) stays intact.
+ */
+data class DynamicPalette(
+    val primary: Color,
+    val onPrimary: Color,
+    val primaryContainer: Color,
+    val secondary: Color,
+    val onSecondary: Color
+)
+
+/**
+ * Extracts a [DynamicPalette] from a cover image URL off the main thread.
+ *
+ * Results are memoized in a small in-memory map so repeated renders of the
+ * same track don't re-run Palette. The cache is intentionally unbounded but
+ * process-scoped; the dataset is small (one entry per distinct cover in a
+ * session) and the app restart clears it.
+ */
+object DynamicColorExtractor {
+
+    private val cache = mutableMapOf<String, DynamicPalette>()
+
+    suspend fun extract(context: Context, coverUrl: String?): DynamicPalette? {
+        if (coverUrl.isNullOrBlank()) return null
+        cache[coverUrl]?.let { return it }
+
+        val bitmap = loadBitmap(context, coverUrl) ?: return null
+        val palette = withContext(Dispatchers.Default) {
+            Palette.from(bitmap).maximumColorCount(24).generate()
+        }
+
+        // Prefer vibrant variants for the primary accent; fall back through
+        // dominant/muted so a mostly-monochrome cover still produces something.
+        val primarySwatch = palette.vibrantSwatch
+            ?: palette.lightVibrantSwatch
+            ?: palette.darkVibrantSwatch
+            ?: palette.dominantSwatch
+            ?: return null
+
+        val secondarySwatch = palette.mutedSwatch
+            ?: palette.darkMutedSwatch
+            ?: palette.lightMutedSwatch
+            ?: primarySwatch
+
+        val dp = DynamicPalette(
+            primary = Color(primarySwatch.rgb),
+            onPrimary = Color(primarySwatch.bodyTextColor),
+            primaryContainer = Color(primarySwatch.rgb).copy(alpha = 0.18f),
+            secondary = Color(secondarySwatch.rgb),
+            onSecondary = Color(secondarySwatch.bodyTextColor)
+        )
+        cache[coverUrl] = dp
+        return dp
+    }
+
+    private suspend fun loadBitmap(context: Context, url: String): Bitmap? {
+        return try {
+            val loader = ImageLoader(context)
+            val request = ImageRequest.Builder(context)
+                .data(url)
+                // Palette needs pixel-readable (software) bitmaps.
+                .allowHardware(false)
+                .build()
+            val result = loader.execute(request)
+            if (result is SuccessResult) {
+                result.image.toBitmap()
+            } else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+
+/**
+ * Composable helper: returns the dynamic palette for the given cover URL,
+ * or null while loading / when extraction fails / when disabled.
+ */
+@Composable
+fun rememberDynamicPalette(coverUrl: String?, enabled: Boolean): State<DynamicPalette?> {
+    val context = LocalContext.current
+    val state = remember { mutableStateOf<DynamicPalette?>(null) }
+    LaunchedEffect(coverUrl, enabled) {
+        state.value = if (!enabled) null
+        else DynamicColorExtractor.extract(context, coverUrl)
+    }
+    return state
+}

--- a/app/src/main/java/tf/monochrome/android/ui/theme/Theme.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/theme/Theme.kt
@@ -381,17 +381,22 @@ val MintDarkScheme = darkColorScheme(
     onError = MonoBlack
 )
 
+// True light theme. Secondary/tertiary use charcoal/near-black so their
+// onSecondary/onTertiary = white stays at ≥7:1 contrast (previously these
+// paired white text on light-gray MonoTextSecondary/Tertiary, which failed
+// WCAG and rendered as ghost text). onSurfaceVariant is a darker gray so
+// secondary labels on WhiteSurfaceVariant (#EBEBEB) stay readable.
 val WhiteScheme = androidx.compose.material3.lightColorScheme(
     primary = WhitePrimary,
     onPrimary = MonoWhite,
     primaryContainer = WhiteSurfaceVariant,
     onPrimaryContainer = MonoBlack,
-    secondary = MonoTextSecondary,
-    onSecondary = MonoWhite,
+    secondary = WhiteSecondary,
+    onSecondary = WhiteOnSecondary,
     secondaryContainer = WhiteCard,
     onSecondaryContainer = MonoBlack,
-    tertiary = MonoTextTertiary,
-    onTertiary = MonoWhite,
+    tertiary = WhiteTertiary,
+    onTertiary = WhiteOnSecondary,
     tertiaryContainer = WhiteCard,
     onTertiaryContainer = MonoBlack,
     background = WhiteBackground,
@@ -399,7 +404,7 @@ val WhiteScheme = androidx.compose.material3.lightColorScheme(
     surface = WhiteSurface,
     onSurface = MonoBlack,
     surfaceVariant = WhiteSurfaceVariant,
-    onSurfaceVariant = MonoTextSecondary,
+    onSurfaceVariant = WhiteOnSurfaceVariant,
     outline = WhiteOutline,
     outlineVariant = WhiteSurfaceVariant,
     error = ErrorRed,
@@ -432,6 +437,7 @@ val ClearDarkScheme = darkColorScheme(
 )
 /** Display names for theme selection UI */
 val themeDisplayNames = mapOf(
+    "system" to "System",
     "monochrome_dark" to "Monochrome",
     "ocean" to "Ocean",
     "midnight" to "Midnight",
@@ -476,9 +482,27 @@ fun MonochromeTheme(
     themeName: String = "monochrome_dark",
     fontScale: Float = 1.0f,
     customFontFamily: FontFamily? = null,
+    dynamicPalette: DynamicPalette? = null,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = getColorScheme(themeName)
+    // "system" follows the OS dark-mode toggle — light mode gets the
+    // rebuilt WhiteScheme, dark mode gets the default Monochrome scheme.
+    val resolvedTheme = if (themeName == "system") {
+        if (androidx.compose.foundation.isSystemInDarkTheme()) "monochrome_dark" else "white"
+    } else themeName
+    val baseScheme = getColorScheme(resolvedTheme)
+    // Overlay album-art-derived colors on the selected theme. We only swap
+    // primary/secondary slots so backgrounds, text-on-surface, and outlines
+    // remain coherent with the user's chosen theme.
+    val colorScheme = if (dynamicPalette != null) {
+        baseScheme.copy(
+            primary = dynamicPalette.primary,
+            onPrimary = dynamicPalette.onPrimary,
+            primaryContainer = dynamicPalette.primaryContainer,
+            secondary = dynamicPalette.secondary,
+            onSecondary = dynamicPalette.onSecondary
+        )
+    } else baseScheme
     val family = customFontFamily ?: InterFontFamily
     val typography = remember(fontScale, family) {
         buildTypography(family, fontScale)

--- a/app/src/main/java/tf/monochrome/android/ui/theme/Theme.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/theme/Theme.kt
@@ -1,9 +1,14 @@
 package tf.monochrome.android.ui.theme
 
+import android.os.Build
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 
 val MonochromeDarkScheme = darkColorScheme(
@@ -477,6 +482,18 @@ fun getColorScheme(themeName: String) = when (themeName) {
     else -> MonochromeDarkScheme
 }
 
+/**
+ * Material You wallpaper-derived scheme. Only available on Android 12 (S) and
+ * above — returns null on older OS versions so callers can fall back to a
+ * built-in theme.
+ */
+@Composable
+fun rememberMaterialYouScheme(dark: Boolean): ColorScheme? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return null
+    val context = LocalContext.current
+    return if (dark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+}
+
 @Composable
 fun MonochromeTheme(
     themeName: String = "monochrome_dark",
@@ -485,12 +502,16 @@ fun MonochromeTheme(
     dynamicPalette: DynamicPalette? = null,
     content: @Composable () -> Unit
 ) {
+    val systemDark = androidx.compose.foundation.isSystemInDarkTheme()
     // "system" follows the OS dark-mode toggle — light mode gets the
     // rebuilt WhiteScheme, dark mode gets the default Monochrome scheme.
     val resolvedTheme = if (themeName == "system") {
-        if (androidx.compose.foundation.isSystemInDarkTheme()) "monochrome_dark" else "white"
+        if (systemDark) "monochrome_dark" else "white"
     } else themeName
-    val baseScheme = getColorScheme(resolvedTheme)
+    val materialYou = if (resolvedTheme == "material_you") {
+        rememberMaterialYouScheme(dark = systemDark)
+    } else null
+    val baseScheme = materialYou ?: getColorScheme(resolvedTheme)
     // Overlay album-art-derived colors on the selected theme. We only swap
     // primary/secondary slots so backgrounds, text-on-surface, and outlines
     // remain coherent with the user's chosen theme.


### PR DESCRIPTION
Kotlin-side: DspEngineManager now clamps bus gain (-60..+12 dB), pan
(-1..+1), and plugin dry/wet (0..1) before both the JNI call and the
StateFlow update, keeping UI state and native state in sync. Non-finite
plugin parameters are rejected so they never reach the real-time path.
JSON restore sanitizes the same fields.

Native: setBusGain gains a clamp (previously only pan clamped), both
setters filter NaN/Inf, loadStateJson routes through the sanitized
setters, and setDryWet filters NaN.

Biquad EQ: ParametricEqProcessor and AutoEqProcessor now fall back to
passthrough coefficients when na0 is ~0 or any computed coefficient is
non-finite, preventing NaN audio on pathological f/Q combinations.