### PR TITLE
fix(player): route notification next/prev through the unified track resolver

### DIFF
--- a/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
+++ b/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
@@ -60,6 +60,7 @@ class PlaybackService : MediaSessionService() {
     @Inject lateinit var autoEqProcessor: AutoEqProcessor
     @Inject lateinit var parametricEqProcessor: ParametricEqProcessor
     @Inject lateinit var spectrumAnalyzerTap: SpectrumAnalyzerTap
+    @Inject lateinit var unifiedTrackRegistry: UnifiedTrackRegistry
 
     private var mediaSession: MediaSession? = null
     private lateinit var player: ExoPlayer
@@ -301,6 +302,22 @@ class PlaybackService : MediaSessionService() {
         val currentTrack = queueManager.currentTrack.value ?: return
         serviceScope.launch {
             try {
+                // Unified tracks (local files, encrypted collections) go through a
+                // different resolver — they aren't HiFi API streams and the legacy
+                // resolver can't handle them. Consult the shared registry first so
+                // notification / lock-screen next / previous taps route correctly
+                // for mixed queues.
+                val unifiedTrack = unifiedTrackRegistry[currentTrack.id]
+                if (unifiedTrack != null) {
+                    val resolved = streamResolver.resolveUnifiedTrack(unifiedTrack)
+                    currentReplayGain = resolved.trackStream?.replayGain
+                    player.setMediaItem(resolved.mediaItem)
+                    player.prepare()
+                    player.play()
+                    libraryRepository.addToHistory(currentTrack)
+                    return@launch
+                }
+
                 val (mediaItem, trackStream) = streamResolver.resolveMediaItem(currentTrack)
                 currentReplayGain = trackStream?.replayGain
 

--- a/app/src/main/java/tf/monochrome/android/player/QueueForwardingPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/player/QueueForwardingPlayer.kt
@@ -1,27 +1,27 @@
 package tf.monochrome.android.player
 
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 
 /**
- * Wraps an [ExoPlayer] so the Media3-managed foreground notification and
- * lock-screen controls can show working next / previous buttons even though
- * the underlying player only ever holds one [androidx.media3.common.MediaItem]
- * at a time.
+ * Wraps an [androidx.media3.exoplayer.ExoPlayer] so the Media3-managed
+ * foreground notification and lock-screen controls can show working
+ * next / previous buttons even though the underlying player only ever holds
+ * one [androidx.media3.common.MediaItem] at a time.
  *
  * The app resolves stream URLs one-track-at-a-time (TIDAL DASH MPDs have short
  * TTLs; batch-resolving a long queue up front wastes requests and ages
- * stream URLs before they're used). So ExoPlayer's own playlist is never the
- * source of truth for queue position — [QueueManager] is. Media3's notification
- * only surfaces SEEK_TO_NEXT / SEEK_TO_PREVIOUS when the wrapped player claims
- * the commands are available and has a next / previous media item, which is
- * why the default setup hides the buttons.
+ * stream URLs before they're used). ExoPlayer's own playlist is therefore
+ * never the source of truth for queue position — [QueueManager] is.
  *
  * This forwarder:
- *  - Always advertises SEEK_TO_NEXT / SEEK_TO_PREVIOUS as available commands
- *    when [QueueManager] has more tracks in that direction.
+ *  - Always advertises SEEK_TO_NEXT / SEEK_TO_PREVIOUS as available so the
+ *    notification UI enables the buttons and the session doesn't silently
+ *    drop the command when the raw player's playlist is empty. End-of-queue
+ *    is handled inside `onNext` / `onPrev` (they simply stop playback).
  *  - Re-routes `seekToNext*` / `seekToPrevious*` calls to [onNext] / [onPrev]
  *    (the service's skipToNext / skipToPrevious), which handle queue
  *    advancement plus stream-URL resolution.
@@ -29,7 +29,7 @@ import androidx.media3.common.util.UnstableApi
 @OptIn(UnstableApi::class)
 class QueueForwardingPlayer(
     delegate: Player,
-    private val queueManager: QueueManager,
+    @Suppress("unused") private val queueManager: QueueManager,
     private val onNext: () -> Unit,
     private val onPrev: () -> Unit,
 ) : ForwardingPlayer(delegate) {
@@ -48,19 +48,40 @@ class QueueForwardingPlayer(
     }
 
     override fun isCommandAvailable(command: Int): Boolean = when (command) {
+        // Unconditional so the notification button is always tappable and the
+        // Media3 session never pre-filters the command. `onNext` / `onPrev`
+        // decide what happens at end-of-queue (they can stop the player).
         Player.COMMAND_SEEK_TO_NEXT,
-        Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM -> queueManager.hasNext()
+        Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
         Player.COMMAND_SEEK_TO_PREVIOUS,
-        Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> queueManager.hasPrevious()
+        Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> true
         else -> super.isCommandAvailable(command)
     }
 
-    override fun hasNextMediaItem(): Boolean = queueManager.hasNext()
-    override fun hasPreviousMediaItem(): Boolean = queueManager.hasPrevious()
+    override fun hasNextMediaItem(): Boolean = true
+    override fun hasPreviousMediaItem(): Boolean = true
 
-    override fun seekToNextMediaItem() = onNext()
-    override fun seekToPreviousMediaItem() = onPrev()
+    override fun seekToNextMediaItem() {
+        Log.i(TAG, "seekToNextMediaItem routed to QueueManager")
+        onNext()
+    }
 
-    override fun seekToNext() = onNext()
-    override fun seekToPrevious() = onPrev()
+    override fun seekToPreviousMediaItem() {
+        Log.i(TAG, "seekToPreviousMediaItem routed to QueueManager")
+        onPrev()
+    }
+
+    override fun seekToNext() {
+        Log.i(TAG, "seekToNext routed to QueueManager")
+        onNext()
+    }
+
+    override fun seekToPrevious() {
+        Log.i(TAG, "seekToPrevious routed to QueueManager")
+        onPrev()
+    }
+
+    private companion object {
+        const val TAG = "QueueForwardingPlayer"
+    }
 }

--- a/app/src/main/java/tf/monochrome/android/player/UnifiedTrackRegistry.kt
+++ b/app/src/main/java/tf/monochrome/android/player/UnifiedTrackRegistry.kt
@@ -1,0 +1,38 @@
+package tf.monochrome.android.player
+
+import tf.monochrome.android.domain.model.UnifiedTrack
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Shared map from legacy [tf.monochrome.android.domain.model.Track.id] to the
+ * originating [UnifiedTrack] (local file, encrypted collection entry, etc.).
+ *
+ * The main-process [tf.monochrome.android.ui.player.PlayerViewModel] populates
+ * this when the user plays a unified queue, and both the ViewModel's
+ * `resolveAndPlay()` path and the [PlaybackService]'s media-button / notification
+ * skip path consult it to decide which resolver branch to use (unified local
+ * vs. legacy HiFi API).
+ *
+ * Without a shared registry, notification / lock-screen next / previous taps
+ * reach `PlaybackService.skipToNext()` → `playQueue()`, which would only ever
+ * call the HiFi API resolver — so skipping in the notification while playing
+ * a local file would silently fail.
+ */
+@Singleton
+class UnifiedTrackRegistry @Inject constructor() {
+    private val map = ConcurrentHashMap<Long, UnifiedTrack>()
+
+    fun put(trackId: Long, unifiedTrack: UnifiedTrack) {
+        map[trackId] = unifiedTrack
+    }
+
+    fun putAll(entries: List<UnifiedTrack>, legacyIdFor: (UnifiedTrack) -> Long) {
+        entries.forEach { map[legacyIdFor(it)] = it }
+    }
+
+    operator fun get(trackId: Long): UnifiedTrack? = map[trackId]
+
+    fun clear() { map.clear() }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -49,6 +49,7 @@ class PlayerViewModel @Inject constructor(
     private val downloadManager: DownloadManager,
     private val preferences: PreferencesManager,
     private val projectMEngineRepository: ProjectMEngineRepository,
+    private val unifiedTrackRegistry: tf.monochrome.android.player.UnifiedTrackRegistry,
     val spectrumAnalyzer: SpectrumAnalyzerTap
 ) : ViewModel() {
 
@@ -162,8 +163,9 @@ class PlayerViewModel @Inject constructor(
     private var mediaController: MediaController? = null
     private var controllerFuture: ListenableFuture<MediaController>? = null
 
-    // Maps legacy Track IDs to their UnifiedTrack source for local/collection playback
-    private val unifiedSourceMap = mutableMapOf<Long, UnifiedTrack>()
+    // Legacy Track IDs → their UnifiedTrack source live in UnifiedTrackRegistry
+    // (a @Singleton) so PlaybackService's notification / media-button skip path
+    // can resolve unified tracks too. Don't redeclare here.
 
 
     init {
@@ -324,7 +326,7 @@ class PlayerViewModel @Inject constructor(
         // Store source mappings so resolveAndPlay can find the right playback source
         trackList.forEach { ut ->
             val legacyId = ut.toLegacyTrack().id
-            unifiedSourceMap[legacyId] = ut
+            unifiedTrackRegistry.put(legacyId, ut)
         }
         val legacyTrack = track.toLegacyTrack()
         queueManager.playTrackInQueue(legacyTrack, legacyTracks)
@@ -335,7 +337,7 @@ class PlayerViewModel @Inject constructor(
     fun playAllUnified(tracks: List<UnifiedTrack>) {
         if (tracks.isEmpty()) return
         tracks.forEach { ut ->
-            unifiedSourceMap[ut.toLegacyTrack().id] = ut
+            unifiedTrackRegistry.put(ut.toLegacyTrack().id, ut)
         }
         val legacyTracks = tracks.map { it.toLegacyTrack() }
         queueManager.setQueue(legacyTracks, 0)
@@ -347,7 +349,7 @@ class PlayerViewModel @Inject constructor(
         if (tracks.isEmpty()) return
         try {
             tracks.forEach { ut ->
-                unifiedSourceMap[ut.toLegacyTrack().id] = ut
+                unifiedTrackRegistry.put(ut.toLegacyTrack().id, ut)
             }
             val legacyTracks = tracks.map { it.toLegacyTrack() }
             queueManager.setQueue(legacyTracks, 0)
@@ -494,7 +496,7 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 // Check if this track has a unified source (local file, collection, etc.)
-                val unifiedTrack = unifiedSourceMap[track.id]
+                val unifiedTrack = unifiedTrackRegistry[track.id]
                 if (unifiedTrack != null) {
                     val resolved = streamResolver.resolveUnifiedTrack(unifiedTrack)
                     mediaController?.let { mc ->


### PR DESCRIPTION
## Summary

Route notification / lock-screen next + previous taps through the shared unified track resolver so skipping actually advances the song on local files and encrypted collections — not just HiFi API streams.

## What was broken

- `QueueForwardingPlayer.seekToNextMediaItem()` → `PlaybackService.skipToNext()` → `playQueue()`. That part was already wired.
- **But** `playQueue()` only knew how to resolve via `streamResolver.resolveMediaItem()` — the HiFi API path. For a local / collection track, that resolver threw, the catch swallowed it into `onTrackEnded()`, and from the user's perspective "next didn't change the song."
- The resolver that handles those tracks (`resolveUnifiedTrack`) needs a `UnifiedTrack`, but that mapping lived as a *private field in `PlayerViewModel`* — completely invisible to the service.

## What's in this change

- New `@Singleton UnifiedTrackRegistry` (ConcurrentHashMap-backed). Both `PlayerViewModel` (writes on queue) and `PlaybackService.playQueue` (reads on skip) now see the same legacy-id → `UnifiedTrack` mappings.
- `PlaybackService.playQueue` consults the registry first; falls back to the HiFi API resolver only when no unified source is registered.
- `QueueForwardingPlayer` tightened:
  - `isCommandAvailable(SEEK_TO_NEXT / PREVIOUS)` returns true unconditionally. Media3 was pre-filtering the command using `queueManager.hasNext()`, which was false momentarily while a newly-queued track settled and the notification silently dropped the tap. End-of-queue is still handled by the existing `player.stop()` fallback.
  - Added `Log.i("QueueForwardingPlayer", ...)` on each seek override so any future misroute lands in the in-app debug log viewer instead of being invisible.

## Test plan

- [ ] Queue a local library playlist → tap play → swipe down the notification shade → tap next → the next local track loads and plays.
- [ ] Same flow from the lock screen.
- [ ] Same flow with BT / wired headphone next button.
- [ ] Start a TIDAL album (non-local), verify next still works (registry miss → HiFi API path still triggers).
- [ ] Reach the last track in the queue → tap next → player stops instead of crashing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vHfSTVoFtgUAHE6AweXgb)_