### PR TITLE
fix(local): unfreeze local artist detail page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Init submodules with retry
+        shell: bash
+        run: |
+          attempts=0
+          max_attempts=5
+          until git submodule update --init --recursive --jobs 4; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::Submodule init failed after $max_attempts attempts"
+              exit 1
+            fi
+            delay=$((5 * attempts))
+            echo "::warning::Submodule init failed (attempt $attempts/$max_attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/gradlew.yml
+++ b/.github/workflows/gradlew.yml
@@ -23,7 +23,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Init submodules with retry
+        shell: bash
+        run: |
+          attempts=0
+          max_attempts=5
+          until git submodule update --init --recursive --jobs 4; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::Submodule init failed after $max_attempts attempts"
+              exit 1
+            fi
+            delay=$((5 * attempts))
+            echo "::warning::Submodule init failed (attempt $attempts/$max_attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -61,7 +77,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Init submodules with retry
+        shell: bash
+        run: |
+          attempts=0
+          max_attempts=5
+          until git submodule update --init --recursive --jobs 4; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::Submodule init failed after $max_attempts attempts"
+              exit 1
+            fi
+            delay=$((5 * attempts))
+            echo "::warning::Submodule init failed (attempt $attempts/$max_attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -100,7 +132,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Init submodules with retry
+        shell: bash
+        run: |
+          attempts=0
+          max_attempts=5
+          until git submodule update --init --recursive --jobs 4; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::Submodule init failed after $max_attempts attempts"
+              exit 1
+            fi
+            delay=$((5 * attempts))
+            echo "::warning::Submodule init failed (attempt $attempts/$max_attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Init submodules with retry
+        shell: bash
+        run: |
+          attempts=0
+          max_attempts=5
+          until git submodule update --init --recursive --jobs 4; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::Submodule init failed after $max_attempts attempts"
+              exit 1
+            fi
+            delay=$((5 * attempts))
+            echo "::warning::Submodule init failed (attempt $attempts/$max_attempts); retrying in ${delay}s..."
+            sleep "$delay"
+          done
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
+++ b/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
@@ -3,6 +3,13 @@ package tf.monochrome.android
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.request.crossfade
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +22,7 @@ import tf.monochrome.android.data.device.DeviceRegistry
 import javax.inject.Inject
 
 @HiltAndroidApp
