### PR TITLE
Fix spectrum analyzer going blank after Settings preview

### DIFF
--- a/app/src/main/java/tf/monochrome/android/audio/eq/SpectrumAnalyzerTap.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/SpectrumAnalyzerTap.kt
@@ -99,6 +99,14 @@ class SpectrumAnalyzerTap @Inject constructor() : AudioProcessor {
         if (enabled == analysisActive) return
         analysisActive = enabled
         if (enabled) {
+            // Restart from a coherent state: a prior disable can leave `ring`
+            // frozen mid-write (queueInput skips writes while inactive) and
+            // `_analysisDirty` false, so the restarted coroutine would trust
+            // stale work arrays against a stale ring. Force reallocation and
+            // refill so the first FFT reads only post-re-enable audio.
+            _analysisDirty = true
+            ringWrite = 0
+            java.util.Arrays.fill(ring, 0f)
             startAnalysis()
         } else {
             analysisJob?.cancel()


### PR DESCRIPTION
The Settings > Interface preview and Now Playing each own a DisposableEffect pair around SpectrumAnalyzerTap.setAnalysisActive. Disable froze `ring` and `ringWrite` mid-write (queueInput skips writes when inactive) and left `_analysisDirty=false`, so the next enable restarted the coroutine against stale work arrays and a stale ring buffer. The overlay then read the zeroed `_spectrumBins` that disable left behind and rendered flat bars.

Force `_analysisDirty=true`, zero the ring, and reset `ringWrite` on re-enable so the restarted coroutine reallocates FFT work arrays to the current fftSize and the first FFT reads only post-re-enable audio.