-class MonochromeApp : Application(), Configuration.Provider {
+class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoader.Factory {
 
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
@@ -31,6 +38,27 @@ class MonochromeApp : Application(), Configuration.Provider {
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
+            .build()
+
+    /**
+     * Single ImageLoader for the whole app. Without this, every Coil call site
+     * spins up a default loader and the in-memory + on-disk caches don't survive
+     * navigation, so identical artwork gets re-decoded on every screen change.
+     */
+    override fun newImageLoader(context: PlatformContext): ImageLoader =
+        ImageLoader.Builder(context)
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, 0.25)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(250L * 1024 * 1024)
+                    .build()
+            }
+            .crossfade(true)
             .build()
 
     override fun onCreate() {

--- a/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
@@ -63,10 +63,14 @@ class InstanceManager @Inject constructor(
     private var cacheTimestamp: Long = 0L
 
     suspend fun getInstances(type: InstanceType): List<Instance> {
-        // Check custom endpoint first
-        val customEndpoint = preferences.customApiEndpoint.first()
-        if (customEndpoint != null) {
-            return listOf(Instance(customEndpoint.trimEnd('/')))
+        // Dev Mode: route all requests through the user-specified custom endpoint.
+        // When disabled, ignore any saved URL and fall through to the normal
+        // instance resolution so stale overrides don't silently redirect traffic.
+        if (preferences.devModeEnabled.first()) {
+            val customEndpoint = preferences.customApiEndpoint.first()
+            if (customEndpoint != null) {
+                return listOf(Instance(customEndpoint.trimEnd('/')))
+            }
         }
 
         // Check memory cache

--- a/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
@@ -53,6 +53,12 @@ interface LocalMediaDao {
     @Update
     suspend fun updateTrack(track: LocalTrackEntity)
 
+    @Update
+    suspend fun updateTracks(tracks: List<LocalTrackEntity>)
+
+    @Query("SELECT * FROM local_tracks")
+    suspend fun getAllTracksSnapshot(): List<LocalTrackEntity>
+
     @Query("DELETE FROM local_tracks WHERE filePath = :path")
     suspend fun deleteTrackByPath(path: String)
 

--- a/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.data.local.scanner
 
+import androidx.room.withTransaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -28,7 +29,8 @@ sealed class ScanProgress {
 class MediaScanner @Inject constructor(
     private val mediaStoreSource: MediaStoreSource,
     private val tagReader: TagReader,
-    private val localMediaDao: LocalMediaDao
+    private val localMediaDao: LocalMediaDao,
+    private val musicDatabase: tf.monochrome.android.data.db.MusicDatabase
 ) {
 
     fun fullScan(
@@ -40,12 +42,15 @@ class MediaScanner @Inject constructor(
             emit(ScanProgress.Started(totalFiles = mediaStoreFiles.size))
 
             var addedCount = 0
+            // Memoize sidecar cover art lookups by parent directory so we don't
+            // listFiles() once per track. A 500-track album → 1 directory scan.
+            val folderArtCache = HashMap<String, String?>()
 
             mediaStoreFiles.forEachIndexed { index, audioFile ->
                 try {
                     val existing = localMediaDao.findByPath(audioFile.absolutePath)
                     if (existing == null || existing.lastModified < audioFile.dateModified) {
-                        val tags = tagReader.readTags(audioFile.absolutePath)
+                        val tags = tagReader.readTags(audioFile.absolutePath, folderArtCache)
                         val trackEntity = buildTrackEntity(audioFile, tags)
                         localMediaDao.insertTrack(trackEntity)
                         addedCount++
@@ -105,10 +110,11 @@ class MediaScanner @Inject constructor(
 
             emit(ScanProgress.Started(totalFiles = modifiedFiles.size))
             var addedCount = 0
+            val folderArtCache = HashMap<String, String?>()
 
             modifiedFiles.forEachIndexed { index, audioFile ->
                 try {
-                    val tags = tagReader.readTags(audioFile.absolutePath)
+                    val tags = tagReader.readTags(audioFile.absolutePath, folderArtCache)
                     val trackEntity = buildTrackEntity(audioFile, tags)
                     localMediaDao.insertTrack(trackEntity)
                     addedCount++
@@ -166,26 +172,15 @@ class MediaScanner @Inject constructor(
     }
 
     private suspend fun rebuildGroupings() {
-        // Build albums
-        localMediaDao.clearAllAlbums()
-        localMediaDao.clearAllArtists()
-        localMediaDao.clearAllGenres()
+        // Pull every track in one query (was: getAllTrackPaths() then per-path
+        // findByPath, i.e. N+1 round-trips for an N-track library).
+        val tracks = localMediaDao.getAllTracksSnapshot()
 
-        // Get all tracks to build groupings
-        // Use a snapshot query instead of Flow for scanning
-        val allPaths = localMediaDao.getAllTrackPaths()
-        val tracksByAlbumKey = mutableMapOf<String, MutableList<LocalTrackEntity>>()
-        val artistSet = mutableMapOf<String, MutableList<LocalTrackEntity>>()
-        val genreSet = mutableMapOf<String, Int>()
-
-        // Process tracks from the database
-        val tracks = mutableListOf<LocalTrackEntity>()
-        for (path in allPaths) {
-            localMediaDao.findByPath(path)?.let { tracks.add(it) }
-        }
-
+        // In-memory grouping — pure CPU work, no DB calls.
+        val tracksByAlbumKey = HashMap<String, MutableList<LocalTrackEntity>>()
+        val artistSet = HashMap<String, MutableList<LocalTrackEntity>>()
+        val genreSet = HashMap<String, Int>()
         for (track in tracks) {
-            // Album grouping
             val albumKey = buildAlbumGroupingKey(
                 track.album,
                 track.albumArtist ?: track.artist,
@@ -193,71 +188,72 @@ class MediaScanner @Inject constructor(
             )
             tracksByAlbumKey.getOrPut(albumKey) { mutableListOf() }.add(track)
 
-            // Artist grouping
             val artistName = track.albumArtist ?: track.artist ?: "Unknown Artist"
             val normalizedArtist = normalizeText(artistName)
             artistSet.getOrPut(normalizedArtist) { mutableListOf() }.add(track)
 
-            // Genre grouping
             track.genre?.let { genre ->
                 genreSet[genre] = (genreSet[genre] ?: 0) + 1
             }
         }
 
-        // Insert albums and remember which albumId each track belongs to.
-        // We defer writing track FKs until after artists are upserted so a
-        // single updateTrack() call persists both IDs — otherwise the artist
-        // loop's track.copy() would carry the pre-update (null) albumId and
-        // clobber what the album loop just wrote.
-        val albumIdByTrackPath = HashMap<String, Long>(tracks.size)
-        for ((key, albumTracks) in tracksByAlbumKey) {
-            val representative = albumTracks.first()
-            val albumEntity = LocalAlbumEntity(
-                title = representative.album ?: "Unknown Album",
-                artist = representative.albumArtist ?: representative.artist ?: "Unknown Artist",
-                year = representative.year,
-                genre = representative.genre,
-                trackCount = albumTracks.size,
-                totalDuration = albumTracks.sumOf { it.durationSeconds },
-                artworkCacheKey = albumTracks.firstOrNull { it.hasEmbeddedArt }?.artworkCacheKey,
-                bestQuality = albumTracks.maxByOrNull { qualityScore(it) }?.let {
-                    "${it.codec} ${it.bitDepth ?: ""}/${(it.sampleRate / 1000)}"
-                },
-                groupingKey = key
-            )
-            val albumId = localMediaDao.upsertAlbum(albumEntity)
-            for (track in albumTracks) albumIdByTrackPath[track.filePath] = albumId
-        }
+        // Wrap every DB write in a single transaction so Room flushes once and
+        // observers (LocalLibraryViewModel's StateFlows) only get one
+        // invalidation pass.
+        musicDatabase.withTransaction {
+            localMediaDao.clearAllAlbums()
+            localMediaDao.clearAllArtists()
+            localMediaDao.clearAllGenres()
 
-        // Insert artists and remember which artistId each track belongs to.
-        val artistIdByTrackPath = HashMap<String, Long>(tracks.size)
-        for ((normalizedName, artistTracks) in artistSet) {
-            val displayName = artistTracks.first().let { it.albumArtist ?: it.artist ?: "Unknown Artist" }
-            val uniqueAlbums = artistTracks.mapNotNull { it.album }.toSet().size
-            val artistEntity = LocalArtistEntity(
-                name = displayName,
-                normalizedName = normalizedName,
-                albumCount = uniqueAlbums,
-                trackCount = artistTracks.size,
-                artworkCacheKey = artistTracks.firstOrNull { it.hasEmbeddedArt }?.artworkCacheKey
-            )
-            val artistId = localMediaDao.upsertArtist(artistEntity)
-            for (track in artistTracks) artistIdByTrackPath[track.filePath] = artistId
-        }
-
-        // Single pass to write both FKs per track.
-        for (track in tracks) {
-            localMediaDao.updateTrack(
-                track.copy(
-                    albumId = albumIdByTrackPath[track.filePath],
-                    artistId = artistIdByTrackPath[track.filePath]
+            val albumIdByTrackPath = HashMap<String, Long>(tracks.size)
+            for ((key, albumTracks) in tracksByAlbumKey) {
+                val representative = albumTracks.first()
+                val albumEntity = LocalAlbumEntity(
+                    title = representative.album ?: "Unknown Album",
+                    artist = representative.albumArtist ?: representative.artist ?: "Unknown Artist",
+                    year = representative.year,
+                    genre = representative.genre,
+                    trackCount = albumTracks.size,
+                    totalDuration = albumTracks.sumOf { it.durationSeconds },
+                    artworkCacheKey = albumTracks.firstOrNull { it.hasEmbeddedArt }?.artworkCacheKey,
+                    bestQuality = albumTracks.maxByOrNull { qualityScore(it) }?.let {
+                        "${it.codec} ${it.bitDepth ?: ""}/${(it.sampleRate / 1000)}"
+                    },
+                    groupingKey = key
                 )
-            )
-        }
+                val albumId = localMediaDao.upsertAlbum(albumEntity)
+                for (track in albumTracks) albumIdByTrackPath[track.filePath] = albumId
+            }
 
-        // Insert genres
-        for ((genre, count) in genreSet) {
-            localMediaDao.upsertGenre(LocalGenreEntity(name = genre, trackCount = count))
+            val artistIdByTrackPath = HashMap<String, Long>(tracks.size)
+            for ((normalizedName, artistTracks) in artistSet) {
+                val displayName = artistTracks.first().let { it.albumArtist ?: it.artist ?: "Unknown Artist" }
+                val uniqueAlbums = artistTracks.mapNotNull { it.album }.toSet().size
+                val artistEntity = LocalArtistEntity(
+                    name = displayName,
+                    normalizedName = normalizedName,
+                    albumCount = uniqueAlbums,
+                    trackCount = artistTracks.size,
+                    artworkCacheKey = artistTracks.firstOrNull { it.hasEmbeddedArt }?.artworkCacheKey
+                )
+                val artistId = localMediaDao.upsertArtist(artistEntity)
+                for (track in artistTracks) artistIdByTrackPath[track.filePath] = artistId
+            }
+
+            // Bulk-update every track in one statement (was: N updateTrack calls).
+            val updatedTracks = tracks.map { t ->
+                t.copy(
+                    albumId = albumIdByTrackPath[t.filePath],
+                    artistId = artistIdByTrackPath[t.filePath]
+                )
+            }
+            if (updatedTracks.isNotEmpty()) {
+                localMediaDao.updateTracks(updatedTracks)
+            }
+
+            for ((genre, count) in genreSet) {
+                localMediaDao.upsertGenre(LocalGenreEntity(name = genre, trackCount = count))
+            }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
@@ -204,7 +204,12 @@ class MediaScanner @Inject constructor(
             }
         }
 
-        // Insert albums and update track references
+        // Insert albums and remember which albumId each track belongs to.
+        // We defer writing track FKs until after artists are upserted so a
+        // single updateTrack() call persists both IDs — otherwise the artist
+        // loop's track.copy() would carry the pre-update (null) albumId and
+        // clobber what the album loop just wrote.
+        val albumIdByTrackPath = HashMap<String, Long>(tracks.size)
         for ((key, albumTracks) in tracksByAlbumKey) {
             val representative = albumTracks.first()
             val albumEntity = LocalAlbumEntity(
@@ -221,14 +226,11 @@ class MediaScanner @Inject constructor(
                 groupingKey = key
             )
             val albumId = localMediaDao.upsertAlbum(albumEntity)
-
-            // Update track albumId references
-            for (track in albumTracks) {
-                localMediaDao.updateTrack(track.copy(albumId = albumId))
-            }
+            for (track in albumTracks) albumIdByTrackPath[track.filePath] = albumId
         }
 
-        // Insert artists and update track references
+        // Insert artists and remember which artistId each track belongs to.
+        val artistIdByTrackPath = HashMap<String, Long>(tracks.size)
         for ((normalizedName, artistTracks) in artistSet) {
             val displayName = artistTracks.first().let { it.albumArtist ?: it.artist ?: "Unknown Artist" }
             val uniqueAlbums = artistTracks.mapNotNull { it.album }.toSet().size
@@ -240,10 +242,17 @@ class MediaScanner @Inject constructor(
                 artworkCacheKey = artistTracks.firstOrNull { it.hasEmbeddedArt }?.artworkCacheKey
             )
             val artistId = localMediaDao.upsertArtist(artistEntity)
+            for (track in artistTracks) artistIdByTrackPath[track.filePath] = artistId
+        }
 
-            for (track in artistTracks) {
-                localMediaDao.updateTrack(track.copy(artistId = artistId))
-            }
+        // Single pass to write both FKs per track.
+        for (track in tracks) {
+            localMediaDao.updateTrack(
+                track.copy(
+                    albumId = albumIdByTrackPath[track.filePath],
+                    artistId = artistIdByTrackPath[track.filePath]
+                )
+            )
         }
 
         // Insert genres

--- a/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
@@ -61,14 +61,17 @@ class TagReader @Inject constructor(
         File(context.cacheDir, "artwork").also { it.mkdirs() }
     }
 
-    suspend fun readTags(filePath: String): AudioTags {
+    suspend fun readTags(
+        filePath: String,
+        folderArtCache: MutableMap<String, String?>? = null
+    ): AudioTags {
         val file = File(filePath)
         if (!file.exists()) return AudioTags(filePath = filePath)
 
         val retriever = MediaMetadataRetriever()
         return try {
             retriever.setDataSource(filePath)
-            extractTags(retriever, file)
+            extractTags(retriever, file, folderArtCache)
         } catch (e: Exception) {
             AudioTags(
                 filePath = filePath,
@@ -93,12 +96,17 @@ class TagReader @Inject constructor(
         }
     }
 
-    private fun extractTags(retriever: MediaMetadataRetriever, file: File): AudioTags {
+    private fun extractTags(
+        retriever: MediaMetadataRetriever,
+        file: File,
+        folderArtCache: MutableMap<String, String?>? = null
+    ): AudioTags {
         return extractTagsFromRetriever(
             retriever,
             file.absolutePath,
             file.length(),
-            file.lastModified()
+            file.lastModified(),
+            folderArtCache
         )
     }
 
@@ -107,7 +115,8 @@ class TagReader @Inject constructor(
         retriever: MediaMetadataRetriever,
         filePath: String,
         fileSize: Long,
-        lastModified: Long
+        lastModified: Long,
+        folderArtCache: MutableMap<String, String?>? = null
     ): AudioTags {
         val title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
         val artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
@@ -140,7 +149,7 @@ class TagReader @Inject constructor(
         val hasArt = artworkBytes != null
         val artworkCacheKey = when {
             hasArt && artworkBytes != null -> cacheArtwork(artworkBytes, filePath)
-            else -> findFolderCoverArt(filePath)
+            else -> findFolderCoverArt(filePath, folderArtCache)
         }
         val hasArtOrSidecar = artworkCacheKey != null
 
@@ -236,10 +245,24 @@ class TagReader @Inject constructor(
      * returns the file's absolute path (Coil will load it directly). Returns null
      * when `filePath` isn't a real filesystem path (e.g. a content:// URI) or the
      * folder has no recognisable image.
+     *
+     * Pass a [cache] keyed by parent directory to avoid re-listing the same folder
+     * for every track in an album.
      */
-    private fun findFolderCoverArt(filePath: String): String? {
+    private fun findFolderCoverArt(
+        filePath: String,
+        cache: MutableMap<String, String?>? = null
+    ): String? {
         val parent = File(filePath).parentFile ?: return null
         if (!parent.isDirectory) return null
+        val parentKey = parent.absolutePath
+        cache?.let { if (it.containsKey(parentKey)) return it[parentKey] }
+        val resolved = scanFolderCoverArt(parent)
+        cache?.put(parentKey, resolved)
+        return resolved
+    }
+
+    private fun scanFolderCoverArt(parent: File): String? {
         val files = parent.listFiles() ?: return null
         val candidates = files.filter { f ->
             if (!f.isFile) return@filter false

--- a/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
@@ -182,13 +182,20 @@ class TagReader @Inject constructor(
     }
 
     private fun detectCodec(mimeType: String?, filePath: String): AudioCodec {
+        // Opus and Vorbis share the Ogg container, so MediaMetadataRetriever often
+        // reports both as "audio/ogg". Check explicit codec MIMEs first, then fall
+        // back to the file extension for generic "audio/ogg".
         return when {
             mimeType?.contains("flac") == true -> AudioCodec.FLAC
             mimeType?.contains("mpeg") == true -> AudioCodec.MP3
             mimeType?.contains("mp4a") == true || mimeType?.contains("aac") == true ||
                 mimeType?.contains("mp4") == true -> AudioCodec.AAC
-            mimeType?.contains("ogg") == true || mimeType?.contains("vorbis") == true -> AudioCodec.OGG_VORBIS
             mimeType?.contains("opus") == true -> AudioCodec.OPUS
+            mimeType?.contains("vorbis") == true -> AudioCodec.OGG_VORBIS
+            mimeType?.contains("ogg") == true -> {
+                val fromExt = detectCodecFromExtension(filePath)
+                if (fromExt == AudioCodec.OPUS) AudioCodec.OPUS else AudioCodec.OGG_VORBIS
+            }
             mimeType?.contains("wav") == true || mimeType?.contains("wave") == true -> AudioCodec.WAV
             mimeType?.contains("aiff") == true -> AudioCodec.AIFF
             mimeType?.contains("x-ms-wma") == true -> AudioCodec.WMA

--- a/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
@@ -132,12 +132,17 @@ class TagReader @Inject constructor(
         // Determine codec
         val codec = detectCodec(mimeType, filePath)
 
-        // Extract and cache artwork
+        // Extract and cache artwork. For MP4/M4A this reads the `covr` atom;
+        // for FLAC/Vorbis/Opus this reads the METADATA_BLOCK_PICTURE/coverart;
+        // for ID3v2 this reads APIC. If nothing is embedded, fall back to a
+        // sidecar image in the track's folder (cover.jpg, folder.jpg, etc.).
         val artworkBytes = retriever.embeddedPicture
         val hasArt = artworkBytes != null
-        val artworkCacheKey = if (hasArt && artworkBytes != null) {
-            cacheArtwork(artworkBytes, filePath)
-        } else null
+        val artworkCacheKey = when {
+            hasArt && artworkBytes != null -> cacheArtwork(artworkBytes, filePath)
+            else -> findFolderCoverArt(filePath)
+        }
+        val hasArtOrSidecar = artworkCacheKey != null
 
         return AudioTags(
             title = title,
@@ -157,7 +162,7 @@ class TagReader @Inject constructor(
             bitRate = (bitRateStr?.toLongOrNull() ?: 0L).let { (it / 1000).toInt() },
             channels = numChannels?.toIntOrNull() ?: 2,
             durationSeconds = (durationMs / 1000).toInt(),
-            hasEmbeddedArt = hasArt,
+            hasEmbeddedArt = hasArtOrSidecar,
             artworkCacheKey = artworkCacheKey,
             filePath = filePath,
             fileSizeBytes = fileSize,
@@ -183,13 +188,18 @@ class TagReader @Inject constructor(
 
     private fun detectCodec(mimeType: String?, filePath: String): AudioCodec {
         // Opus and Vorbis share the Ogg container, so MediaMetadataRetriever often
-        // reports both as "audio/ogg". Check explicit codec MIMEs first, then fall
-        // back to the file extension for generic "audio/ogg".
+        // reports both as "audio/ogg". ALAC and AAC share the MP4 container, so
+        // both report as "audio/mp4" on some Android versions. Check explicit
+        // codec MIMEs first, then fall back to the file extension.
         return when {
             mimeType?.contains("flac") == true -> AudioCodec.FLAC
             mimeType?.contains("mpeg") == true -> AudioCodec.MP3
+            mimeType?.contains("alac") == true -> AudioCodec.ALAC
             mimeType?.contains("mp4a") == true || mimeType?.contains("aac") == true ||
-                mimeType?.contains("mp4") == true -> AudioCodec.AAC
+                mimeType?.contains("mp4") == true -> {
+                val fromExt = detectCodecFromExtension(filePath)
+                if (fromExt == AudioCodec.ALAC) AudioCodec.ALAC else AudioCodec.AAC
+            }
             mimeType?.contains("opus") == true -> AudioCodec.OPUS
             mimeType?.contains("vorbis") == true -> AudioCodec.OGG_VORBIS
             mimeType?.contains("ogg") == true -> {
@@ -207,7 +217,8 @@ class TagReader @Inject constructor(
         return when (filePath.substringAfterLast('.').lowercase()) {
             "flac" -> AudioCodec.FLAC
             "mp3" -> AudioCodec.MP3
-            "m4a", "aac" -> AudioCodec.AAC
+            "alac" -> AudioCodec.ALAC
+            "m4a", "aac", "mp4" -> AudioCodec.AAC
             "ogg", "oga" -> AudioCodec.OGG_VORBIS
             "opus" -> AudioCodec.OPUS
             "wav" -> AudioCodec.WAV
@@ -216,6 +227,50 @@ class TagReader @Inject constructor(
             "wma" -> AudioCodec.WMA
             else -> AudioCodec.UNKNOWN
         }
+    }
+
+    /**
+     * Look for a sidecar cover art file in the track's folder. Matches the common
+     * naming conventions (cover.*, folder.*, album.*, front.*, AlbumArt*.jpg) case-
+     * insensitively, prefers larger images when multiple candidates exist, and
+     * returns the file's absolute path (Coil will load it directly). Returns null
+     * when `filePath` isn't a real filesystem path (e.g. a content:// URI) or the
+     * folder has no recognisable image.
+     */
+    private fun findFolderCoverArt(filePath: String): String? {
+        val parent = File(filePath).parentFile ?: return null
+        if (!parent.isDirectory) return null
+        val files = parent.listFiles() ?: return null
+        val candidates = files.filter { f ->
+            if (!f.isFile) return@filter false
+            val name = f.name.lowercase()
+            val ext = name.substringAfterLast('.', "")
+            if (ext !in IMAGE_EXTENSIONS) return@filter false
+            val stem = name.substringBeforeLast('.')
+            stem in COVER_STEMS || COVER_STEM_PREFIXES.any { stem.startsWith(it) }
+        }
+        if (candidates.isEmpty()) return null
+        // Prefer exact stem match over prefix match, then the largest file
+        // (Windows Media Player writes both AlbumArt.jpg and AlbumArtSmall.jpg).
+        return candidates
+            .sortedWith(
+                compareByDescending<File> { f ->
+                    val stem = f.name.lowercase().substringBeforeLast('.')
+                    if (stem in COVER_STEMS) 1 else 0
+                }.thenByDescending { it.length() }
+            )
+            .first()
+            .absolutePath
+    }
+
+    companion object {
+        private val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "webp")
+        private val COVER_STEMS = setOf(
+            "cover", "folder", "album", "albumart", "front", "artwork"
+        )
+        private val COVER_STEM_PREFIXES = setOf(
+            "albumart" // AlbumArt_{GUID}_Large.jpg (WMP)
+        )
     }
 
     private fun cacheArtwork(artworkBytes: ByteArray, filePath: String): String {

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -65,6 +65,7 @@ class PreferencesManager @Inject constructor(
 
         // Custom API endpoint
         private val CUSTOM_API_ENDPOINT = stringPreferencesKey("custom_api_endpoint")
+        private val DEV_MODE_ENABLED = booleanPreferencesKey("dev_mode_enabled")
 
         // Interface
         private val GAPLESS_PLAYBACK = booleanPreferencesKey("gapless_playback")
@@ -328,6 +329,14 @@ class PreferencesManager @Inject constructor(
                 it.remove(CUSTOM_API_ENDPOINT)
             }
         }
+    }
+
+    val devModeEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[DEV_MODE_ENABLED] ?: false
+    }
+
+    suspend fun setDevModeEnabled(enabled: Boolean) {
+        dataStore.edit { it[DEV_MODE_ENABLED] = enabled }
     }
 
     // --- Interface ---

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -146,6 +146,7 @@ class PreferencesManager @Inject constructor(
         private val MIN_TRACK_DURATION_MS = longPreferencesKey("min_track_duration_ms")
         private val EXCLUDED_PATHS_JSON = stringPreferencesKey("excluded_paths_json")
         private val BACKGROUND_SCAN_INTERVAL = stringPreferencesKey("background_scan_interval")
+        private val USER_FOLDER_ROOTS_JSON = stringPreferencesKey("user_folder_roots_json")
 
         // DSP Mixer
         private val DSP_ENABLED = booleanPreferencesKey("dsp_enabled")
@@ -735,6 +736,29 @@ class PreferencesManager @Inject constructor(
     val excludedPathsJson: Flow<String> = dataStore.data.map { it[EXCLUDED_PATHS_JSON] ?: "[]" }
     suspend fun setExcludedPaths(pathsJson: String) {
         dataStore.edit { it[EXCLUDED_PATHS_JSON] = pathsJson }
+    }
+
+    val userFolderRoots: Flow<Set<String>> = dataStore.data.map { prefs ->
+        val raw = prefs[USER_FOLDER_ROOTS_JSON] ?: return@map emptySet()
+        runCatching { json.decodeFromString<Set<String>>(raw) }.getOrDefault(emptySet())
+    }
+
+    suspend fun addUserFolderRoot(path: String) {
+        dataStore.edit { prefs ->
+            val current = prefs[USER_FOLDER_ROOTS_JSON]
+                ?.let { runCatching { json.decodeFromString<Set<String>>(it) }.getOrNull() }
+                ?: emptySet()
+            prefs[USER_FOLDER_ROOTS_JSON] = json.encodeToString(current + path)
+        }
+    }
+
+    suspend fun removeUserFolderRoot(path: String) {
+        dataStore.edit { prefs ->
+            val current = prefs[USER_FOLDER_ROOTS_JSON]
+                ?.let { runCatching { json.decodeFromString<Set<String>>(it) }.getOrNull() }
+                ?: return@edit
+            prefs[USER_FOLDER_ROOTS_JSON] = json.encodeToString(current - path)
+        }
     }
 
     val backgroundScanInterval: Flow<String> = dataStore.data.map {

--- a/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
@@ -42,29 +43,35 @@ fun Modifier.liquidGlass(
     val adaptedTintAlpha = if (isDark) (tintAlpha * 1.4f).coerceAtMost(0.50f) else tintAlpha
     val borderColor = MaterialTheme.colorScheme.outline
 
-    // Specular rim — thin gradient border simulating reflected light on glass edges
-    val luminousBorderBrush = Brush.linearGradient(
-        colors = listOf(
-            borderColor.copy(alpha = borderAlpha * 2f),
-            borderColor.copy(alpha = borderAlpha * 0.5f),
-            borderColor.copy(alpha = borderAlpha * 1.5f)
-        ),
-        start = Offset.Zero,
-        end = Offset.Infinite
-    )
-
-    // Refraction overlay — subtle gradient to enhance glass depth
-    val refractionBrush = if (showRefraction) {
-        val refractionColor = if (isDark) Color.White else Color.Black
+    // Specular rim — thin gradient border simulating reflected light on glass edges.
+    // Cache per-(theme, alpha) so we don't allocate a fresh Brush per recomposition,
+    // which is the dominant cost when this modifier is applied to LazyColumn rows.
+    val luminousBorderBrush = remember(borderColor, borderAlpha) {
         Brush.linearGradient(
             colors = listOf(
-                refractionColor.copy(alpha = 0.04f),
-                Color.Transparent,
-                refractionColor.copy(alpha = 0.02f)
+                borderColor.copy(alpha = borderAlpha * 2f),
+                borderColor.copy(alpha = borderAlpha * 0.5f),
+                borderColor.copy(alpha = borderAlpha * 1.5f)
             ),
             start = Offset.Zero,
             end = Offset.Infinite
         )
+    }
+
+    // Refraction overlay — subtle gradient to enhance glass depth
+    val refractionBrush = if (showRefraction) {
+        remember(isDark) {
+            val refractionColor = if (isDark) Color.White else Color.Black
+            Brush.linearGradient(
+                colors = listOf(
+                    refractionColor.copy(alpha = 0.04f),
+                    Color.Transparent,
+                    refractionColor.copy(alpha = 0.02f)
+                ),
+                start = Offset.Zero,
+                end = Offset.Infinite
+            )
+        }
     } else null
 
     var modifier = this

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalAlbumDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalAlbumDetailScreen.kt
@@ -47,7 +47,6 @@ import coil3.compose.AsyncImage
 import tf.monochrome.android.domain.model.UnifiedTrack
 import tf.monochrome.android.ui.components.ErrorScreen
 import tf.monochrome.android.ui.components.LoadingScreen
-import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.theme.MonoDimens
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -207,10 +206,9 @@ private fun LocalTrackRow(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs)
-            .liquidGlass(shape = MonoDimens.shapeMd),
+            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs),
         shape = MonoDimens.shapeMd,
-        color = androidx.compose.ui.graphics.Color.Transparent,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = MonoDimens.cardAlpha),
         onClick = onClick
     ) {
         Row(

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailScreen.kt
@@ -54,7 +54,6 @@ import tf.monochrome.android.domain.model.UnifiedAlbum
 import tf.monochrome.android.domain.model.UnifiedTrack
 import tf.monochrome.android.ui.components.ErrorScreen
 import tf.monochrome.android.ui.components.LoadingScreen
-import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.components.SectionHeader
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.navigation.Screen
@@ -289,10 +288,9 @@ private fun ArtistTrackRow(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs)
-            .liquidGlass(shape = MonoDimens.shapeMd),
+            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs),
         shape = MonoDimens.shapeMd,
-        color = androidx.compose.ui.graphics.Color.Transparent,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = MonoDimens.cardAlpha),
         onClick = onClick
     ) {
         Row(

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -74,6 +75,12 @@ fun LocalArtistDetailScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
 
+    val sortedTracks = remember(tracks) {
+        tracks.sortedWith(
+            compareBy({ it.albumTitle ?: "" }, { it.discNumber ?: 1 }, { it.trackNumber ?: 0 })
+        )
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = {},
@@ -87,14 +94,14 @@ fun LocalArtistDetailScreen(
             )
         )
 
+        val artistData = artist
         when {
             isLoading -> LoadingScreen()
             error != null -> ErrorScreen(
                 message = error ?: "Unknown error",
                 onRetry = { viewModel.retry() }
             )
-            artist != null -> {
-                val artistData = artist ?: return
+            artistData != null -> {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = 80.dp)
@@ -196,13 +203,9 @@ fun LocalArtistDetailScreen(
                     }
 
                     // All tracks
-                    if (tracks.isNotEmpty()) {
+                    if (sortedTracks.isNotEmpty()) {
                         item { SectionHeader(title = "All Tracks") }
-                        val sortedTracks = tracks.sortedWith(
-                            compareBy({ it.albumTitle ?: "" }, { it.discNumber ?: 1 }, { it.trackNumber ?: 0 })
-                        )
-                        items(sortedTracks.size) { index ->
-                            val track = sortedTracks[index]
+                        items(sortedTracks, key = { it.id }) { track ->
                             ArtistTrackRow(
                                 track = track,
                                 onClick = { onPlayTrack(track, sortedTracks) }
@@ -336,13 +339,14 @@ private fun ArtistTrackRow(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            if (track.qualityBadge != null) {
+            val badge = track.qualityBadge
+            if (badge != null) {
                 Surface(
                     shape = RoundedCornerShape(999.dp),
                     color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
                 ) {
                     Text(
-                        text = track.qualityBadge!!,
+                        text = badge,
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalArtistDetailViewModel.kt
@@ -4,10 +4,14 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.local.repository.LocalMediaRepository
@@ -16,6 +20,7 @@ import tf.monochrome.android.domain.model.UnifiedArtist
 import tf.monochrome.android.domain.model.UnifiedTrack
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class LocalArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -27,43 +32,51 @@ class LocalArtistDetailViewModel @Inject constructor(
     private val _artist = MutableStateFlow<UnifiedArtist?>(null)
     val artist: StateFlow<UnifiedArtist?> = _artist.asStateFlow()
 
-    private val _albums = MutableStateFlow<List<UnifiedAlbum>>(emptyList())
-    val albums: StateFlow<List<UnifiedAlbum>> = _albums.asStateFlow()
-
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
-    val tracks: StateFlow<List<UnifiedTrack>> = localMediaRepository.getTracksByArtist(artistId)
+    val albums: StateFlow<List<UnifiedAlbum>> = _artist
+        .flatMapLatest { a ->
+            if (a == null) flowOf(emptyList())
+            else localMediaRepository.getAlbumsByArtist(a.name)
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val tracks: StateFlow<List<UnifiedTrack>> =
+        localMediaRepository.getTracksByArtist(artistId)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     init {
         loadArtist()
     }
+
+    fun retry() = loadArtist()
 
     private fun loadArtist() {
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
             try {
-                val result = localMediaRepository.getArtistById(artistId)
-                if (result != null) {
-                    _artist.value = result
-                    // Load albums by this artist's name
-                    localMediaRepository.getAlbumsByArtist(result.name).collect { albumList ->
-                        _albums.value = albumList
-                    }
-                } else {
+                if (artistId <= 0L) {
                     _error.value = "Artist not found"
+                } else {
+                    val result = localMediaRepository.getArtistById(artistId)
+                    if (result == null) {
+                        _error.value = "Artist not found"
+                    } else {
+                        _artist.value = result
+                    }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _error.value = e.message ?: "Failed to load artist"
+            } finally {
+                _isLoading.value = false
             }
-            _isLoading.value = false
         }
     }
-
-    fun retry() = loadArtist()
 }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailScreen.kt
@@ -46,7 +46,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import tf.monochrome.android.domain.model.UnifiedTrack
-import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.theme.MonoDimens
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -169,10 +168,9 @@ private fun GenreTrackRow(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs)
-            .liquidGlass(shape = MonoDimens.shapeMd),
+            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs),
         shape = MonoDimens.shapeMd,
-        color = androidx.compose.ui.graphics.Color.Transparent,
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = MonoDimens.cardAlpha),
         onClick = onClick
     ) {
         Row(

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailScreen.kt
@@ -1,0 +1,244 @@
+package tf.monochrome.android.ui.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.Style
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import tf.monochrome.android.domain.model.UnifiedTrack
+import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.theme.MonoDimens
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocalGenreDetailScreen(
+    navController: NavController,
+    onPlayTrack: (UnifiedTrack, List<UnifiedTrack>) -> Unit,
+    onPlayAll: (List<UnifiedTrack>) -> Unit,
+    onShuffleAll: (List<UnifiedTrack>) -> Unit,
+    viewModel: LocalGenreDetailViewModel = hiltViewModel()
+) {
+    val tracks by viewModel.tracks.collectAsState()
+    val genreName = viewModel.genreName
+
+    val sortedTracks = remember(tracks) {
+        tracks.sortedWith(
+            compareBy({ it.artistName }, { it.albumTitle ?: "" }, { it.discNumber ?: 1 }, { it.trackNumber ?: 0 })
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {},
+            navigationIcon = {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.background
+            )
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 80.dp)
+        ) {
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(160.dp)
+                            .clip(CircleShape),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            Icons.Default.Style,
+                            contentDescription = null,
+                            modifier = Modifier.size(80.dp),
+                            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = genreName.ifBlank { "Unknown Genre" },
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = "${sortedTracks.size} tracks",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        FilledIconButton(
+                            onClick = { if (sortedTracks.isNotEmpty()) onPlayAll(sortedTracks) },
+                            modifier = Modifier.size(48.dp),
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary
+                            )
+                        ) {
+                            Icon(
+                                Icons.Default.PlayArrow,
+                                contentDescription = "Play All",
+                                tint = MaterialTheme.colorScheme.onPrimary
+                            )
+                        }
+                        FilledIconButton(
+                            onClick = { if (sortedTracks.isNotEmpty()) onShuffleAll(sortedTracks) },
+                            modifier = Modifier.size(48.dp),
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant
+                            )
+                        ) {
+                            Icon(
+                                Icons.Default.Shuffle,
+                                contentDescription = "Shuffle",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (sortedTracks.isNotEmpty()) {
+                items(sortedTracks, key = { it.id }) { track ->
+                    GenreTrackRow(
+                        track = track,
+                        onClick = { onPlayTrack(track, sortedTracks) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenreTrackRow(
+    track: UnifiedTrack,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs)
+            .liquidGlass(shape = MonoDimens.shapeMd),
+        shape = MonoDimens.shapeMd,
+        color = androidx.compose.ui.graphics.Color.Transparent,
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingSm),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (track.artworkUri != null) {
+                AsyncImage(
+                    model = track.artworkUri,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(MonoDimens.shapeSm)
+                )
+            } else {
+                Box(
+                    modifier = Modifier.size(48.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.MusicNote,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(MonoDimens.spacingMd))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = track.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = track.artistName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            val badge = track.qualityBadge
+            if (badge != null) {
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                ) {
+                    Text(
+                        text = badge,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(
+                text = track.formattedDuration,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailViewModel.kt
@@ -1,0 +1,30 @@
+package tf.monochrome.android.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import tf.monochrome.android.data.local.repository.LocalMediaRepository
+import tf.monochrome.android.domain.model.UnifiedTrack
+import java.net.URLDecoder
+import javax.inject.Inject
+
+@HiltViewModel
+class LocalGenreDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    localMediaRepository: LocalMediaRepository
+) : ViewModel() {
+
+    val genreName: String = savedStateHandle.get<String>("genre")
+        ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
+        .orEmpty()
+
+    val tracks: StateFlow<List<UnifiedTrack>> =
+        if (genreName.isBlank()) MutableStateFlow(emptyList())
+        else localMediaRepository.getTracksByGenre(genreName)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+}

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,7 +82,7 @@ fun LibraryScreen(
     )
     val tabs = libraryTabOrder.mapNotNull { id -> tabDisplayNames[id]?.let { id to it } }
 
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
 
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -239,6 +239,9 @@ fun LibraryScreen(
                             navController.navigate("local_artist/$artistId")
                         }
                     },
+                    onGenreClick = { genre ->
+                        navController.navigate(Screen.LocalGenreDetail.createRoute(genre))
+                    },
                     onFolderClick = { path ->
                         navController.navigate("folder/${java.net.URLEncoder.encode(path, "UTF-8")}")
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -244,6 +244,9 @@ fun LibraryScreen(
                     },
                     onFolderClick = { path ->
                         navController.navigate("folder/${java.net.URLEncoder.encode(path, "UTF-8")}")
+                    },
+                    onShuffleAll = { tracks ->
+                        playerViewModel.shufflePlayUnified(tracks)
                     }
                 )
 

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.Style
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -85,7 +86,8 @@ fun LocalLibraryTab(
     onAlbumClick: (UnifiedAlbum) -> Unit,
     onArtistClick: (UnifiedArtist) -> Unit,
     onGenreClick: (String) -> Unit,
-    onFolderClick: (String) -> Unit
+    onFolderClick: (String) -> Unit,
+    onShuffleAll: (List<UnifiedTrack>) -> Unit
 ) {
     val localTracks by viewModel.localTracks.collectAsState()
     val localAlbums by viewModel.localAlbums.collectAsState()
@@ -195,6 +197,12 @@ fun LocalLibraryTab(
             }
             IconButton(onClick = { showSearch = !showSearch; if (!showSearch) viewModel.setSearchQuery("") }) {
                 Icon(Icons.Default.Search, contentDescription = "Search")
+            }
+            IconButton(
+                onClick = { if (localTracks.isNotEmpty()) onShuffleAll(localTracks) },
+                enabled = localTracks.isNotEmpty()
+            ) {
+                Icon(Icons.Default.Shuffle, contentDescription = "Shuffle all")
             }
             IconButton(onClick = { folderPickerLauncher.launch(null) }) {
                 Icon(Icons.Default.CreateNewFolder, contentDescription = "Add folder")

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.DocumentsContract
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -83,13 +84,14 @@ fun LocalLibraryTab(
     onTrackClick: (UnifiedTrack, List<UnifiedTrack>) -> Unit,
     onAlbumClick: (UnifiedAlbum) -> Unit,
     onArtistClick: (UnifiedArtist) -> Unit,
+    onGenreClick: (String) -> Unit,
     onFolderClick: (String) -> Unit
 ) {
     val localTracks by viewModel.localTracks.collectAsState()
     val localAlbums by viewModel.localAlbums.collectAsState()
     val localArtists by viewModel.localArtists.collectAsState()
     val localGenres by viewModel.localGenres.collectAsState()
-    val rootFolders by viewModel.rootFolders.collectAsState()
+    val rootFolders by viewModel.displayRootFolders.collectAsState()
     val scanProgress by viewModel.scanProgress.collectAsState()
     val isScanning by viewModel.isScanning.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
@@ -117,6 +119,9 @@ fun LocalLibraryTab(
             // Take persistent read permission so we can access this folder across restarts
             val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
             context.contentResolver.takePersistableUriPermission(uri, flags)
+            // Persist the selected folder so it shows up in the Folders tab even
+            // before MediaStore re-indexes and the scanner derives it from tracks.
+            safTreeUriToPath(uri)?.let { viewModel.addUserFolderRoot(it) }
             // Trigger a full scan after adding a folder (MediaStore will include it)
             viewModel.startFullScan()
         }
@@ -212,10 +217,10 @@ fun LocalLibraryTab(
             2 -> SongList(tracks = localTracks, onTrackClick = onTrackClick)
             3 -> GenreList(
                 genres = localGenres.map { it.name to it.trackCount },
-                onGenreClick = { /* navigate to genre detail */ }
+                onGenreClick = onGenreClick
             )
             4 -> FolderList(
-                folders = rootFolders.map { it.displayName to it.path },
+                folders = rootFolders,
                 onFolderClick = onFolderClick
             )
         }
@@ -567,6 +572,24 @@ fun GenreList(
         }
     }
 }
+
+/**
+ * Resolve a SAF tree URI (from `OpenDocumentTree`) to a best-guess filesystem path.
+ * Handles "primary" (emulated) storage plus SD-card volume IDs. Returns null if the
+ * URI isn't a recognized tree document — callers should fall back gracefully.
+ */
+private fun safTreeUriToPath(uri: Uri): String? = runCatching {
+    val docId = DocumentsContract.getTreeDocumentId(uri)
+    val parts = docId.split(":", limit = 2)
+    if (parts.size != 2) return@runCatching null
+    val (type, path) = parts
+    val base = if (type.equals("primary", ignoreCase = true)) {
+        "/storage/emulated/0"
+    } else {
+        "/storage/$type"
+    }
+    if (path.isBlank()) base else "$base/$path".trimEnd('/')
+}.getOrNull()
 
 @Composable
 fun FolderList(

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -99,7 +100,7 @@ fun LocalLibraryTab(
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
 
-    var selectedSubTab by remember { mutableIntStateOf(0) }
+    var selectedSubTab by rememberSaveable { mutableIntStateOf(0) }
     val subTabs = listOf("Albums", "Artists", "Songs", "Genres", "Folders")
     var showSearch by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -219,12 +219,15 @@ fun LocalLibraryTab(
             }
         }
 
+        val genrePairs = remember(localGenres) {
+            localGenres.map { it.name to it.trackCount }
+        }
         when (selectedSubTab) {
             0 -> AlbumGrid(albums = localAlbums, onAlbumClick = onAlbumClick)
             1 -> ArtistList(artists = localArtists, onArtistClick = onArtistClick)
             2 -> SongList(tracks = localTracks, onTrackClick = onTrackClick)
             3 -> GenreList(
-                genres = localGenres.map { it.name to it.trackCount },
+                genres = genrePairs,
                 onGenreClick = onGenreClick
             )
             4 -> FolderList(
@@ -551,7 +554,7 @@ fun GenreList(
     LazyColumn(
         contentPadding = PaddingValues(bottom = MonoDimens.listBottomPadding)
     ) {
-        items(genres) { (genre, count) ->
+        items(genres, key = { it.first }) { (genre, count) ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -607,7 +610,7 @@ fun FolderList(
     LazyColumn(
         contentPadding = PaddingValues(bottom = MonoDimens.listBottomPadding)
     ) {
-        items(folders) { (name, path) ->
+        items(folders, key = { it.second }) { (name, path) ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -20,6 +21,7 @@ import tf.monochrome.android.data.local.db.LocalFolderEntity
 import tf.monochrome.android.data.local.db.LocalGenreEntity
 import tf.monochrome.android.data.local.repository.LocalMediaRepository
 import tf.monochrome.android.data.local.scanner.ScanProgress
+import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.domain.model.UnifiedAlbum
 import tf.monochrome.android.domain.model.UnifiedArtist
 import tf.monochrome.android.domain.model.UnifiedTrack
@@ -34,7 +36,8 @@ class LocalLibraryViewModel @Inject constructor(
     private val collectionRepository: CollectionRepository,
     private val scanLocalMediaUseCase: ScanLocalMediaUseCase,
     private val importCollectionUseCase: ImportCollectionUseCase,
-    private val backupManager: BackupManager
+    private val backupManager: BackupManager,
+    private val preferencesManager: PreferencesManager
 ) : ViewModel() {
 
     // ── Local media ─────────────────────────────────────────────────
@@ -53,6 +56,28 @@ class LocalLibraryViewModel @Inject constructor(
 
     val rootFolders: StateFlow<List<LocalFolderEntity>> = localMediaRepository.getRootFolders()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** User-added folder roots merged with scanner-derived folders. User roots come first. */
+    val displayRootFolders: StateFlow<List<Pair<String, String>>> = combine(
+        localMediaRepository.getRootFolders(),
+        preferencesManager.userFolderRoots
+    ) { dbFolders, userPaths ->
+        val user = userPaths.map { path ->
+            val name = path.substringAfterLast('/').ifBlank { path }
+            name to path
+        }
+        val db = dbFolders
+            .filter { it.path !in userPaths }
+            .map { it.displayName to it.path }
+        user + db
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun addUserFolderRoot(path: String) {
+        if (path.isBlank()) return
+        viewModelScope.launch {
+            preferencesManager.addUserFolderRoot(path)
+        }
+    }
 
     // ── Search ────────────────────────────────────────────────────────
 

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -59,6 +59,7 @@ import tf.monochrome.android.ui.detail.AlbumDetailScreen
 import tf.monochrome.android.ui.detail.ArtistDetailScreen
 import tf.monochrome.android.ui.detail.LocalAlbumDetailScreen
 import tf.monochrome.android.ui.detail.LocalArtistDetailScreen
+import tf.monochrome.android.ui.detail.LocalGenreDetailScreen
 import tf.monochrome.android.ui.detail.MixScreen
 import tf.monochrome.android.ui.eq.EqualizerScreen
 import tf.monochrome.android.ui.eq.ParametricEqEditScreen
@@ -115,6 +116,9 @@ sealed class Screen(val route: String) {
     }
     data object LocalArtistDetail : Screen("local_artist/{artistId}") {
         fun createRoute(artistId: Long) = "local_artist/$artistId"
+    }
+    data object LocalGenreDetail : Screen("local_genre/{genre}") {
+        fun createRoute(genre: String) = "local_genre/${java.net.URLEncoder.encode(genre, "UTF-8")}"
     }
     data object Mixer : Screen("mixer")
     data object CarMode : Screen("car_mode")
@@ -348,6 +352,23 @@ fun MonochromeNavHost() {
                     arguments = listOf(navArgument("artistId") { type = NavType.LongType })
                 ) {
                     LocalArtistDetailScreen(
+                        navController = navController,
+                        onPlayTrack = { track, queue ->
+                            playerViewModel.playUnifiedTrack(track, queue)
+                        },
+                        onPlayAll = { tracks ->
+                            playerViewModel.playAllUnified(tracks)
+                        },
+                        onShuffleAll = { tracks ->
+                            playerViewModel.shufflePlayUnified(tracks)
+                        }
+                    )
+                }
+                composable(
+                    route = Screen.LocalGenreDetail.route,
+                    arguments = listOf(navArgument("genre") { type = NavType.StringType })
+                ) {
+                    LocalGenreDetailScreen(
                         navController = navController,
                         onPlayTrack = { track, queue ->
                             playerViewModel.playUnifiedTrack(track, queue)

--- a/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableIntStateOf
@@ -392,6 +393,11 @@ private fun TouchWaveformOverlay(
     modifier: Modifier = Modifier
 ) {
     val touchPoints = remember { mutableStateMapOf<Long, Offset>() }
+
+    DisposableEffect(audioBus) {
+        audioBus.acquire()
+        onDispose { audioBus.release() }
+    }
 
     Canvas(
         modifier = modifier

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -1077,6 +1078,11 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
                 )
             }
             Spacer(modifier = Modifier.width(12.dp))
+            // Snapshot the latest input/saved value into stable holders so the
+            // onFocusChanged closure captured by the OutlinedTextField doesn't
+            // need to re-allocate on every keystroke recomposition.
+            val latestInput = rememberUpdatedState(customInput)
+            val latestSaved = rememberUpdatedState(customEndpoint)
             OutlinedTextField(
                 value = customInput,
                 onValueChange = { customInput = it },
@@ -1090,14 +1096,14 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
                 enabled = devModeEnabled,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = {
-                    viewModel.setCustomEndpoint(customInput.trim().ifBlank { null })
+                    viewModel.setCustomEndpoint(latestInput.value.trim().ifBlank { null })
                 }),
                 modifier = Modifier
                     .widthIn(max = 240.dp)
                     .onFocusChanged { focusState ->
                         if (!focusState.isFocused) {
-                            val trimmed = customInput.trim().ifBlank { null }
-                            if (trimmed != customEndpoint) {
+                            val trimmed = latestInput.value.trim().ifBlank { null }
+                            if (trimmed != latestSaved.value) {
                                 viewModel.setCustomEndpoint(trimmed)
                             }
                         }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1043,10 +1043,20 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
     val apiInstances by viewModel.apiInstances.collectAsState()
     val streamingInstances by viewModel.streamingInstances.collectAsState()
     val customEndpoint by viewModel.customEndpoint.collectAsState()
+    val devModeEnabled by viewModel.devModeEnabled.collectAsState()
     val refreshing by viewModel.instancesRefreshing.collectAsState()
     var customInput by remember(customEndpoint) { mutableStateOf(customEndpoint ?: "") }
 
     SettingsTabContent {
+        SettingSwitchItem(
+            title = "Dev Mode",
+            subtitle = "Route all API requests through a local Tidal HiFi API server. Requires a compatible server running at the specified URL.",
+            checked = devModeEnabled,
+            onCheckedChange = { viewModel.setDevModeEnabled(it) }
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
         SettingsGroupHeader("Custom Endpoint")
         OutlinedTextField(
             value = customInput,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -3,7 +3,9 @@ package tf.monochrome.android.ui.settings
 import android.content.Intent
 import androidx.core.net.toUri
 import java.util.Locale
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -17,11 +19,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -1055,29 +1060,49 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
             onCheckedChange = { viewModel.setDevModeEnabled(it) }
         )
 
-        Spacer(modifier = Modifier.height(20.dp))
-
-        SettingsGroupHeader("Custom Endpoint")
-        OutlinedTextField(
-            value = customInput,
-            onValueChange = { customInput = it },
-            label = { Text("Custom API URL (optional)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true
-        )
         Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            OutlinedButton(onClick = {
-                viewModel.setCustomEndpoint(customInput.ifBlank { null })
-            }) { Text("Apply") }
-            if (customEndpoint != null) {
-                OutlinedButton(onClick = {
-                    customInput = ""
-                    viewModel.setCustomEndpoint(null)
-                }) { Text("Clear") }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Dev Mode API URL",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "The URL of your local Tidal HiFi API instance",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
+            Spacer(modifier = Modifier.width(12.dp))
+            OutlinedTextField(
+                value = customInput,
+                onValueChange = { customInput = it },
+                placeholder = {
+                    Text(
+                        "http://127.0.0.1:8000",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                singleLine = true,
+                enabled = devModeEnabled,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    viewModel.setCustomEndpoint(customInput.trim().ifBlank { null })
+                }),
+                modifier = Modifier
+                    .widthIn(max = 240.dp)
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) {
+                            val trimmed = customInput.trim().ifBlank { null }
+                            if (trimmed != customEndpoint) {
+                                viewModel.setCustomEndpoint(trimmed)
+                            }
+                        }
+                    }
+            )
         }
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -164,6 +164,8 @@ class SettingsViewModel @Inject constructor(
     val streamingInstances: StateFlow<List<Instance>> = _streamingInstances.asStateFlow()
     val customEndpoint: StateFlow<String?> = preferences.customApiEndpoint
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val devModeEnabled: StateFlow<Boolean> = preferences.devModeEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     private val _instancesRefreshing = MutableStateFlow(false)
     val instancesRefreshing: StateFlow<Boolean> = _instancesRefreshing.asStateFlow()
 
@@ -420,6 +422,13 @@ class SettingsViewModel @Inject constructor(
     fun setCustomEndpoint(endpoint: String?) {
         viewModelScope.launch {
             preferences.setCustomApiEndpoint(endpoint)
+            loadInstances()
+        }
+    }
+
+    fun setDevModeEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            preferences.setDevModeEnabled(enabled)
             loadInstances()
         }
     }

--- a/app/src/main/java/tf/monochrome/android/visualizer/ProjectMAudioBus.kt
+++ b/app/src/main/java/tf/monochrome/android/visualizer/ProjectMAudioBus.kt
@@ -1,6 +1,7 @@
 package tf.monochrome.android.visualizer
 
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,6 +18,17 @@ class ProjectMAudioBus @Inject constructor() {
     private val pendingFrames = ConcurrentLinkedQueue<ProjectMAudioFrame>()
     private val latestTimestampMs = AtomicLong(0L)
     private val sampleSnapshot = java.util.concurrent.atomic.AtomicReference<FloatArray?>(null)
+    private val subscriberCount = AtomicInteger(0)
+
+    /**
+     * Reference-count subscribers (visualizer engine + waveform overlay). Callers
+     * must pair acquire/release. When zero, the audio tap skips the per-frame
+     * PCM→float conversion entirely so the audio render thread doesn't do work
+     * no one is consuming.
+     */
+    fun acquire() { subscriberCount.incrementAndGet() }
+    fun release() { subscriberCount.updateAndGet { (it - 1).coerceAtLeast(0) } }
+    fun hasSubscribers(): Boolean = subscriberCount.get() > 0
 
     fun publish(samples: FloatArray, channelCount: Int, sampleRate: Int) {
         val now = System.currentTimeMillis()

--- a/app/src/main/java/tf/monochrome/android/visualizer/ProjectMAudioTapProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/visualizer/ProjectMAudioTapProcessor.kt
@@ -24,6 +24,10 @@ class ProjectMAudioTapProcessor(
 
     override fun handleBuffer(buffer: ByteBuffer) {
         if (!buffer.hasRemaining()) return
+        // No visualizer engine or waveform overlay listening → skip the PCM→float
+        // conversion entirely. handleBuffer is called on the audio render thread
+        // for every frame of every track, so even modest per-frame work matters.
+        if (!audioBus.hasSubscribers()) return
 
         val copy = buffer.asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN)
         val floatSamples = when (encoding) {

--- a/app/src/main/java/tf/monochrome/android/visualizer/ProjectMEngineRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/visualizer/ProjectMEngineRepository.kt
@@ -92,8 +92,19 @@ class ProjectMEngineRepository @Inject constructor(
 
     private fun observePreferences() {
         scope.launch {
+            var heldSubscription = false
             preferences.visualizerEngineEnabled.collectLatest { enabled ->
                 _engineEnabled.value = enabled
+                // Acquire/release the audio bus subscription so the audio render
+                // thread skips the per-frame PCM→float conversion when the engine
+                // is disabled in settings.
+                if (enabled && !heldSubscription) {
+                    audioBus.acquire()
+                    heldSubscription = true
+                } else if (!enabled && heldSubscription) {
+                    audioBus.release()
+                    heldSubscription = false
+                }
                 synchronized(engineLock) {
                     if (!enabled) {
                         releaseNativeLocked()


### PR DESCRIPTION
The artist detail ViewModel called .collect on a cold Room Flow inside loadArtist, so _isLoading never reset — the page stayed on LoadingScreen forever after a successful artist lookup, which users perceived as a crash/ANR. Rework it so albums derive reactively from _artist via flatMapLatest + stateIn, and the one-shot artist fetch terminates in a finally block. CancellationException is re-thrown instead of swallowed.

Also harden the screen: memoize the sorted track list with remember(tracks), switch to keyed items(sortedTracks, key = { it.id }) to keep stable slots under recomposition, drop the non-local return / !! assertion by hoisting artistData before the when and capturing qualityBadge into a local.