### PR TITLE
feat(downloads): route through dedicated TrypT HiFi (Qobuz) instance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,11 @@ name: Build APK
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'claude/**'
+      - 'feat/**'
+      - 'fix/**'
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,15 +55,6 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // Optional: project-private download instance. Read from local.properties
-        // (gitignored) so the URL never lands in committed source. When unset,
-        // downloads silently fall back to the public streaming pool.
-        buildConfigField(
-            "String",
-            "DOWNLOAD_INSTANCE_URL",
-            "\"${localProperties.getProperty("download.instance.url", "").trim().trimEnd('/')}\"",
-        )
-
         externalNativeBuild {
             cmake {
                 cppFlags += "-std=c++17"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,15 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // Optional: project-private download instance. Read from local.properties
+        // (gitignored) so the URL never lands in committed source. When unset,
+        // downloads silently fall back to the public streaming pool.
+        buildConfigField(
+            "String",
+            "DOWNLOAD_INSTANCE_URL",
+            "\"${localProperties.getProperty("download.instance.url", "").trim().trimEnd('/')}\"",
+        )
+
         externalNativeBuild {
             cmake {
                 cppFlags += "-std=c++17"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,21 @@
         android:usesCleartextTraffic="false"
         tools:targetApi="36">
 
+        <!-- Backs the per-track 'Share file' action: a FileProvider grants
+             time-limited content:// URIs for downloaded FLACs and Qobuz
+             stream cache files so other apps (Messages, Drive, etc.)
+             can read them through the share sheet. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"

--- a/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
+++ b/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.auth.SupabaseAuthManager
 import tf.monochrome.android.data.device.DeviceRegistry
+import tf.monochrome.android.debug.CrashLogger
 import tf.monochrome.android.debug.DebugLogCollector
 import tf.monochrome.android.performance.DeviceCapabilities
 import tf.monochrome.android.performance.PerformanceProfile
@@ -76,6 +77,9 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
     @Inject
     lateinit var debugLogCollector: DebugLogCollector
 
+    @Inject
+    lateinit var crashLogger: CrashLogger
+
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override val workManagerConfiguration: Configuration
@@ -108,6 +112,11 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
 
     override fun onCreate() {
         super.onCreate()
+        // Catch uncaught exceptions and dump the in-memory log + stack trace
+        // to Downloads/monotrypt-crash-<timestamp>.log before chaining to the
+        // system handler. Installed before anything else so a crash anywhere
+        // in onCreate is captured.
+        crashLogger.install()
         // Pre-create the Now Playing channel so the first foreground-service
         // notification from Media3 has a named channel instead of showing up
         // under "default" in Android Settings → App → Notifications. Media3

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -6,7 +6,10 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import tf.monochrome.android.data.api.model.AlbumResponse
 import tf.monochrome.android.data.api.model.AlbumTrackItem
@@ -46,6 +49,13 @@ class HiFiApiClient @Inject constructor(
     private val json: Json
 ) {
     private val cache = LruCache<String, CacheEntry>(200)
+
+    companion object {
+        // Hard ceiling per Qobuz sub-request so a slow or unreachable Qobuz
+        // instance can't stall the search UI behind coroutineScope's
+        // wait-for-all-children semantics.
+        private const val QOBUZ_REQUEST_TIMEOUT_MS = 6_000L
+    }
 
     private data class CacheEntry(
         val data: Any,
@@ -177,26 +187,34 @@ class HiFiApiClient @Inject constructor(
         )
     }
 
-    // Qobuz catalog search — hits the user-configured Qobuz instance via
-    // InstanceType.DOWNLOAD (same pool used for downloads). Returns an empty
-    // SearchResult when the instance isn't set or the request fails, so the
-    // TIDAL search flow keeps working even if the Qobuz endpoint is offline.
+    // Qobuz catalog search — hits ONLY the user-configured Qobuz instance.
+    // Returns an empty SearchResult when the instance isn't set, the request
+    // times out, or the response can't be parsed, so the TIDAL search flow
+    // is never blocked or duplicated by Qobuz state.
     suspend fun searchQobuz(query: String): SearchResult {
-        suspend fun parsedSearch(path: String) =
-            runCatching {
-                val body = fetchWithRetry(path, instanceType = InstanceType.DOWNLOAD)
-                parseSearchResponse(body)
-            }.getOrNull()
+        val instance = instanceManager.qobuzInstanceOrNull() ?: return SearchResult()
+        val base = instance.url.trimEnd('/')
 
-        val tracks = parsedSearch("/search/?s=${query.encodeUrl()}")?.items?.map { it.toTrack() }
-            ?: emptyList()
-        val albums = parsedSearch("/search/?al=${query.encodeUrl()}")?.items?.map { it.toAlbum() }
-            ?: emptyList()
-        val artists = parsedSearch("/search/?a=${query.encodeUrl()}")?.items?.map { it.toArtist() }
-            ?: emptyList()
-        val playlists = parsedSearch("/search/?p=${query.encodeUrl()}")?.items?.map { it.toPlaylist() }
-            ?: emptyList()
-        return SearchResult(tracks = tracks, albums = albums, artists = artists, playlists = playlists)
+        suspend fun parsedSearch(path: String): SearchResponse? = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+            runCatching {
+                val response = httpClient.get(base + path)
+                if (!response.status.isSuccess()) return@runCatching null
+                parseSearchResponse(response.bodyAsText())
+            }.getOrNull()
+        }
+
+        return coroutineScope {
+            val tracksDeferred = async { parsedSearch("/search/?s=${query.encodeUrl()}") }
+            val albumsDeferred = async { parsedSearch("/search/?al=${query.encodeUrl()}") }
+            val artistsDeferred = async { parsedSearch("/search/?a=${query.encodeUrl()}") }
+            val playlistsDeferred = async { parsedSearch("/search/?p=${query.encodeUrl()}") }
+            SearchResult(
+                tracks = tracksDeferred.await()?.items?.map { it.toTrack() } ?: emptyList(),
+                albums = albumsDeferred.await()?.items?.map { it.toAlbum() } ?: emptyList(),
+                artists = artistsDeferred.await()?.items?.map { it.toArtist() } ?: emptyList(),
+                playlists = playlistsDeferred.await()?.items?.map { it.toPlaylist() } ?: emptyList(),
+            )
+        }
     }
 
     // --- Album ---

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -789,7 +789,11 @@ private fun QobuzAlbumItem.toDomainAlbum(): tf.monochrome.android.domain.model.A
 
 private fun QobuzTrackItem.toDomainTrack(): tf.monochrome.android.domain.model.Track {
     val resolvedAlbum = album?.toDomainAlbum()
-    val resolvedArtist = performer?.toDomainArtistRef()
+    // performer is the track-level primary artist ({id, name}). Fall back to
+    // the album's main artist when missing (the response always populates one
+    // or the other).
+    val resolvedArtist = performer?.toDomainArtist()
+        ?: album?.artist?.toDomainArtistRef()
     return tf.monochrome.android.domain.model.Track(
         id = id ?: 0L,
         title = listOfNotNull(title.takeIf { it.isNotBlank() }, version?.takeIf { it.isNotBlank() })
@@ -804,6 +808,13 @@ private fun QobuzTrackItem.toDomainTrack(): tf.monochrome.android.domain.model.T
         volumeNumber = mediaNumber,
     )
 }
+
+private fun QobuzPerson.toDomainArtist(): tf.monochrome.android.domain.model.Artist =
+    tf.monochrome.android.domain.model.Artist(
+        id = id ?: 0L,
+        name = name,
+        picture = null,
+    )
 
 private fun QobuzArtistItem.toDomainArtist(): tf.monochrome.android.domain.model.Artist =
     tf.monochrome.android.domain.model.Artist(

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -24,10 +24,12 @@ import tf.monochrome.android.data.api.model.LyricsResponse
 import tf.monochrome.android.data.api.model.ManifestJson
 import tf.monochrome.android.data.api.model.MixResponse
 import tf.monochrome.android.data.api.model.PlaylistResponse
+import tf.monochrome.android.data.api.model.QobuzAlbumDetailEnvelope
 import tf.monochrome.android.data.api.model.QobuzAlbumItem
 import tf.monochrome.android.data.api.model.QobuzArtistItem
 import tf.monochrome.android.data.api.model.QobuzArtistRef
 import tf.monochrome.android.data.api.model.QobuzDownloadEnvelope
+import tf.monochrome.android.data.api.model.QobuzPerson
 import tf.monochrome.android.data.api.model.QobuzSearchEnvelope
 import tf.monochrome.android.data.api.model.QobuzTrackItem
 import tf.monochrome.android.data.api.model.RecommendationsResponse
@@ -59,6 +61,7 @@ class HiFiApiClient @Inject constructor(
     private val httpClient: HttpClient,
     private val json: Json,
     private val preferences: tf.monochrome.android.data.preferences.PreferencesManager,
+    private val qobuzIdRegistry: QobuzIdRegistry,
 ) {
     private val cache = LruCache<String, CacheEntry>(200)
 
@@ -225,12 +228,59 @@ class HiFiApiClient @Inject constructor(
 
         if (!envelope.success || envelope.data == null) return SearchResult()
         val data = envelope.data
+
+        // Record (qobuz_id -> alphanumeric slug) so the detail VM can look the
+        // slug back up at navigation time. Numeric artist ids are also tagged
+        // as Qobuz so ArtistDetailViewModel can route appropriately.
+        data.albums?.items?.forEach { item ->
+            val qid = item.qobuzId
+            val slug = item.id
+            if (qid != null && !slug.isNullOrBlank()) {
+                qobuzIdRegistry.registerAlbum(qid, slug)
+            }
+        }
+        data.artists?.items?.forEach { item -> item.id?.let { qobuzIdRegistry.registerArtist(it) } }
+
         return SearchResult(
             tracks = data.tracks?.items?.map { it.toDomainTrack() } ?: emptyList(),
             albums = data.albums?.items?.map { it.toDomainAlbum() } ?: emptyList(),
             artists = data.artists?.items?.map { it.toDomainArtist() } ?: emptyList(),
             playlists = emptyList(),
         )
+    }
+
+    /**
+     * Qobuz album detail — GET /api/get-album?album_id=<alphanumeric-slug>.
+     * The response is the standard {success, data: …} envelope; data has all
+     * the QobuzAlbumItem fields plus a `tracks: { items: [...] }` block with
+     * the album's full track list. Returns null when the Qobuz instance
+     * isn't configured, the request fails, or the body can't be parsed.
+     */
+    suspend fun getQobuzAlbum(albumSlug: String): AlbumDetail? {
+        val instance = instanceManager.qobuzInstanceOrNull() ?: return null
+        if (albumSlug.isBlank()) return null
+        val base = instance.url.trimEnd('/')
+        val cookie = preferences.qobuzAuthCookie.first()
+
+        val envelope = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+            runCatching {
+                val res = httpClient.get(
+                    "$base/api/get-album?album_id=${albumSlug.encodeUrl()}"
+                ) { attachQobuzAuth(cookie) }
+                if (!res.status.isSuccess()) return@runCatching null
+                json.decodeFromString<QobuzAlbumDetailEnvelope>(res.bodyAsText())
+            }.getOrNull()
+        } ?: return null
+
+        if (!envelope.success || envelope.data == null) return null
+        val albumItem = envelope.data
+        val album = albumItem.toDomainAlbum()
+        val tracks = albumItem.tracks?.items?.map { item ->
+            // Detail responses don't repeat the album object inside each track
+            // — provide it explicitly so playback / display has full context.
+            item.toDomainTrack(fallbackAlbum = album)
+        } ?: emptyList()
+        return AlbumDetail(album = album, tracks = tracks)
     }
 
     // --- Album ---
@@ -787,13 +837,16 @@ private fun QobuzAlbumItem.toDomainAlbum(): tf.monochrome.android.domain.model.A
     )
 }
 
-private fun QobuzTrackItem.toDomainTrack(): tf.monochrome.android.domain.model.Track {
-    val resolvedAlbum = album?.toDomainAlbum()
+private fun QobuzTrackItem.toDomainTrack(
+    fallbackAlbum: tf.monochrome.android.domain.model.Album? = null,
+): tf.monochrome.android.domain.model.Track {
+    val resolvedAlbum = album?.toDomainAlbum() ?: fallbackAlbum
     // performer is the track-level primary artist ({id, name}). Fall back to
     // the album's main artist when missing (the response always populates one
     // or the other).
     val resolvedArtist = performer?.toDomainArtist()
         ?: album?.artist?.toDomainArtistRef()
+        ?: fallbackAlbum?.artist
     return tf.monochrome.android.domain.model.Track(
         id = id ?: 0L,
         title = listOfNotNull(title.takeIf { it.isNotBlank() }, version?.takeIf { it.isNotBlank() })

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -6,11 +6,13 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import tf.monochrome.android.data.api.model.AlbumResponse
 import tf.monochrome.android.data.api.model.AlbumTrackItem
 import tf.monochrome.android.data.api.model.ArtistContentResponse
@@ -187,34 +189,34 @@ class HiFiApiClient @Inject constructor(
         )
     }
 
-    // Qobuz catalog search — hits ONLY the user-configured Qobuz instance.
-    // Returns an empty SearchResult when the instance isn't set, the request
-    // times out, or the response can't be parsed, so the TIDAL search flow
-    // is never blocked or duplicated by Qobuz state.
+    // Qobuz catalog search — hits the user-configured trypt-hifi instance
+    // at GET /api/get-music?q=<query>&offset=<n>. Returns an empty
+    // SearchResult when the instance isn't set, the request times out, or
+    // the response can't be parsed, so the TIDAL search flow is never
+    // blocked by Qobuz state.
+    //
+    // The response shape isn't fully documented here — `parseSearchResponse`
+    // already handles wrapped {data:...}, {items:[...]}, and bare arrays, so
+    // most reasonable shapes get mapped to tracks. Albums/artists/playlists
+    // are left empty until the response payload is verified end-to-end.
     suspend fun searchQobuz(query: String): SearchResult {
         val instance = instanceManager.qobuzInstanceOrNull() ?: return SearchResult()
         val base = instance.url.trimEnd('/')
 
-        suspend fun parsedSearch(path: String): SearchResponse? = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+        val response = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
             runCatching {
-                val response = httpClient.get(base + path)
-                if (!response.status.isSuccess()) return@runCatching null
-                parseSearchResponse(response.bodyAsText())
+                val res = httpClient.get("$base/api/get-music?q=${query.encodeUrl()}&offset=0")
+                if (!res.status.isSuccess()) return@runCatching null
+                parseSearchResponse(res.bodyAsText())
             }.getOrNull()
-        }
+        } ?: return SearchResult()
 
-        return coroutineScope {
-            val tracksDeferred = async { parsedSearch("/search/?s=${query.encodeUrl()}") }
-            val albumsDeferred = async { parsedSearch("/search/?al=${query.encodeUrl()}") }
-            val artistsDeferred = async { parsedSearch("/search/?a=${query.encodeUrl()}") }
-            val playlistsDeferred = async { parsedSearch("/search/?p=${query.encodeUrl()}") }
-            SearchResult(
-                tracks = tracksDeferred.await()?.items?.map { it.toTrack() } ?: emptyList(),
-                albums = albumsDeferred.await()?.items?.map { it.toAlbum() } ?: emptyList(),
-                artists = artistsDeferred.await()?.items?.map { it.toArtist() } ?: emptyList(),
-                playlists = playlistsDeferred.await()?.items?.map { it.toPlaylist() } ?: emptyList(),
-            )
-        }
+        return SearchResult(
+            tracks = response.items.map { it.toTrack() },
+            albums = emptyList(),
+            artists = emptyList(),
+            playlists = emptyList(),
+        )
     }
 
     // --- Album ---
@@ -380,9 +382,28 @@ class HiFiApiClient @Inject constructor(
         quality: AudioQuality,
         forDownload: Boolean = false
     ): TrackStream {
+        // Downloads route through the project-private trypt-hifi (Qobuz) API
+        // when configured. The frontend's network trace shows the real call
+        // is GET /api/download-music?track_id=<id>&quality=<qobuz_code>, which
+        // returns a JSON envelope containing a short-lived HMAC-signed
+        // /api/file?... URL we then stream the bytes from.
+        if (forDownload) {
+            val qobuzUrl = runCatching { resolveQobuzDownloadUrl(trackId, quality) }.getOrNull()
+            if (qobuzUrl != null) {
+                return TrackStream(
+                    track = Track(id = trackId, title = "", duration = 0),
+                    streamUrl = qobuzUrl,
+                    isDash = false,
+                    replayGain = ReplayGainValues()
+                )
+            }
+            // Qobuz unset or upstream returned nothing — fall through to the
+            // existing TIDAL streaming path so the user still gets bytes.
+        }
+
         val body = fetchWithRetry(
             "/track/?id=$trackId&quality=${quality.apiValue}",
-            instanceType = if (forDownload) InstanceType.DOWNLOAD else InstanceType.STREAMING
+            instanceType = InstanceType.STREAMING
         )
         val streamResponse = json.decodeFromString<TrackStreamResponse>(unwrapResponse(body))
 
@@ -610,6 +631,80 @@ class HiFiApiClient @Inject constructor(
 
     private fun String.encodeUrl(): String {
         return java.net.URLEncoder.encode(this, "UTF-8")
+    }
+
+    // --- Qobuz (trypt-hifi) download resolution -----------------------------
+    //
+    // The trypt-hifi frontend at https://<host>/ ships a SPA, but the same
+    // origin also exposes a JSON API under /api/. The download flow seen in
+    // the frontend's network trace is:
+    //
+    //   1. GET /api/download-music?track_id=<id>&quality=<qobuz_code>
+    //        → small JSON envelope with a stream URL (per-request HMAC-signed)
+    //   2. GET that returned URL  → audio bytes (FLAC for quality 6/7/27,
+    //                                MP3 for 5)
+    //
+    // Step 2 is just a regular byte download, which DownloadWorker already
+    // handles. So all we need to do is resolve step 1 and return the URL.
+
+    private suspend fun resolveQobuzDownloadUrl(trackId: Long, quality: AudioQuality): String? {
+        val instance = instanceManager.qobuzInstanceOrNull() ?: return null
+        val base = instance.url.trimEnd('/')
+        val code = quality.qobuzCode()
+        val response = httpClient.get("$base/api/download-music?track_id=$trackId&quality=$code")
+        if (!response.status.isSuccess()) return null
+        val body = response.bodyAsText()
+        return extractQobuzFileUrl(body, base)
+            // Hi-Res isn't always available on Qobuz — fall back to lossless
+            // exactly like the TIDAL path does, instead of failing the
+            // download.
+            ?: if (quality == AudioQuality.HI_RES) {
+                resolveQobuzDownloadUrl(trackId, AudioQuality.LOSSLESS)
+            } else null
+    }
+
+    // Qobuz exposes four quality codes; map our 4-tier AudioQuality onto them.
+    // Reference: 5 = MP3 320kbps, 6 = FLAC 16/44.1, 7 = FLAC 24/96, 27 = FLAC
+    // hi-res. Quality 27 was the one observed in the captured request.
+    private fun AudioQuality.qobuzCode(): Int = when (this) {
+        AudioQuality.LOW, AudioQuality.HIGH -> 5
+        AudioQuality.LOSSLESS -> 6
+        AudioQuality.HI_RES -> 27
+    }
+
+    // Defensive parser — the response body is short JSON but the field name
+    // hasn't been verified, so we try a handful of common shapes (top-level
+    // url, file_url, stream_url, download_url, nested data.url) and finally
+    // fall back to a regex scan for any /api/file? URL hosted on the same
+    // instance. Returns null if no candidate is found.
+    private fun extractQobuzFileUrl(body: String, base: String): String? {
+        val parsed = runCatching { json.parseToJsonElement(body) }.getOrNull()
+        val direct = (parsed as? JsonObject)?.let { obj ->
+            obj["url"]?.jsonPrimitive?.contentOrNull
+                ?: obj["file_url"]?.jsonPrimitive?.contentOrNull
+                ?: obj["stream_url"]?.jsonPrimitive?.contentOrNull
+                ?: obj["download_url"]?.jsonPrimitive?.contentOrNull
+                ?: (obj["data"] as? JsonObject)?.get("url")?.jsonPrimitive?.contentOrNull
+        } ?: (parsed as? JsonPrimitive)?.contentOrNull
+        if (!direct.isNullOrBlank()) return absoluteUrl(direct, base)
+
+        // Regex fallback — match either the full URL or the relative path
+        // and resolve against the instance base. Trace showed the frontend's
+        // file URL begins with "file?uid=...&eid=...&hmac=...", so we accept
+        // both /api/file?... and bare file?... shapes.
+        val urlMatch = Regex("https?://[^\"\\s]*?/api/file\\?[^\"\\s]+").find(body)?.value
+        if (urlMatch != null) return urlMatch
+        val pathMatch = Regex("/?(?:api/)?file\\?[^\"\\s]+").find(body)?.value
+        return pathMatch?.let { absoluteUrl(it, base) }
+    }
+
+    private fun absoluteUrl(value: String, base: String): String {
+        return when {
+            value.startsWith("http://") || value.startsWith("https://") -> value
+            value.startsWith("/api/") -> base + value
+            value.startsWith("/") -> "$base/api${value}".replace("/api/api/", "/api/")
+            else -> "$base/api/$value"
+        }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -26,11 +26,17 @@ import tf.monochrome.android.data.api.model.MixResponse
 import tf.monochrome.android.data.api.model.PlaylistResponse
 import tf.monochrome.android.data.api.model.QobuzAlbumDetailEnvelope
 import tf.monochrome.android.data.api.model.QobuzAlbumItem
+import tf.monochrome.android.data.api.model.QobuzArtistDetail
+import tf.monochrome.android.data.api.model.QobuzArtistDetailEnvelope
+import tf.monochrome.android.data.api.model.QobuzArtistImages
 import tf.monochrome.android.data.api.model.QobuzArtistItem
 import tf.monochrome.android.data.api.model.QobuzArtistRef
+import tf.monochrome.android.data.api.model.QobuzArtistTopTrack
 import tf.monochrome.android.data.api.model.QobuzDownloadEnvelope
+import tf.monochrome.android.data.api.model.QobuzNamedRef
 import tf.monochrome.android.data.api.model.QobuzPerson
 import tf.monochrome.android.data.api.model.QobuzSearchEnvelope
+import tf.monochrome.android.data.api.model.QobuzSimilarArtist
 import tf.monochrome.android.data.api.model.QobuzTrackItem
 import tf.monochrome.android.data.api.model.RecommendationsResponse
 import tf.monochrome.android.data.api.model.SearchResponse
@@ -231,14 +237,11 @@ class HiFiApiClient @Inject constructor(
 
         // Record (qobuz_id -> alphanumeric slug) so the detail VM can look the
         // slug back up at navigation time. Numeric artist ids are also tagged
-        // as Qobuz so ArtistDetailViewModel can route appropriately.
-        data.albums?.items?.forEach { item ->
-            val qid = item.qobuzId
-            val slug = item.id
-            if (qid != null && !slug.isNullOrBlank()) {
-                qobuzIdRegistry.registerAlbum(qid, slug)
-            }
-        }
+        // as Qobuz so ArtistDetailViewModel can route appropriately. Tracks
+        // also carry an album object — register those slugs too so navigation
+        // from a track row resolves correctly.
+        data.albums?.items?.forEach { registerAlbumWithRegistry(it) }
+        data.tracks?.items?.forEach { it.album?.let { album -> registerAlbumWithRegistry(album) } }
         data.artists?.items?.forEach { item -> item.id?.let { qobuzIdRegistry.registerArtist(it) } }
 
         return SearchResult(
@@ -274,6 +277,7 @@ class HiFiApiClient @Inject constructor(
 
         if (!envelope.success || envelope.data == null) return null
         val albumItem = envelope.data
+        registerAlbumWithRegistry(albumItem)
         val album = albumItem.toDomainAlbum()
         val tracks = albumItem.tracks?.items?.map { item ->
             // Detail responses don't repeat the album object inside each track
@@ -281,6 +285,71 @@ class HiFiApiClient @Inject constructor(
             item.toDomainTrack(fallbackAlbum = album)
         } ?: emptyList()
         return AlbumDetail(album = album, tracks = tracks)
+    }
+
+    /**
+     * Qobuz artist detail — GET /api/get-artist?artist_id=<numeric-id>.
+     *
+     * Response shape is materially different from search/album:
+     *   {success, data: {artist: {id, name:{display}, biography, images:
+     *     {portrait:{hash, format}}, top_tracks:[…], similar_artists:
+     *     {has_more, items:[…]}}}}
+     *
+     * Album lists per artist aren't part of this payload — the SPA likely
+     * loads them via a separate call. Until that contract is known, the
+     * mapped ArtistDetail leaves albums/eps/singles empty and populates
+     * topTracks + similarArtists.
+     */
+    suspend fun getQobuzArtist(artistId: Long): ArtistDetail? {
+        val instance = instanceManager.qobuzInstanceOrNull() ?: return null
+        val base = instance.url.trimEnd('/')
+        val cookie = preferences.qobuzAuthCookie.first()
+
+        val envelope = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+            runCatching {
+                val res = httpClient.get("$base/api/get-artist?artist_id=$artistId") {
+                    attachQobuzAuth(cookie)
+                }
+                if (!res.status.isSuccess()) return@runCatching null
+                json.decodeFromString<QobuzArtistDetailEnvelope>(res.bodyAsText())
+            }.getOrNull()
+        } ?: return null
+
+        if (!envelope.success || envelope.data?.artist == null) return null
+        val raw = envelope.data.artist
+
+        // Register top_track album slugs so clicking through to an album
+        // from the artist screen still resolves via QobuzIdRegistry.
+        raw.topTracks.forEach { it.album?.let { album -> registerAlbumWithRegistry(album) } }
+
+        val artist = Artist(
+            id = raw.id ?: artistId,
+            name = raw.name?.display ?: "",
+            picture = raw.images?.portraitUrl(),
+        )
+        val topTracks = raw.topTracks.mapNotNull { it.toDomainTrack() }
+        val similar = raw.similarArtists?.items?.mapNotNull { it.toDomainArtist() } ?: emptyList()
+        return ArtistDetail(
+            artist = artist,
+            topTracks = topTracks,
+            albums = emptyList(),
+            eps = emptyList(),
+            singles = emptyList(),
+            unreleasedTracks = emptyList(),
+            similarArtists = similar,
+        )
+    }
+
+    // Side-channel registry update for any QobuzAlbumItem we decode. Album.id
+    // produced by toDomainAlbum is qobuz_id when available and slug.hashCode()
+    // otherwise — register that exact value so AlbumDetailViewModel's
+    // registry lookup always resolves regardless of which path produced the id.
+    private fun registerAlbumWithRegistry(item: QobuzAlbumItem) {
+        val albumId = item.qobuzId ?: item.id?.hashCode()?.toLong()
+        val slug = item.id
+        if (albumId != null && !slug.isNullOrBlank()) {
+            qobuzIdRegistry.registerAlbum(albumId, slug)
+        }
     }
 
     // --- Album ---
@@ -882,6 +951,57 @@ private fun QobuzArtistRef.toDomainArtistRef(): tf.monochrome.android.domain.mod
         name = name,
         picture = image?.large ?: image?.small ?: picture,
     )
+
+// Qobuz hashes artist images in the response; the actual URL is a templated
+// CDN path. "large" is a reasonable default for the artist detail screen.
+private fun QobuzArtistImages.portraitUrl(size: String = "large"): String? {
+    val p = portrait ?: return null
+    val hash = p.hash ?: return null
+    val format = p.format ?: "jpg"
+    return "https://static.qobuz.com/images/artists/covers/$size/$hash.$format"
+}
+
+private fun QobuzSimilarArtist.toDomainArtist(): tf.monochrome.android.domain.model.Artist? {
+    val artistId = id ?: return null
+    return tf.monochrome.android.domain.model.Artist(
+        id = artistId,
+        name = name?.display ?: "",
+        picture = images?.portraitUrl(size = "medium"),
+    )
+}
+
+private fun QobuzNamedRef.toDomainArtist(): tf.monochrome.android.domain.model.Artist =
+    tf.monochrome.android.domain.model.Artist(
+        id = id ?: 0L,
+        name = name?.display ?: "",
+    )
+
+// Top-tracks on the artist endpoint use a different shape than QobuzTrackItem
+// (rights/physical_support/audio_info wrappers, nested name objects). Map
+// directly so the artist screen surfaces playable rows.
+private fun QobuzArtistTopTrack.toDomainTrack(): tf.monochrome.android.domain.model.Track? {
+    val trackId = id ?: return null
+    val resolvedAlbum = album?.toDomainAlbum()
+    val resolvedArtist = artist?.toDomainArtist() ?: album?.artist?.toDomainArtistRef()
+    val audioQuality = when {
+        rights?.hiresStreamable == true -> "HI_RES_LOSSLESS"
+        (audioInfo?.maximumBitDepth ?: 0) >= 16 -> "LOSSLESS"
+        else -> null
+    }
+    return tf.monochrome.android.domain.model.Track(
+        id = trackId,
+        title = listOfNotNull(title.takeIf { it.isNotBlank() }, version?.takeIf { it.isNotBlank() })
+            .joinToString(" — "),
+        duration = duration ?: 0,
+        artist = resolvedArtist,
+        artists = listOfNotNull(resolvedArtist),
+        album = resolvedAlbum,
+        audioQuality = audioQuality,
+        explicit = parentalWarning,
+        trackNumber = physicalSupport?.trackNumber,
+        volumeNumber = physicalSupport?.mediaNumber,
+    )
+}
 
 // --- Extension functions for API model → Domain model conversion ---
 

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -3,10 +3,13 @@ package tf.monochrome.android.data.api
 import android.util.Base64
 import android.util.LruCache
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -21,6 +24,12 @@ import tf.monochrome.android.data.api.model.LyricsResponse
 import tf.monochrome.android.data.api.model.ManifestJson
 import tf.monochrome.android.data.api.model.MixResponse
 import tf.monochrome.android.data.api.model.PlaylistResponse
+import tf.monochrome.android.data.api.model.QobuzAlbumItem
+import tf.monochrome.android.data.api.model.QobuzArtistItem
+import tf.monochrome.android.data.api.model.QobuzArtistRef
+import tf.monochrome.android.data.api.model.QobuzDownloadEnvelope
+import tf.monochrome.android.data.api.model.QobuzSearchEnvelope
+import tf.monochrome.android.data.api.model.QobuzTrackItem
 import tf.monochrome.android.data.api.model.RecommendationsResponse
 import tf.monochrome.android.data.api.model.SearchResponse
 import tf.monochrome.android.data.api.model.TrackInfoResponse
@@ -48,7 +57,8 @@ import kotlin.random.Random
 class HiFiApiClient @Inject constructor(
     private val instanceManager: InstanceManager,
     private val httpClient: HttpClient,
-    private val json: Json
+    private val json: Json,
+    private val preferences: tf.monochrome.android.data.preferences.PreferencesManager,
 ) {
     private val cache = LruCache<String, CacheEntry>(200)
 
@@ -189,32 +199,36 @@ class HiFiApiClient @Inject constructor(
         )
     }
 
-    // Qobuz catalog search — hits the user-configured trypt-hifi instance
-    // at GET /api/get-music?q=<query>&offset=<n>. Returns an empty
-    // SearchResult when the instance isn't set, the request times out, or
-    // the response can't be parsed, so the TIDAL search flow is never
-    // blocked by Qobuz state.
+    // Qobuz catalog search — hits the user-configured trypt-hifi instance at
+    // GET /api/get-music?q=<query>&offset=<n>. Response envelope shape is
+    // { success, data: { albums?: { items: [...] }, tracks?: ..., artists?:
+    // ... } }. Whichever section the user's tab targeted is populated; the
+    // others are absent. We accept all three so a single parser works.
     //
-    // The response shape isn't fully documented here — `parseSearchResponse`
-    // already handles wrapped {data:...}, {items:[...]}, and bare arrays, so
-    // most reasonable shapes get mapped to tracks. Albums/artists/playlists
-    // are left empty until the response payload is verified end-to-end.
+    // Returns an empty SearchResult when the instance isn't set, the request
+    // times out, or the response can't be parsed, so the TIDAL search flow
+    // is never blocked by Qobuz state.
     suspend fun searchQobuz(query: String): SearchResult {
         val instance = instanceManager.qobuzInstanceOrNull() ?: return SearchResult()
         val base = instance.url.trimEnd('/')
+        val cookie = preferences.qobuzAuthCookie.first()
 
-        val response = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+        val envelope: QobuzSearchEnvelope? = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
             runCatching {
-                val res = httpClient.get("$base/api/get-music?q=${query.encodeUrl()}&offset=0")
+                val res = httpClient.get("$base/api/get-music?q=${query.encodeUrl()}&offset=0") {
+                    attachQobuzAuth(cookie)
+                }
                 if (!res.status.isSuccess()) return@runCatching null
-                parseSearchResponse(res.bodyAsText())
+                json.decodeFromString<QobuzSearchEnvelope>(res.bodyAsText())
             }.getOrNull()
         } ?: return SearchResult()
 
+        if (!envelope.success || envelope.data == null) return SearchResult()
+        val data = envelope.data
         return SearchResult(
-            tracks = response.items.map { it.toTrack() },
-            albums = emptyList(),
-            artists = emptyList(),
+            tracks = data.tracks?.items?.map { it.toDomainTrack() } ?: emptyList(),
+            albums = data.albums?.items?.map { it.toDomainAlbum() } ?: emptyList(),
+            artists = data.artists?.items?.map { it.toDomainArtist() } ?: emptyList(),
             playlists = emptyList(),
         )
     }
@@ -650,17 +664,40 @@ class HiFiApiClient @Inject constructor(
     private suspend fun resolveQobuzDownloadUrl(trackId: Long, quality: AudioQuality): String? {
         val instance = instanceManager.qobuzInstanceOrNull() ?: return null
         val base = instance.url.trimEnd('/')
+        val cookie = preferences.qobuzAuthCookie.first()
         val code = quality.qobuzCode()
-        val response = httpClient.get("$base/api/download-music?track_id=$trackId&quality=$code")
+        val response = httpClient.get("$base/api/download-music?track_id=$trackId&quality=$code") {
+            attachQobuzAuth(cookie)
+        }
         if (!response.status.isSuccess()) return null
         val body = response.bodyAsText()
-        return extractQobuzFileUrl(body, base)
+        val resolved = extractQobuzFileUrlFromEnvelope(body, base)
+            ?: extractQobuzFileUrl(body, base)
+        return resolved
             // Hi-Res isn't always available on Qobuz — fall back to lossless
             // exactly like the TIDAL path does, instead of failing the
             // download.
             ?: if (quality == AudioQuality.HI_RES) {
                 resolveQobuzDownloadUrl(trackId, AudioQuality.LOSSLESS)
             } else null
+    }
+
+    private fun extractQobuzFileUrlFromEnvelope(body: String, base: String): String? {
+        val parsed = runCatching { json.decodeFromString<QobuzDownloadEnvelope>(body) }.getOrNull()
+            ?: return null
+        if (!parsed.success && parsed.data == null && parsed.url == null
+            && parsed.fileUrl == null && parsed.streamUrl == null && parsed.downloadUrl == null) {
+            return null
+        }
+        val candidate = parsed.url
+            ?: parsed.fileUrl
+            ?: parsed.streamUrl
+            ?: parsed.downloadUrl
+            ?: parsed.data?.url
+            ?: parsed.data?.fileUrl
+            ?: parsed.data?.streamUrl
+            ?: parsed.data?.downloadUrl
+        return candidate?.let { absoluteUrl(it, base) }
     }
 
     // Qobuz exposes four quality codes; map our 4-tier AudioQuality onto them.
@@ -706,7 +743,75 @@ class HiFiApiClient @Inject constructor(
             else -> "$base/api/$value"
         }
     }
+
+    // Attach the user-pinned Qobuz session cookie (Settings → Instances →
+    // Qobuz Auth Cookie) when one is set. The trypt-hifi backend issues a
+    // session cookie at login that the SPA forwards on every /api/ request;
+    // without it the backend 401s. Cookie value should be the raw header
+    // form (one or more "name=value" pairs separated by "; "), as copied
+    // from DevTools → Application → Cookies.
+    private fun HttpRequestBuilder.attachQobuzAuth(rawCookie: String?) {
+        val trimmed = rawCookie?.trim().orEmpty()
+        if (trimmed.isNotEmpty()) {
+            header("Cookie", trimmed)
+        }
+    }
 }
+
+// --- Qobuz item → domain mappers (file-private extensions) -----------------
+
+private fun QobuzAlbumItem.toDomainAlbum(): tf.monochrome.android.domain.model.Album {
+    val resolvedArtist = artist?.toDomainArtistRef()
+    val resolvedArtists = artists.map { it.toDomainArtistRef() }
+    val cover = image?.large ?: image?.small ?: image?.thumbnail
+    val explicit = parentalWarning
+    val typeLabel = if ((tracksCount ?: 0) <= 4) "EP" else "ALBUM"
+    return tf.monochrome.android.domain.model.Album(
+        id = qobuzId ?: id?.hashCode()?.toLong() ?: 0L,
+        title = listOfNotNull(title.takeIf { it.isNotBlank() }, version?.takeIf { it.isNotBlank() })
+            .joinToString(" — "),
+        artist = resolvedArtist,
+        artists = resolvedArtists,
+        numberOfTracks = tracksCount,
+        releaseDate = releaseDateOriginal,
+        cover = cover,
+        explicit = explicit,
+        type = typeLabel,
+        duration = duration,
+    )
+}
+
+private fun QobuzTrackItem.toDomainTrack(): tf.monochrome.android.domain.model.Track {
+    val resolvedAlbum = album?.toDomainAlbum()
+    val resolvedArtist = performer?.toDomainArtistRef()
+    return tf.monochrome.android.domain.model.Track(
+        id = id ?: 0L,
+        title = listOfNotNull(title.takeIf { it.isNotBlank() }, version?.takeIf { it.isNotBlank() })
+            .joinToString(" — "),
+        duration = duration ?: 0,
+        artist = resolvedArtist,
+        artists = listOfNotNull(resolvedArtist),
+        album = resolvedAlbum,
+        audioQuality = if (hires) "HI_RES_LOSSLESS" else if ((maximumBitDepth ?: 0) >= 16) "LOSSLESS" else null,
+        explicit = parentalWarning,
+        trackNumber = trackNumber,
+        volumeNumber = mediaNumber,
+    )
+}
+
+private fun QobuzArtistItem.toDomainArtist(): tf.monochrome.android.domain.model.Artist =
+    tf.monochrome.android.domain.model.Artist(
+        id = id ?: 0L,
+        name = name,
+        picture = image?.large ?: image?.small ?: picture,
+    )
+
+private fun QobuzArtistRef.toDomainArtistRef(): tf.monochrome.android.domain.model.Artist =
+    tf.monochrome.android.domain.model.Artist(
+        id = id ?: 0L,
+        name = name,
+        picture = image?.large ?: image?.small ?: picture,
+    )
 
 // --- Extension functions for API model → Domain model conversion ---
 

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -126,7 +126,28 @@ class HiFiApiClient @Inject constructor(
                         instanceIndex++
                     }
                     response.status.isSuccess() -> {
-                        return response.bodyAsText()
+                        val body = response.bodyAsText()
+                        // Reject HTML payloads — most often the user has Dev
+                        // Mode pointed at a SPA (e.g. trypt-hifi root) that
+                        // serves index.html for any unknown path. Surfacing
+                        // the raw HTML to a JSON parser produces a confusing
+                        // 'Unexpected JSON token at offset 0' error in the
+                        // detail screens; treat it as an instance failure
+                        // and fall through to the next one. Sniff only the
+                        // first non-whitespace char so we don't allocate a
+                        // copy of large bodies just to check.
+                        val sniff = body.asSequence().take(64)
+                            .dropWhile { it.isWhitespace() }
+                            .firstOrNull()
+                        if (sniff == '<') {
+                            lastError = Exception(
+                                "Instance returned HTML instead of JSON " +
+                                    "(check Settings → Instances → Dev Mode URL)"
+                            )
+                            instanceIndex++
+                        } else {
+                            return body
+                        }
                     }
                     else -> {
                         lastError = Exception("HTTP ${response.status.value}")

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -213,7 +213,7 @@ class HiFiApiClient @Inject constructor(
         val base = instance.url.trimEnd('/')
         val cookie = preferences.qobuzAuthCookie.first()
 
-        val envelope: QobuzSearchEnvelope? = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
+        val envelope = withTimeoutOrNull(QOBUZ_REQUEST_TIMEOUT_MS) {
             runCatching {
                 val res = httpClient.get("$base/api/get-music?q=${query.encodeUrl()}&offset=0") {
                     attachQobuzAuth(cookie)

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -661,6 +661,12 @@ class HiFiApiClient @Inject constructor(
     // Step 2 is just a regular byte download, which DownloadWorker already
     // handles. So all we need to do is resolve step 1 and return the URL.
 
+    // Public entry point for callers (DownloadWorker via getTrackStream, the
+    // streaming cache manager, etc.) that need to resolve a Qobuz file URL
+    // without the TIDAL fallthrough getTrackStream(forDownload=true) does.
+    suspend fun getQobuzDownloadUrl(trackId: Long, quality: AudioQuality): String? =
+        resolveQobuzDownloadUrl(trackId, quality)
+
     private suspend fun resolveQobuzDownloadUrl(trackId: Long, quality: AudioQuality): String? {
         val instance = instanceManager.qobuzInstanceOrNull() ?: return null
         val base = instance.url.trimEnd('/')

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -262,7 +262,10 @@ class HiFiApiClient @Inject constructor(
         // also carry an album object — register those slugs too so navigation
         // from a track row resolves correctly.
         data.albums?.items?.forEach { registerAlbumWithRegistry(it) }
-        data.tracks?.items?.forEach { it.album?.let { album -> registerAlbumWithRegistry(album) } }
+        data.tracks?.items?.forEach { item ->
+            item.id?.let { qobuzIdRegistry.registerTrack(it) }
+            item.album?.let { album -> registerAlbumWithRegistry(album) }
+        }
         data.artists?.items?.forEach { item -> item.id?.let { qobuzIdRegistry.registerArtist(it) } }
 
         return SearchResult(
@@ -301,6 +304,10 @@ class HiFiApiClient @Inject constructor(
         registerAlbumWithRegistry(albumItem)
         val album = albumItem.toDomainAlbum()
         val tracks = albumItem.tracks?.items?.map { item ->
+            // Tag every track id as Qobuz so PlayerViewModel.resolveAndPlay
+            // routes it through the QobuzCached path rather than the TIDAL
+            // streaming fallback.
+            item.id?.let { qobuzIdRegistry.registerTrack(it) }
             // Detail responses don't repeat the album object inside each track
             // — provide it explicitly so playback / display has full context.
             item.toDomainTrack(fallbackAlbum = album)
@@ -341,7 +348,12 @@ class HiFiApiClient @Inject constructor(
 
         // Register top_track album slugs so clicking through to an album
         // from the artist screen still resolves via QobuzIdRegistry.
-        raw.topTracks.forEach { it.album?.let { album -> registerAlbumWithRegistry(album) } }
+        // Also tag each top_track id as Qobuz so playback routes through
+        // QobuzCached instead of falling through to TIDAL streaming.
+        raw.topTracks.forEach { topTrack ->
+            topTrack.id?.let { qobuzIdRegistry.registerTrack(it) }
+            topTrack.album?.let { album -> registerAlbumWithRegistry(album) }
+        }
 
         val artist = Artist(
             id = raw.id ?: artistId,

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -177,6 +177,28 @@ class HiFiApiClient @Inject constructor(
         )
     }
 
+    // Qobuz catalog search — hits the user-configured Qobuz instance via
+    // InstanceType.DOWNLOAD (same pool used for downloads). Returns an empty
+    // SearchResult when the instance isn't set or the request fails, so the
+    // TIDAL search flow keeps working even if the Qobuz endpoint is offline.
+    suspend fun searchQobuz(query: String): SearchResult {
+        suspend fun parsedSearch(path: String) =
+            runCatching {
+                val body = fetchWithRetry(path, instanceType = InstanceType.DOWNLOAD)
+                parseSearchResponse(body)
+            }.getOrNull()
+
+        val tracks = parsedSearch("/search/?s=${query.encodeUrl()}")?.items?.map { it.toTrack() }
+            ?: emptyList()
+        val albums = parsedSearch("/search/?al=${query.encodeUrl()}")?.items?.map { it.toAlbum() }
+            ?: emptyList()
+        val artists = parsedSearch("/search/?a=${query.encodeUrl()}")?.items?.map { it.toArtist() }
+            ?: emptyList()
+        val playlists = parsedSearch("/search/?p=${query.encodeUrl()}")?.items?.map { it.toPlaylist() }
+            ?: emptyList()
+        return SearchResult(tracks = tracks, albums = albums, artists = artists, playlists = playlists)
+    }
+
     // --- Album ---
 
     suspend fun getAlbum(albumId: Long): AlbumDetail {

--- a/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/HiFiApiClient.kt
@@ -335,10 +335,14 @@ class HiFiApiClient @Inject constructor(
 
     // --- Streaming ---
 
-    suspend fun getTrackStream(trackId: Long, quality: AudioQuality): TrackStream {
+    suspend fun getTrackStream(
+        trackId: Long,
+        quality: AudioQuality,
+        forDownload: Boolean = false
+    ): TrackStream {
         val body = fetchWithRetry(
             "/track/?id=$trackId&quality=${quality.apiValue}",
-            instanceType = InstanceType.STREAMING
+            instanceType = if (forDownload) InstanceType.DOWNLOAD else InstanceType.STREAMING
         )
         val streamResponse = json.decodeFromString<TrackStreamResponse>(unwrapResponse(body))
 
@@ -348,7 +352,7 @@ class HiFiApiClient @Inject constructor(
         if (streamUrl == null) {
             // Fallback to lower quality
             if (quality == AudioQuality.HI_RES) {
-                return getTrackStream(trackId, AudioQuality.LOSSLESS)
+                return getTrackStream(trackId, AudioQuality.LOSSLESS, forDownload)
             }
             throw Exception("Could not extract stream URL for track $trackId")
         }

--- a/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
@@ -127,6 +127,16 @@ class InstanceManager @Inject constructor(
         }
     }
 
+    // Strict resolution of the configured Qobuz instance — null when unset.
+    // Unlike getInstances(DOWNLOAD), this never falls back to the TIDAL pool,
+    // so callers like Qobuz-only search don't accidentally duplicate TIDAL
+    // results when the user hasn't configured a Qobuz endpoint.
+    suspend fun qobuzInstanceOrNull(): Instance? {
+        val raw = preferences.qobuzInstanceUrl.first()?.trim()?.takeIf { it.isNotBlank() }
+            ?: return null
+        return Instance(raw.trimEnd('/'))
+    }
+
     private fun isCacheValid(): Boolean {
         return System.currentTimeMillis() - cacheTimestamp < CACHE_DURATION_MS
     }

--- a/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import tf.monochrome.android.BuildConfig
 import tf.monochrome.android.data.preferences.PreferencesManager
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -48,16 +47,6 @@ class InstanceManager @Inject constructor(
             Instance("https://hifi.geeked.wtf"),
             Instance("https://monochrome-api.samidy.com"),
         )
-
-        // Optional project-private download source, configured per-build via
-        // local.properties (`download.instance.url`). When unset, this list is
-        // empty and downloads transparently fall back to the public streaming
-        // pool — so OSS contributors don't need the private endpoint to build.
-        private val DOWNLOAD_INSTANCES: List<Instance> =
-            BuildConfig.DOWNLOAD_INSTANCE_URL
-                .takeIf { it.isNotBlank() }
-                ?.let { listOf(Instance(it)) }
-                ?: emptyList()
     }
 
     private var cachedApiInstances: List<Instance>? = null
@@ -65,11 +54,14 @@ class InstanceManager @Inject constructor(
     private var cacheTimestamp: Long = 0L
 
     suspend fun getInstances(type: InstanceType): List<Instance> {
-        // Downloads pin to the per-build private instance when configured; skip
-        // uptime resolution and Dev Mode overrides so the source can't drift.
-        // If unconfigured, fall through and serve the public streaming pool.
-        if (type == InstanceType.DOWNLOAD && DOWNLOAD_INSTANCES.isNotEmpty()) {
-            return DOWNLOAD_INSTANCES
+        // Downloads pin to the user-configured Qobuz instance (Settings →
+        // Instances → Qobuz URL) when set, regardless of Dev Mode. If unset,
+        // fall through and serve the public streaming pool.
+        if (type == InstanceType.DOWNLOAD) {
+            val qobuz = preferences.qobuzInstanceUrl.first()?.trim()?.takeIf { it.isNotBlank() }
+            if (qobuz != null) {
+                return listOf(Instance(qobuz.trimEnd('/')))
+            }
         }
         val effectiveType = if (type == InstanceType.DOWNLOAD) InstanceType.STREAMING else type
 

--- a/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/InstanceManager.kt
@@ -11,11 +11,12 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import tf.monochrome.android.BuildConfig
 import tf.monochrome.android.data.preferences.PreferencesManager
 import javax.inject.Inject
 import javax.inject.Singleton
 
-enum class InstanceType { API, STREAMING }
+enum class InstanceType { API, STREAMING, DOWNLOAD }
 
 data class Instance(
     val url: String,
@@ -47,6 +48,16 @@ class InstanceManager @Inject constructor(
             Instance("https://hifi.geeked.wtf"),
             Instance("https://monochrome-api.samidy.com"),
         )
+
+        // Optional project-private download source, configured per-build via
+        // local.properties (`download.instance.url`). When unset, this list is
+        // empty and downloads transparently fall back to the public streaming
+        // pool — so OSS contributors don't need the private endpoint to build.
+        private val DOWNLOAD_INSTANCES: List<Instance> =
+            BuildConfig.DOWNLOAD_INSTANCE_URL
+                .takeIf { it.isNotBlank() }
+                ?.let { listOf(Instance(it)) }
+                ?: emptyList()
     }
 
     private var cachedApiInstances: List<Instance>? = null
@@ -54,6 +65,14 @@ class InstanceManager @Inject constructor(
     private var cacheTimestamp: Long = 0L
 
     suspend fun getInstances(type: InstanceType): List<Instance> {
+        // Downloads pin to the per-build private instance when configured; skip
+        // uptime resolution and Dev Mode overrides so the source can't drift.
+        // If unconfigured, fall through and serve the public streaming pool.
+        if (type == InstanceType.DOWNLOAD && DOWNLOAD_INSTANCES.isNotEmpty()) {
+            return DOWNLOAD_INSTANCES
+        }
+        val effectiveType = if (type == InstanceType.DOWNLOAD) InstanceType.STREAMING else type
+
         // Dev Mode: route all requests through the user-specified custom endpoint.
         // When disabled, ignore any saved URL and fall through to the normal
         // instance resolution so stale overrides don't silently redirect traffic.
@@ -66,9 +85,10 @@ class InstanceManager @Inject constructor(
 
         // Check memory cache
         if (isCacheValid()) {
-            val cached = when (type) {
+            val cached = when (effectiveType) {
                 InstanceType.API -> cachedApiInstances
                 InstanceType.STREAMING -> cachedStreamingInstances
+                InstanceType.DOWNLOAD -> null
             }
             if (!cached.isNullOrEmpty()) return cached.shuffled()
         }
@@ -78,9 +98,10 @@ class InstanceManager @Inject constructor(
         val storedTimestamp = preferences.instancesCacheTimestamp.first()
         if (storedCache != null && System.currentTimeMillis() - storedTimestamp < CACHE_DURATION_MS) {
             parseAndCacheInstances(storedCache)
-            val cached = when (type) {
+            val cached = when (effectiveType) {
                 InstanceType.API -> cachedApiInstances
                 InstanceType.STREAMING -> cachedStreamingInstances
+                InstanceType.DOWNLOAD -> null
             }
             if (!cached.isNullOrEmpty()) return cached.shuffled()
         }
@@ -90,17 +111,19 @@ class InstanceManager @Inject constructor(
         if (fetched != null) {
             parseAndCacheInstances(fetched)
             preferences.saveInstancesCache(fetched)
-            val cached = when (type) {
+            val cached = when (effectiveType) {
                 InstanceType.API -> cachedApiInstances
                 InstanceType.STREAMING -> cachedStreamingInstances
+                InstanceType.DOWNLOAD -> null
             }
             if (!cached.isNullOrEmpty()) return cached.shuffled()
         }
 
         // Fallback to hardcoded instances
-        return when (type) {
+        return when (effectiveType) {
             InstanceType.API -> FALLBACK_API_INSTANCES.shuffled()
             InstanceType.STREAMING -> FALLBACK_STREAMING_INSTANCES.shuffled()
+            InstanceType.DOWNLOAD -> emptyList()
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/api/LrcLibClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/LrcLibClient.kt
@@ -1,0 +1,133 @@
+package tf.monochrome.android.data.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import tf.monochrome.android.domain.model.LyricLine
+import tf.monochrome.android.domain.model.Lyrics
+import tf.monochrome.android.util.RomajiConverter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * LRCLib (https://lrclib.net) — open, no-auth lyrics API. Used as a fallback
+ * when the primary TIDAL `/lyrics` endpoint returns 404, which happens
+ * frequently for older / niche / non-Western tracks.
+ *
+ * Two endpoints used:
+ *   1. /api/get?track_name=&artist_name=&album_name=&duration= — exact match.
+ *      Requires all four params; LRCLib 404s if any disagrees.
+ *   2. /api/search?track_name=&artist_name= — fuzzy match, returns array.
+ *      Used when album/duration aren't known.
+ *
+ * Response carries either `syncedLyrics` (LRC `[mm:ss.cs]text` per line) or
+ * `plainLyrics` (newline-delimited unsynced text). We prefer the synced
+ * variant; if absent, fall back to plain.
+ */
+@Singleton
+class LrcLibClient @Inject constructor(
+    private val httpClient: HttpClient,
+    private val json: Json,
+) {
+    suspend fun lookup(
+        title: String,
+        artist: String,
+        album: String? = null,
+        durationSeconds: Int? = null,
+        convertToRomaji: Boolean = false,
+    ): Lyrics? {
+        if (title.isBlank() || artist.isBlank()) return null
+
+        // Prefer /api/get when all the exact-match params are available;
+        // fall back to /api/search for fuzzy matches.
+        val exact = if (!album.isNullOrBlank() && durationSeconds != null && durationSeconds > 0) {
+            tryGet(title, artist, album, durationSeconds)
+        } else null
+        val item = exact ?: trySearch(title, artist) ?: return null
+
+        return parseLyricsRecord(item, convertToRomaji)
+    }
+
+    private suspend fun tryGet(title: String, artist: String, album: String, durationSeconds: Int): LrcLibRecord? {
+        val url = buildString {
+            append("$BASE_URL/api/get?")
+            append("track_name=").append(title.urlEncode())
+            append("&artist_name=").append(artist.urlEncode())
+            append("&album_name=").append(album.urlEncode())
+            append("&duration=").append(durationSeconds)
+        }
+        return fetchJson<LrcLibRecord>(url)
+    }
+
+    private suspend fun trySearch(title: String, artist: String): LrcLibRecord? {
+        val url = buildString {
+            append("$BASE_URL/api/search?")
+            append("track_name=").append(title.urlEncode())
+            append("&artist_name=").append(artist.urlEncode())
+        }
+        return fetchJson<List<LrcLibRecord>>(url)
+            ?.firstOrNull { !it.syncedLyrics.isNullOrBlank() || !it.plainLyrics.isNullOrBlank() }
+    }
+
+    private suspend inline fun <reified T> fetchJson(url: String): T? {
+        return withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
+            runCatching {
+                val resp = httpClient.get(url) {
+                    header("User-Agent", "MonoTrypT/1.0 (https://github.com/tryptz/monotrypt.android)")
+                }
+                if (!resp.status.isSuccess()) return@runCatching null
+                json.decodeFromString<T>(resp.bodyAsText())
+            }.getOrNull()
+        }
+    }
+
+    private fun parseLyricsRecord(record: LrcLibRecord, convertToRomaji: Boolean): Lyrics? {
+        // Synced first — LRC `[mm:ss.cs]text` lines map cleanly to LyricLine.
+        record.syncedLyrics?.takeIf { it.isNotBlank() }?.let { synced ->
+            val lines = mutableListOf<LyricLine>()
+            val regex = Regex("\\[(\\d+):(\\d+\\.\\d+)](.*)")
+            synced.split('\n').forEach { rawLine ->
+                regex.find(rawLine)?.let { match ->
+                    val minutes = match.groupValues[1].toLongOrNull() ?: 0
+                    val seconds = match.groupValues[2].toDoubleOrNull() ?: 0.0
+                    val timeMs = (minutes * 60 * 1000) + (seconds * 1000).toLong()
+                    var text = match.groupValues[3].trim()
+                    if (convertToRomaji) text = RomajiConverter.convert(text)
+                    if (text.isNotBlank()) lines.add(LyricLine(timeMs, text))
+                }
+            }
+            if (lines.isNotEmpty()) return Lyrics(lines = lines, isSynced = true)
+        }
+        record.plainLyrics?.takeIf { it.isNotBlank() }?.let { plain ->
+            val text = if (convertToRomaji) RomajiConverter.convert(plain) else plain
+            val lines = text.split('\n').map { LyricLine(0L, it) }
+            return Lyrics(lines = lines, isSynced = false)
+        }
+        return null
+    }
+
+    private fun String.urlEncode(): String = java.net.URLEncoder.encode(this, "UTF-8")
+
+    companion object {
+        private const val BASE_URL = "https://lrclib.net"
+        private const val REQUEST_TIMEOUT_MS = 6_000L
+    }
+}
+
+@Serializable
+private data class LrcLibRecord(
+    val id: Long? = null,
+    @SerialName("trackName") val trackName: String? = null,
+    @SerialName("artistName") val artistName: String? = null,
+    @SerialName("albumName") val albumName: String? = null,
+    val duration: Double? = null,
+    val instrumental: Boolean = false,
+    @SerialName("plainLyrics") val plainLyrics: String? = null,
+    @SerialName("syncedLyrics") val syncedLyrics: String? = null,
+)

--- a/app/src/main/java/tf/monochrome/android/data/api/QobuzIdRegistry.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/QobuzIdRegistry.kt
@@ -1,0 +1,44 @@
+package tf.monochrome.android.data.api
+
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory registry that records which numeric ids the app has seen come
+ * out of the trypt-hifi (Qobuz) API.
+ *
+ * Why this exists: the navigation routes for AlbumDetail / ArtistDetail are
+ * keyed by `Long`, but Qobuz's album-detail endpoint
+ * (/api/get-album?album_id=<id>) takes the alphanumeric slug ("fr2agovnqpeka")
+ * — not the numeric `qobuz_id`. We don't want to widen Album.id to String
+ * across the whole app, so we record (qobuz_id -> slug) at search time and
+ * the detail VM looks the slug back up at navigation time.
+ *
+ * Artist ids are already numeric on both ends; the artist set is only used
+ * as a "this id came from Qobuz, don't try TIDAL first" hint.
+ *
+ * Lifecycle: process-scoped. Entries persist until process death. A user
+ * who searches for an album, swipes away the app, then deep-links to the
+ * detail screen would lose the Qobuz slug — but the existing flow always
+ * navigates from a freshly-populated search list, so the gap isn't
+ * reachable in practice.
+ */
+@Singleton
+class QobuzIdRegistry @Inject constructor() {
+    private val albumSlugs = ConcurrentHashMap<Long, String>()
+    private val qobuzArtistIds: MutableSet<Long> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+
+    fun registerAlbum(qobuzId: Long, slug: String) {
+        if (slug.isBlank()) return
+        albumSlugs[qobuzId] = slug
+    }
+
+    fun albumSlugFor(qobuzId: Long): String? = albumSlugs[qobuzId]
+
+    fun registerArtist(id: Long) {
+        qobuzArtistIds.add(id)
+    }
+
+    fun isQobuzArtist(id: Long): Boolean = id in qobuzArtistIds
+}

--- a/app/src/main/java/tf/monochrome/android/data/api/QobuzIdRegistry.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/QobuzIdRegistry.kt
@@ -28,6 +28,11 @@ import javax.inject.Singleton
 class QobuzIdRegistry @Inject constructor() {
     private val albumSlugs = ConcurrentHashMap<Long, String>()
     private val qobuzArtistIds: MutableSet<Long> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+    // Set of track ids we know to be Qobuz. PlayerViewModel.resolveAndPlay
+    // consults this so a Qobuz-album track row plays via the QobuzCached
+    // path instead of falling through to TIDAL streaming with a Qobuz id
+    // that TIDAL either doesn't have or maps to a different track.
+    private val qobuzTrackIds: MutableSet<Long> = java.util.concurrent.ConcurrentHashMap.newKeySet()
 
     fun registerAlbum(qobuzId: Long, slug: String) {
         if (slug.isBlank()) return
@@ -41,4 +46,10 @@ class QobuzIdRegistry @Inject constructor() {
     }
 
     fun isQobuzArtist(id: Long): Boolean = id in qobuzArtistIds
+
+    fun registerTrack(id: Long) {
+        qobuzTrackIds.add(id)
+    }
+
+    fun isQobuzTrack(id: Long): Boolean = id in qobuzTrackIds
 }

--- a/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
@@ -69,6 +69,121 @@ data class QobuzAlbumDetailEnvelope(
     val data: QobuzAlbumItem? = null,
 )
 
+// ---------------------------------------------------------------------------
+// Artist-detail response shape (/api/get-artist?artist_id=<numeric>)
+//
+// Notably different from search/album responses:
+//   - name is a nested object {display: "..."} instead of a plain string
+//   - image is {portrait: {hash, format}} — URL has to be constructed:
+//     https://static.qobuz.com/images/artists/covers/<size>/<hash>.<format>
+//   - top_tracks is a flat array, NOT a paginated {items: [...]} structure
+//   - track entries inside top_tracks use rights/physical_support/audio_info
+//     wrappers instead of flat boolean fields
+//   - similar_artists has {has_more, items: [...]} structure
+@Serializable
+data class QobuzArtistDetailEnvelope(
+    val success: Boolean = false,
+    val data: QobuzArtistDetailData? = null,
+)
+
+@Serializable
+data class QobuzArtistDetailData(
+    val artist: QobuzArtistDetail? = null,
+)
+
+@Serializable
+data class QobuzArtistDetail(
+    val id: Long? = null,
+    val name: QobuzDisplayName? = null,
+    @SerialName("artist_category") val artistCategory: String? = null,
+    val biography: QobuzBiography? = null,
+    val images: QobuzArtistImages? = null,
+    @SerialName("similar_artists") val similarArtists: QobuzSimilarArtists? = null,
+    @SerialName("top_tracks") val topTracks: List<QobuzArtistTopTrack> = emptyList(),
+)
+
+@Serializable
+data class QobuzDisplayName(
+    val display: String? = null,
+)
+
+@Serializable
+data class QobuzBiography(
+    val content: String? = null,
+    val source: String? = null,
+    val language: String? = null,
+)
+
+@Serializable
+data class QobuzArtistImages(
+    val portrait: QobuzImageHash? = null,
+)
+
+@Serializable
+data class QobuzImageHash(
+    val hash: String? = null,
+    val format: String? = null,
+)
+
+@Serializable
+data class QobuzSimilarArtists(
+    @SerialName("has_more") val hasMore: Boolean = false,
+    val items: List<QobuzSimilarArtist> = emptyList(),
+)
+
+@Serializable
+data class QobuzSimilarArtist(
+    val id: Long? = null,
+    val name: QobuzDisplayName? = null,
+    val images: QobuzArtistImages? = null,
+)
+
+@Serializable
+data class QobuzArtistTopTrack(
+    val id: Long? = null,
+    val isrc: String? = null,
+    val title: String = "",
+    val version: String? = null,
+    val duration: Int? = null,
+    @SerialName("parental_warning") val parentalWarning: Boolean = false,
+    val composer: QobuzNamedRef? = null,
+    val artist: QobuzNamedRef? = null,
+    @SerialName("audio_info") val audioInfo: QobuzAudioSpec? = null,
+    val rights: QobuzTrackRights? = null,
+    @SerialName("physical_support") val physicalSupport: QobuzPhysicalSupport? = null,
+    val album: QobuzAlbumItem? = null,
+)
+
+@Serializable
+data class QobuzNamedRef(
+    val id: Long? = null,
+    val name: QobuzDisplayName? = null,
+)
+
+@Serializable
+data class QobuzAudioSpec(
+    @SerialName("maximum_bit_depth") val maximumBitDepth: Int? = null,
+    @SerialName("maximum_channel_count") val maximumChannelCount: Int? = null,
+    @SerialName("maximum_sampling_rate") val maximumSamplingRate: Double? = null,
+)
+
+@Serializable
+data class QobuzTrackRights(
+    val streamable: Boolean = false,
+    @SerialName("hires_streamable") val hiresStreamable: Boolean = false,
+    @SerialName("hires_purchasable") val hiresPurchasable: Boolean = false,
+    val purchasable: Boolean = false,
+    val downloadable: Boolean = false,
+    val previewable: Boolean = false,
+    val sampleable: Boolean = false,
+)
+
+@Serializable
+data class QobuzPhysicalSupport(
+    @SerialName("media_number") val mediaNumber: Int? = null,
+    @SerialName("track_number") val trackNumber: Int? = null,
+)
+
 @Serializable
 data class QobuzTrackItem(
     val id: Long? = null,

--- a/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
@@ -1,0 +1,147 @@
+package tf.monochrome.android.data.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Response shape for the trypt-hifi (Qobuz) instance, captured from a real
+// /api/get-music?q=... call. Top-level envelope is { success, data: { query,
+// albums?, tracks?, artists? } } where each section paginates its own items.
+// Only the section relevant to the user's active tab is populated; the others
+// are absent. We accept all three on the same envelope so a single parser
+// works regardless of which tab was searched.
+@Serializable
+data class QobuzSearchEnvelope(
+    val success: Boolean = false,
+    val data: QobuzSearchData? = null,
+)
+
+@Serializable
+data class QobuzSearchData(
+    val query: String? = null,
+    val albums: QobuzPaginated<QobuzAlbumItem>? = null,
+    val tracks: QobuzPaginated<QobuzTrackItem>? = null,
+    val artists: QobuzPaginated<QobuzArtistItem>? = null,
+)
+
+@Serializable
+data class QobuzPaginated<T>(
+    val limit: Int? = null,
+    val offset: Int? = null,
+    val total: Int? = null,
+    val items: List<T> = emptyList(),
+)
+
+@Serializable
+data class QobuzAlbumItem(
+    val id: String? = null,                // alphanumeric slug (e.g. "h8lxgr12m97wc")
+    @SerialName("qobuz_id") val qobuzId: Long? = null,  // numeric id used by /api/download-music
+    val title: String = "",
+    val version: String? = null,
+    val artist: QobuzArtistRef? = null,
+    val artists: List<QobuzArtistRef> = emptyList(),
+    val image: QobuzImage? = null,
+    val duration: Int? = null,
+    @SerialName("tracks_count") val tracksCount: Int? = null,
+    @SerialName("release_date_original") val releaseDateOriginal: String? = null,
+    @SerialName("parental_warning") val parentalWarning: Boolean = false,
+    val downloadable: Boolean = true,
+    val streamable: Boolean = true,
+    val hires: Boolean = false,
+    @SerialName("hires_streamable") val hiresStreamable: Boolean = false,
+    @SerialName("maximum_bit_depth") val maximumBitDepth: Int? = null,
+    @SerialName("maximum_sampling_rate") val maximumSamplingRate: Double? = null,
+    val genre: QobuzGenre? = null,
+    val label: QobuzLabel? = null,
+    val upc: String? = null,
+    val url: String? = null,
+)
+
+@Serializable
+data class QobuzTrackItem(
+    val id: Long? = null,
+    val title: String = "",
+    val version: String? = null,
+    val duration: Int? = null,
+    @SerialName("track_number") val trackNumber: Int? = null,
+    @SerialName("media_number") val mediaNumber: Int? = null,
+    val performer: QobuzArtistRef? = null,
+    val composer: QobuzArtistRef? = null,
+    val album: QobuzAlbumItem? = null,
+    @SerialName("parental_warning") val parentalWarning: Boolean = false,
+    val downloadable: Boolean = true,
+    val streamable: Boolean = true,
+    val hires: Boolean = false,
+    @SerialName("maximum_bit_depth") val maximumBitDepth: Int? = null,
+    @SerialName("maximum_sampling_rate") val maximumSamplingRate: Double? = null,
+    @SerialName("isrc") val isrc: String? = null,
+)
+
+@Serializable
+data class QobuzArtistItem(
+    val id: Long? = null,
+    val name: String = "",
+    val slug: String? = null,
+    val image: QobuzImage? = null,
+    val picture: String? = null,
+    @SerialName("albums_count") val albumsCount: Int? = null,
+)
+
+@Serializable
+data class QobuzArtistRef(
+    val id: Long? = null,
+    val name: String = "",
+    val slug: String? = null,
+    val image: QobuzImage? = null,
+    val picture: String? = null,
+    val roles: List<String> = emptyList(),
+    @SerialName("albums_count") val albumsCount: Int? = null,
+)
+
+@Serializable
+data class QobuzImage(
+    val small: String? = null,
+    val thumbnail: String? = null,
+    val large: String? = null,
+    val back: String? = null,
+)
+
+@Serializable
+data class QobuzGenre(
+    val id: Int? = null,
+    val name: String? = null,
+    val slug: String? = null,
+)
+
+@Serializable
+data class QobuzLabel(
+    val id: Long? = null,
+    val name: String? = null,
+    val slug: String? = null,
+)
+
+// Response shape for /api/download-music?track_id=...&quality=...
+// Captured response is small (~0.2 KB) and contains a per-request HMAC-signed
+// stream URL. Field name hasn't been confirmed yet, so the parser tries
+// several common keys; this model covers the one most likely to match.
+@Serializable
+data class QobuzDownloadEnvelope(
+    val success: Boolean = false,
+    val data: QobuzDownloadData? = null,
+    // Some hifi-api forks emit the URL at the top level instead of under data.
+    val url: String? = null,
+    @SerialName("file_url") val fileUrl: String? = null,
+    @SerialName("stream_url") val streamUrl: String? = null,
+    @SerialName("download_url") val downloadUrl: String? = null,
+)
+
+@Serializable
+data class QobuzDownloadData(
+    val url: String? = null,
+    @SerialName("file_url") val fileUrl: String? = null,
+    @SerialName("stream_url") val streamUrl: String? = null,
+    @SerialName("download_url") val downloadUrl: String? = null,
+    val format: String? = null,
+    val mime_type: String? = null,
+    val sampling_rate: Double? = null,
+    val bit_depth: Int? = null,
+)

--- a/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
@@ -54,6 +54,19 @@ data class QobuzAlbumItem(
     val label: QobuzLabel? = null,
     val upc: String? = null,
     val url: String? = null,
+    // Album-detail responses (/api/get-album?album_id=) embed the track list
+    // here. Search responses leave it null — ignoreUnknownKeys drops the
+    // detail-only fields like description, awards, track_ids, etc.
+    val tracks: QobuzPaginated<QobuzTrackItem>? = null,
+    val description: String? = null,
+)
+
+// Detail envelope — wraps the same QobuzAlbumItem shape (now with `tracks`
+// populated) under the standard {success, data: …} response.
+@Serializable
+data class QobuzAlbumDetailEnvelope(
+    val success: Boolean = false,
+    val data: QobuzAlbumItem? = null,
 )
 
 @Serializable

--- a/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/model/QobuzModels.kt
@@ -64,16 +64,38 @@ data class QobuzTrackItem(
     val duration: Int? = null,
     @SerialName("track_number") val trackNumber: Int? = null,
     @SerialName("media_number") val mediaNumber: Int? = null,
-    val performer: QobuzArtistRef? = null,
-    val composer: QobuzArtistRef? = null,
+    // Real response uses "performer" as a single object {id, name} for the
+    // primary credited artist on a track. There's also "performers" (string)
+    // and "composer" (single object) which we keep optional.
+    val performer: QobuzPerson? = null,
+    val composer: QobuzPerson? = null,
+    val performers: String? = null,
     val album: QobuzAlbumItem? = null,
+    @SerialName("audio_info") val audioInfo: QobuzTrackAudioInfo? = null,
     @SerialName("parental_warning") val parentalWarning: Boolean = false,
     val downloadable: Boolean = true,
     val streamable: Boolean = true,
     val hires: Boolean = false,
+    @SerialName("hires_streamable") val hiresStreamable: Boolean = false,
     @SerialName("maximum_bit_depth") val maximumBitDepth: Int? = null,
     @SerialName("maximum_sampling_rate") val maximumSamplingRate: Double? = null,
-    @SerialName("isrc") val isrc: String? = null,
+    val isrc: String? = null,
+)
+
+// Lightweight credit (track-level performer/composer). Response uses just
+// {id, name} here, distinct from the richer QobuzArtistRef on albums.
+@Serializable
+data class QobuzPerson(
+    val id: Long? = null,
+    val name: String = "",
+)
+
+@Serializable
+data class QobuzTrackAudioInfo(
+    @SerialName("replaygain_track_gain") val replayGainTrackGain: Float? = null,
+    @SerialName("replaygain_track_peak") val replayGainTrackPeak: Float? = null,
+    @SerialName("replaygain_album_gain") val replayGainAlbumGain: Float? = null,
+    @SerialName("replaygain_album_peak") val replayGainAlbumPeak: Float? = null,
 )
 
 @Serializable
@@ -97,12 +119,18 @@ data class QobuzArtistRef(
     @SerialName("albums_count") val albumsCount: Int? = null,
 )
 
+// Album covers: small/thumbnail/large/back. Artist images: small/medium/
+// large/extralarge/mega. Both are accepted on the same type because
+// ignoreUnknownKeys = true silently drops the missing fields per source.
 @Serializable
 data class QobuzImage(
     val small: String? = null,
     val thumbnail: String? = null,
     val large: String? = null,
     val back: String? = null,
+    val medium: String? = null,
+    val extralarge: String? = null,
+    val mega: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/tf/monochrome/android/data/cache/QobuzStreamCacheManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/cache/QobuzStreamCacheManager.kt
@@ -1,0 +1,144 @@
+package tf.monochrome.android.data.cache
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import tf.monochrome.android.data.api.HiFiApiClient
+import tf.monochrome.android.domain.model.AudioQuality
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Qobuz playback cache.
+ *
+ * Pre-fetches the full audio file via HiFiApiClient.getQobuzDownloadUrl on the
+ * first request for a (trackId, quality) pair, writes it atomically into the
+ * app cache directory, and serves the same File on subsequent requests so
+ * ExoPlayer can play from local disk. Cache is bounded by total size with
+ * mtime-LRU eviction.
+ *
+ * Why pre-fetch instead of progressive streaming: the URL the backend returns
+ * is HMAC-signed with a time-bounded `etsp` parameter, so a long-running
+ * progressive read can race the signature window. Downloading the whole file
+ * up front is more reliable, and the second play is instant since it serves
+ * from disk.
+ */
+@Singleton
+class QobuzStreamCacheManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val httpClient: HttpClient,
+    private val apiClient: HiFiApiClient,
+) {
+    private val cacheDir: File by lazy {
+        File(context.cacheDir, CACHE_DIR_NAME).also { if (!it.exists()) it.mkdirs() }
+    }
+
+    // Per-key mutex map so concurrent plays of the same track don't double-fetch.
+    // Guarded by [locksMutex] so the map itself isn't a race.
+    private val locks = HashMap<String, Mutex>()
+    private val locksMutex = Mutex()
+
+    /**
+     * Returns the local cache file for [qobuzId] at [quality], fetching it
+     * over the network on first request. Returns null when the Qobuz instance
+     * isn't configured or the network fetch fails — callers should treat null
+     * as "playback unavailable" and surface an error.
+     *
+     * Suspends until the file is fully written; expect this to take seconds
+     * for typical FLAC payloads. Caller should drive this from the IO
+     * dispatcher (we already withContext(IO) internally for the file work).
+     */
+    suspend fun getOrFetch(qobuzId: Long, quality: AudioQuality): File? = withContext(Dispatchers.IO) {
+        val key = cacheKey(qobuzId, quality)
+        val target = File(cacheDir, "$key.bin")
+        if (isComplete(target)) {
+            // Touch for LRU; ignore failures, mtime is just a hint.
+            target.setLastModified(System.currentTimeMillis())
+            return@withContext target
+        }
+
+        val lock = locksMutex.withLock { locks.getOrPut(key) { Mutex() } }
+        try {
+            lock.withLock {
+                // Re-check inside the lock — another caller may have completed
+                // the fetch while we were waiting.
+                if (isComplete(target)) {
+                    target.setLastModified(System.currentTimeMillis())
+                    return@withLock target
+                }
+                fetchInto(qobuzId, quality, target)
+            }
+        } finally {
+            locksMutex.withLock { locks.remove(key) }
+        }
+    }
+
+    private suspend fun fetchInto(qobuzId: Long, quality: AudioQuality, target: File): File? {
+        val url = apiClient.getQobuzDownloadUrl(qobuzId, quality) ?: return null
+        evictIfNeeded()
+
+        val temp = File(cacheDir, "${target.name}.tmp").also { if (it.exists()) it.delete() }
+        return try {
+            val response = httpClient.get(url)
+            if (!response.status.isSuccess()) {
+                temp.delete()
+                return null
+            }
+            val channel = response.bodyAsChannel()
+            val buffer = ByteArray(BUFFER_BYTES)
+            temp.outputStream().use { out ->
+                while (!channel.isClosedForRead) {
+                    val read = channel.readAvailable(buffer)
+                    if (read <= 0) break
+                    out.write(buffer, 0, read)
+                }
+            }
+            // Atomic install. If rename fails (e.g. cross-mount), fall back to
+            // copying the bytes and removing the temp file.
+            if (!temp.renameTo(target)) {
+                target.writeBytes(temp.readBytes())
+                temp.delete()
+            }
+            target.setLastModified(System.currentTimeMillis())
+            target
+        } catch (_: Exception) {
+            temp.delete()
+            null
+        }
+    }
+
+    /** Trim the cache to [MAX_BYTES] by deleting the oldest .bin entries. */
+    private fun evictIfNeeded() {
+        val files = cacheDir.listFiles()?.filter { it.isFile && it.name.endsWith(".bin") }
+            ?: return
+        var total = files.sumOf { it.length() }
+        if (total < MAX_BYTES) return
+        for (file in files.sortedBy { it.lastModified() }) {
+            if (total < MAX_BYTES) break
+            val size = file.length()
+            if (file.delete()) total -= size
+        }
+    }
+
+    private fun isComplete(file: File): Boolean = file.exists() && file.length() > 0
+
+    private fun cacheKey(qobuzId: Long, quality: AudioQuality): String = "${qobuzId}_${quality.name}"
+
+    companion object {
+        private const val CACHE_DIR_NAME = "qobuz_stream"
+        private const val BUFFER_BYTES = 16 * 1024
+        // 1 GiB ceiling matches what most music apps spend on transient
+        // playback caches; the OS may also evict under storage pressure since
+        // we live under context.cacheDir.
+        private const val MAX_BYTES: Long = 1L * 1024 * 1024 * 1024
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/cache/QobuzStreamCacheManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/cache/QobuzStreamCacheManager.kt
@@ -116,6 +116,17 @@ class QobuzStreamCacheManager @Inject constructor(
         }
     }
 
+    /**
+     * Synchronous lookup that returns the cached file if it exists for
+     * (qobuzId, quality), without triggering a network fetch. Used by the
+     * share helper so it can hand the FLAC out to other apps when the user
+     * has already played the track once.
+     */
+    fun peekCached(qobuzId: Long, quality: AudioQuality): File? {
+        val target = File(cacheDir, "${cacheKey(qobuzId, quality)}.bin")
+        return if (isComplete(target)) target else null
+    }
+
     /** Trim the cache to [MAX_BYTES] by deleting the oldest .bin entries. */
     private fun evictIfNeeded() {
         val files = cacheDir.listFiles()?.filter { it.isFile && it.name.endsWith(".bin") }

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
@@ -31,6 +31,7 @@ class DownloadWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted params: WorkerParameters,
     private val apiClient: HiFiApiClient,
+    private val lrcLibClient: tf.monochrome.android.data.api.LrcLibClient,
     private val httpClient: HttpClient,
     private val preferences: PreferencesManager,
     private val downloadDao: DownloadDao
@@ -118,11 +119,19 @@ class DownloadWorker @AssistedInject constructor(
                 filePath = saveToInternal(trackId, fileName, audioData)
             }
 
-            // Save lyrics if enabled
+            // Save lyrics if enabled. TIDAL is preferred (best quality
+            // synced LRC); LRCLib fills in for anything TIDAL 404s on,
+            // which is most older / niche / non-Western catalog.
             val downloadLyricsEnabled = preferences.downloadLyrics.first()
             if (downloadLyricsEnabled) {
                 try {
                     val lyrics = apiClient.getLyrics(trackId)
+                        ?: lrcLibClient.lookup(
+                            title = trackTitle,
+                            artist = artistName,
+                            album = albumTitle,
+                            durationSeconds = duration.takeIf { it > 0 },
+                        )
                     if (lyrics != null && lyrics.isSynced) {
                         val lrcContent = StringBuilder()
                         lyrics.lines.forEach { line ->

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
@@ -60,8 +60,8 @@ class DownloadWorker @AssistedInject constructor(
             // Get download quality preference
             val quality = preferences.downloadQuality.first()
 
-            // Get streaming URL
-            val streamResponse = apiClient.getTrackStream(trackId, quality)
+            // Get streaming URL from the dedicated TrypT HiFi (Qobuz) download instance
+            val streamResponse = apiClient.getTrackStream(trackId, quality, forDownload = true)
             val streamUrl = streamResponse.streamUrl
                 ?: return Result.failure()
 

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
@@ -165,6 +165,26 @@ class DownloadWorker @AssistedInject constructor(
                 }
             }
 
+            // Save the album art alongside the track. Two reasons:
+            //   1. The system MediaScanner picks up `cover.jpg` /
+            //      `albumart.jpg` in the same folder as audio files and
+            //      attaches them as the album image automatically — that's
+            //      what makes downloaded albums show their cover in the
+            //      Local tab on a fresh install.
+            //   2. Other Android players (and our own DownloadsScreen) can
+            //      load the cover off-line.
+            // Errors here are non-fatal — losing the cover shouldn't fail
+            // the whole download.
+            if (!albumCover.isNullOrBlank()) {
+                runCatching { saveAlbumArt(albumCover, sanitizedTitle, customFolderUri) }
+            }
+
+            // Tell MediaStore about the new audio + cover so the Local tab
+            // sees them without a manual rescan. Only meaningful when the
+            // file is in shared storage (SAF folder); for app-private
+            // downloads MediaStore won't index regardless.
+            notifyMediaScanner(filePath)
+
             // Insert into database
             downloadDao.insertDownloadedTrack(
                 DownloadedTrackEntity(
@@ -184,6 +204,82 @@ class DownloadWorker @AssistedInject constructor(
             Result.success()
         } catch (_: Exception) {
             if (runAttemptCount < 3) Result.retry() else Result.failure()
+        }
+    }
+
+    /**
+     * Fetches the album cover URL and saves it both as `<sanitizedTitle>.jpg`
+     * (per-track sidecar, matched by some MP3-style players) and as
+     * `cover.jpg` in the same folder (the Android MediaScanner convention).
+     * Skipped silently on network or SAF failure.
+     */
+    private suspend fun saveAlbumArt(
+        coverUrl: String,
+        sanitizedTitle: String,
+        customFolderUri: String?,
+    ) {
+        val response = httpClient.get(coverUrl)
+        if (!response.status.isSuccess()) return
+        val bytes = response.readBytes()
+        if (bytes.isEmpty()) return
+
+        if (customFolderUri != null) {
+            val treeUri = customFolderUri.toUri()
+            val docFile = DocumentFile.fromTreeUri(context, treeUri) ?: return
+            if (!docFile.canWrite()) return
+            // Per-track sidecar.
+            val perTrackName = "$sanitizedTitle.jpg"
+            docFile.findFile(perTrackName)?.delete()
+            docFile.createFile("image/jpeg", sanitizedTitle)?.let { file ->
+                context.contentResolver.openOutputStream(file.uri)?.use { it.write(bytes) }
+                notifyMediaScanner(file.uri.toString())
+            }
+            // Folder-level cover.jpg — MediaScanner reads this for the
+            // album thumbnail without needing to embed the picture in
+            // each FLAC's METADATA_BLOCK_PICTURE.
+            if (docFile.findFile("cover.jpg") == null) {
+                docFile.createFile("image/jpeg", "cover")?.let { file ->
+                    context.contentResolver.openOutputStream(file.uri)?.use { it.write(bytes) }
+                    notifyMediaScanner(file.uri.toString())
+                }
+            }
+        } else {
+            val downloadsDir = File(context.getExternalFilesDir(null), "downloads")
+            if (!downloadsDir.exists()) downloadsDir.mkdirs()
+            File(downloadsDir, "$sanitizedTitle.jpg").writeBytes(bytes)
+            // App-private storage isn't MediaStore-visible, so cover.jpg
+            // is purely for the in-app off-line cover lookup.
+            val coverFile = File(downloadsDir, "cover.jpg")
+            if (!coverFile.exists()) coverFile.writeBytes(bytes)
+        }
+    }
+
+    /**
+     * Triggers MediaScannerConnection.scanFile for files in shared storage
+     * so the Local tab picks them up. content:// SAF URIs are mapped back
+     * to their on-disk path via DocumentFile / DocumentsContract; raw file
+     * paths are scanned directly. Failures are silent — the download
+     * succeeded regardless.
+     */
+    private fun notifyMediaScanner(pathOrUri: String) {
+        runCatching {
+            val resolved = when {
+                pathOrUri.startsWith("content://") -> {
+                    // Best effort: we only need the path for MediaScanner,
+                    // and not all SAF backings expose one. If we can't
+                    // resolve, skip — the user's MediaStore cache will
+                    // catch it on the next general scan.
+                    null
+                }
+                pathOrUri.startsWith("file://") -> pathOrUri.removePrefix("file://")
+                else -> pathOrUri
+            } ?: return
+            android.media.MediaScannerConnection.scanFile(
+                context,
+                arrayOf(resolved),
+                null,
+                null,
+            )
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -68,6 +68,7 @@ class PreferencesManager @Inject constructor(
         // Custom API endpoint
         private val CUSTOM_API_ENDPOINT = stringPreferencesKey("custom_api_endpoint")
         private val QOBUZ_INSTANCE_URL = stringPreferencesKey("qobuz_instance_url")
+        private val QOBUZ_AUTH_COOKIE = stringPreferencesKey("qobuz_auth_cookie")
         private val DEV_MODE_ENABLED = booleanPreferencesKey("dev_mode_enabled")
 
         // Interface
@@ -347,6 +348,24 @@ class PreferencesManager @Inject constructor(
                 it[QOBUZ_INSTANCE_URL] = endpoint
             } else {
                 it.remove(QOBUZ_INSTANCE_URL)
+            }
+        }
+    }
+
+    // Optional session cookie pinned by the user from their browser. The
+    // trypt-hifi backend issues a session cookie on login and expects it on
+    // every /api/ request; without it the backend returns 401. Stored as the
+    // raw header value (one or more "name=value" pairs separated by "; ").
+    val qobuzAuthCookie: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[QOBUZ_AUTH_COOKIE]
+    }
+
+    suspend fun setQobuzAuthCookie(cookie: String?) {
+        dataStore.edit {
+            if (cookie != null) {
+                it[QOBUZ_AUTH_COOKIE] = cookie
+            } else {
+                it.remove(QOBUZ_AUTH_COOKIE)
             }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -67,6 +67,7 @@ class PreferencesManager @Inject constructor(
 
         // Custom API endpoint
         private val CUSTOM_API_ENDPOINT = stringPreferencesKey("custom_api_endpoint")
+        private val QOBUZ_INSTANCE_URL = stringPreferencesKey("qobuz_instance_url")
         private val DEV_MODE_ENABLED = booleanPreferencesKey("dev_mode_enabled")
 
         // Interface
@@ -330,6 +331,22 @@ class PreferencesManager @Inject constructor(
                 it[CUSTOM_API_ENDPOINT] = endpoint
             } else {
                 it.remove(CUSTOM_API_ENDPOINT)
+            }
+        }
+    }
+
+    // Qobuz instance — used for downloads. Independent of Dev Mode: any
+    // value set here is honored whenever the download path is invoked.
+    val qobuzInstanceUrl: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[QOBUZ_INSTANCE_URL]
+    }
+
+    suspend fun setQobuzInstanceUrl(endpoint: String?) {
+        dataStore.edit {
+            if (endpoint != null) {
+                it[QOBUZ_INSTANCE_URL] = endpoint
+            } else {
+                it.remove(QOBUZ_INSTANCE_URL)
             }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -27,6 +27,9 @@ import javax.inject.Singleton
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "monochrome_prefs")
 
+/** Which catalog(s) drive search and discovery surfaces. */
+enum class SourceMode { BOTH, TIDAL_ONLY, QOBUZ_ONLY }
+
 @Singleton
 class PreferencesManager @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -70,6 +73,7 @@ class PreferencesManager @Inject constructor(
         private val QOBUZ_INSTANCE_URL = stringPreferencesKey("qobuz_instance_url")
         private val QOBUZ_AUTH_COOKIE = stringPreferencesKey("qobuz_auth_cookie")
         private val DEV_MODE_ENABLED = booleanPreferencesKey("dev_mode_enabled")
+        private val SOURCE_MODE = stringPreferencesKey("source_mode")
 
         // Interface
         private val GAPLESS_PLAYBACK = booleanPreferencesKey("gapless_playback")
@@ -368,6 +372,22 @@ class PreferencesManager @Inject constructor(
                 it.remove(QOBUZ_AUTH_COOKIE)
             }
         }
+    }
+
+    /**
+     * Which catalog(s) drive search/discovery. BOTH (default) is the
+     * existing fan-out behavior; TIDAL_ONLY skips the Qobuz call so search
+     * doesn't surface Qobuz hits; QOBUZ_ONLY skips the TIDAL pool. Stream
+     * playback and downloads still follow the per-track PlaybackSource —
+     * the setting only governs which catalogs feed search results.
+     */
+    val sourceMode: Flow<SourceMode> = dataStore.data.map { prefs ->
+        prefs[SOURCE_MODE]?.let { runCatching { SourceMode.valueOf(it) }.getOrNull() }
+            ?: SourceMode.BOTH
+    }
+
+    suspend fun setSourceMode(mode: SourceMode) {
+        dataStore.edit { it[SOURCE_MODE] = mode.name }
     }
 
     val devModeEnabled: Flow<Boolean> = dataStore.data.map { prefs ->

--- a/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
@@ -40,6 +40,10 @@ class MusicRepository @Inject constructor(
         apiClient.search(query)
     }
 
+    suspend fun searchQobuz(query: String): Result<SearchResult> = runCatching {
+        apiClient.searchQobuz(query)
+    }
+
     suspend fun searchTracks(query: String): Result<List<Track>> = runCatching {
         apiClient.searchTracks(query)
     }

--- a/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.first
 import tf.monochrome.android.data.ai.AudioSnippetFetcher
 import tf.monochrome.android.data.ai.GeminiClient
 import tf.monochrome.android.data.api.HiFiApiClient
+import tf.monochrome.android.data.api.LrcLibClient
 import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.domain.model.AiFilter
 import tf.monochrome.android.domain.model.Album
@@ -29,6 +30,7 @@ import javax.inject.Singleton
 @Singleton
 class MusicRepository @Inject constructor(
     private val apiClient: HiFiApiClient,
+    private val lrcLibClient: LrcLibClient,
     private val preferences: PreferencesManager,
     private val geminiClient: GeminiClient,
     private val audioSnippetFetcher: AudioSnippetFetcher,
@@ -160,9 +162,25 @@ class MusicRepository @Inject constructor(
 
     // --- Lyrics ---
 
-    suspend fun getLyrics(trackId: Long): Result<Lyrics?> = runCatching {
+    suspend fun getLyrics(trackId: Long, track: Track? = null): Result<Lyrics?> = runCatching {
         val romajiEnabled = preferences.romajiLyrics.first()
-        apiClient.getLyrics(trackId, romajiEnabled)
+        // TIDAL first — when it has the lyrics this is the highest-quality
+        // path (LRC + word-level timing on Tidal Hi-Fi).
+        val tidalLyrics = apiClient.getLyrics(trackId, romajiEnabled)
+        if (tidalLyrics != null) return@runCatching tidalLyrics
+        // Tidal returned 404 / empty — fall back to LRCLib (open API,
+        // no auth) using the track's metadata. Skip when we don't have
+        // enough info to make any reasonable query.
+        val title = track?.title?.takeIf { it.isNotBlank() } ?: return@runCatching null
+        val artistName = (track.artist?.name ?: track.artists.firstOrNull()?.name)
+            ?.takeIf { it.isNotBlank() } ?: return@runCatching null
+        lrcLibClient.lookup(
+            title = title,
+            artist = artistName,
+            album = track.album?.title,
+            durationSeconds = track.duration.takeIf { it > 0 },
+            convertToRomaji = romajiEnabled,
+        )
     }
 
     // --- Quality ---

--- a/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
@@ -44,6 +44,16 @@ class MusicRepository @Inject constructor(
         apiClient.searchQobuz(query)
     }
 
+    /**
+     * Qobuz album-detail fetch. Returns Result.failure when the Qobuz instance
+     * isn't configured or the lookup fails so the detail VM can fall back to
+     * the TIDAL path cleanly.
+     */
+    suspend fun getQobuzAlbum(albumSlug: String): Result<AlbumDetail> = runCatching {
+        apiClient.getQobuzAlbum(albumSlug)
+            ?: throw IllegalStateException("Qobuz album not available: $albumSlug")
+    }
+
     suspend fun searchTracks(query: String): Result<List<Track>> = runCatching {
         apiClient.searchTracks(query)
     }

--- a/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/MusicRepository.kt
@@ -54,6 +54,11 @@ class MusicRepository @Inject constructor(
             ?: throw IllegalStateException("Qobuz album not available: $albumSlug")
     }
 
+    suspend fun getQobuzArtist(artistId: Long): Result<ArtistDetail> = runCatching {
+        apiClient.getQobuzArtist(artistId)
+            ?: throw IllegalStateException("Qobuz artist not available: $artistId")
+    }
+
     suspend fun searchTracks(query: String): Result<List<Track>> = runCatching {
         apiClient.searchTracks(query)
     }

--- a/app/src/main/java/tf/monochrome/android/debug/CrashLogger.kt
+++ b/app/src/main/java/tf/monochrome/android/debug/CrashLogger.kt
@@ -1,0 +1,132 @@
+package tf.monochrome.android.debug
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import tf.monochrome.android.BuildConfig
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Catches uncaught exceptions, dumps the in-memory `DebugLogBuffer` plus the
+ * throwable's stack trace to a timestamped file under the device's public
+ * Downloads directory, then chains to the previous default handler so the
+ * system crash dialog still appears and the process is killed.
+ *
+ * The dump goes to `Downloads/monotrypt-crash-YYYYMMDD-HHMMSS.log` so it's
+ * easy to find and share without leaving the app.
+ *
+ * Storage path varies by API level:
+ *   - API 29+ (Q and above): MediaStore.Downloads — no permission needed.
+ *   - API 26-28 (O / O_MR1 / P): Direct file write to
+ *     Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS).
+ *     Requires WRITE_EXTERNAL_STORAGE which is already declared in the
+ *     manifest with android:maxSdkVersion="28".
+ *
+ * If the dump itself throws (storage full, no permission, MediaStore
+ * insertion rejected, …) we swallow the secondary exception and still
+ * forward the original throwable to the prior handler — losing the crash
+ * dialog because of a logging side effect would be worse than losing the
+ * log.
+ */
+@Singleton
+class CrashLogger @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val debugLogBuffer: DebugLogBuffer,
+) {
+    private var installed = false
+
+    fun install() {
+        if (installed) return
+        installed = true
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                writeCrashDump(thread, throwable)
+            } catch (t: Throwable) {
+                Log.w(TAG, "Crash dump failed", t)
+            }
+            // Always chain to the prior handler so the system shows its crash
+            // dialog and kills the process. Without this, an uncaught
+            // exception would leave the app in an undefined state.
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun writeCrashDump(thread: Thread, throwable: Throwable) {
+        val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val fileName = "monotrypt-crash-$timestamp.log"
+        val content = formatDump(thread, throwable, timestamp)
+
+        val bytes = content.toByteArray(Charsets.UTF_8)
+        val wrote = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            writeViaMediaStore(fileName, bytes)
+        } else {
+            writeViaPublicDirectory(fileName, bytes)
+        }
+        if (!wrote) Log.w(TAG, "Crash dump could not be written to Downloads")
+    }
+
+    private fun writeViaMediaStore(fileName: String, bytes: ByteArray): Boolean {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+            put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+            put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values) ?: return false
+        return runCatching {
+            resolver.openOutputStream(uri)?.use { it.write(bytes) }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun writeViaPublicDirectory(fileName: String, bytes: ByteArray): Boolean {
+        val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            ?: return false
+        if (!downloads.exists() && !downloads.mkdirs()) return false
+        val target = File(downloads, fileName)
+        return runCatching {
+            target.writeBytes(bytes)
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun formatDump(thread: Thread, throwable: Throwable, timestamp: String): String {
+        val stack = StringWriter().also { sw ->
+            PrintWriter(sw).use { throwable.printStackTrace(it) }
+        }.toString()
+        val header = buildString {
+            appendLine("MonoTrypT crash dump")
+            appendLine("====================")
+            appendLine("timestamp: $timestamp")
+            appendLine("app:       ${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+            appendLine("android:   ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+            appendLine("device:    ${Build.MANUFACTURER} ${Build.MODEL} (${Build.PRODUCT})")
+            appendLine("thread:    ${thread.name} (id=${thread.id})")
+            appendLine()
+        }
+        val recentLog = runCatching { debugLogBuffer.dumpAsText() }.getOrDefault("(log buffer unavailable)")
+        return buildString {
+            append(header)
+            appendLine("--- stack trace ---")
+            appendLine(stack)
+            appendLine("--- recent log ---")
+            appendLine(recentLog)
+        }
+    }
+
+    companion object {
+        private const val TAG = "CrashLogger"
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
@@ -221,7 +221,7 @@ fun buildCoverUrl(coverId: String, size: Int): String {
 
 // ========== Unified Three-Source Models ==========
 
-enum class SourceType { API, COLLECTION, LOCAL }
+enum class SourceType { API, COLLECTION, LOCAL, QOBUZ }
 
 enum class AudioCodec(val displayName: String) {
     FLAC("FLAC"),

--- a/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
@@ -261,6 +261,18 @@ sealed class PlaybackSource {
         val sampleRate: Int,
         val bitDepth: Int? = null
     ) : PlaybackSource()
+
+    /**
+     * Qobuz (trypt-hifi) source — fetches the audio file via /api/download-music
+     * on first play, parks it in the cache directory, and plays subsequent
+     * times from local disk. The HMAC-signed file URL the backend returns
+     * isn't suitable for long-running streams (signature is time-bounded), so
+     * pre-fetching the whole file is more reliable than progressive streaming.
+     */
+    data class QobuzCached(
+        val qobuzId: Long,
+        val preferredQuality: AudioQuality = AudioQuality.LOSSLESS,
+    ) : PlaybackSource()
 }
 
 data class CollectionDirectLink(
@@ -350,6 +362,7 @@ data class UnifiedTrack(
     fun toLegacyTrack(): Track {
         val tidalId = when (val s = source) {
             is PlaybackSource.HiFiApi -> s.tidalId
+            is PlaybackSource.QobuzCached -> s.qobuzId
             else -> id.hashCode().toLong()
         }
         return Track(

--- a/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
+++ b/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
@@ -585,5 +585,23 @@ class PlaybackService : MediaSessionService() {
             )
             return com.google.common.util.concurrent.Futures.immediateFuture(resumption)
         }
+
+        /**
+         * Echo controller-provided MediaItems back unchanged. PlayerViewModel
+         * already resolves URIs (and other LocalConfiguration) before calling
+         * `MediaController.setMediaItem(...)`, so the items the session
+         * receives are play-ready. Without this override, the default impl
+         * throws `UnsupportedOperationException` on every play tap (visible
+         * as a long MediaSessionStub stack trace in logcat) and the
+         * downstream PlayerWrapper.setMediaItems then NPEs in
+         * DefaultMediaSourceFactory because it gets fed empty items.
+         */
+        override fun onAddMediaItems(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: MutableList<MediaItem>,
+        ): com.google.common.util.concurrent.ListenableFuture<MutableList<MediaItem>> {
+            return com.google.common.util.concurrent.Futures.immediateFuture(mediaItems)
+        }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/player/StreamResolver.kt
+++ b/app/src/main/java/tf/monochrome/android/player/StreamResolver.kt
@@ -6,6 +6,7 @@ import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.util.UnstableApi
+import tf.monochrome.android.data.cache.QobuzStreamCacheManager
 import tf.monochrome.android.data.repository.MusicRepository
 import tf.monochrome.android.domain.model.CollectionDirectLink
 import tf.monochrome.android.domain.model.PlaybackSource
@@ -28,7 +29,8 @@ data class ResolvedMedia(
 
 @Singleton
 class StreamResolver @Inject constructor(
-    private val repository: MusicRepository
+    private val repository: MusicRepository,
+    private val qobuzCache: QobuzStreamCacheManager,
 ) {
     private fun normalizeArtworkUri(raw: String?): Uri? {
         if (raw.isNullOrBlank()) return null
@@ -57,7 +59,41 @@ class StreamResolver @Inject constructor(
             is PlaybackSource.LocalFile -> resolveLocalFile(track, source)
             is PlaybackSource.CollectionDirect -> resolveCollectionDirect(track, source)
             is PlaybackSource.HiFiApi -> resolveHiFiApi(track, source)
+            is PlaybackSource.QobuzCached -> resolveQobuzCached(track, source)
         }
+    }
+
+    // Qobuz resolution = "fetch via /api/download-music, park in app cache,
+    // play from local file". The cache manager dedupes concurrent plays of
+    // the same track and evicts oldest entries when over the size cap. If
+    // Qobuz isn't configured or the fetch fails, return a media item with
+    // an empty URI so ExoPlayer surfaces an error instead of silently
+    // hanging on a malformed source.
+    private suspend fun resolveQobuzCached(
+        track: UnifiedTrack,
+        source: PlaybackSource.QobuzCached,
+    ): ResolvedMedia {
+        val cachedFile = qobuzCache.getOrFetch(source.qobuzId, source.preferredQuality)
+
+        val metadata = MediaMetadata.Builder()
+            .setTitle(track.title)
+            .setArtist(track.artistName)
+            .setAlbumTitle(track.albumTitle)
+            .setArtworkUri(normalizeArtworkUri(track.artworkUri))
+            .setTrackNumber(track.trackNumber)
+            .setDiscNumber(track.discNumber)
+            .build()
+
+        val mediaItem = MediaItem.Builder()
+            .setMediaId(track.id)
+            .setUri(cachedFile?.let { Uri.fromFile(it) } ?: Uri.EMPTY)
+            .setMediaMetadata(metadata)
+            .build()
+
+        return ResolvedMedia(
+            mediaItem = mediaItem,
+            isLocalFile = cachedFile != null,
+        )
     }
 
     private fun resolveLocalFile(

--- a/app/src/main/java/tf/monochrome/android/player/StreamResolver.kt
+++ b/app/src/main/java/tf/monochrome/android/player/StreamResolver.kt
@@ -100,8 +100,19 @@ class StreamResolver @Inject constructor(
         track: UnifiedTrack,
         source: PlaybackSource.LocalFile
     ): ResolvedMedia {
-        val file = File(source.filePath)
-        val uri = Uri.fromFile(file)
+        // DownloadWorker stores filePath either as an absolute filesystem path
+        // (internal storage) or as a content:// URI string (when the user
+        // picked a SAF folder). Wrapping a content:// path with File(...) +
+        // Uri.fromFile produces a malformed file:// URI that ExoPlayer can't
+        // open and DefaultMediaSourceFactory NPEs on. Detect the scheme and
+        // route accordingly.
+        val uri = if (source.filePath.startsWith("content://") ||
+            source.filePath.startsWith("file://")
+        ) {
+            source.filePath.toUri()
+        } else {
+            Uri.fromFile(File(source.filePath))
+        }
 
         val metadata = MediaMetadata.Builder()
             .setTitle(track.title)

--- a/app/src/main/java/tf/monochrome/android/share/TrackShareHelper.kt
+++ b/app/src/main/java/tf/monochrome/android/share/TrackShareHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -47,18 +48,37 @@ class TrackShareHelper @Inject constructor(
         if (downloaded != null) {
             return@withContext shareDownloadedTrack(downloaded)
         }
-        // Fall back to whatever's parked in the Qobuz cache. Try the qualities
-        // we actually save under — LOSSLESS first, then HI_RES, since the
-        // cache key encodes (id, quality) and we don't know which qualities
-        // the user has played at.
+        // Already cached from a previous play? Try the qualities we save under
+        // — LOSSLESS first, then HI_RES, since the cache key encodes (id,
+        // quality) and we don't know which qualities the user has played at.
         for (quality in arrayOf(AudioQuality.LOSSLESS, AudioQuality.HI_RES, AudioQuality.HIGH, AudioQuality.LOW)) {
             val cached = runCatching { qobuzCache.peekCached(track.id, quality) }.getOrNull()
             if (cached != null) {
                 return@withContext shareLocalFile(cached, track.title, mimeFor(cached.name))
             }
         }
-        Log.i(TAG, "shareTrack: no local file for trackId=${track.id}")
+        // Download-on-demand: nothing local, so reach out to the Qobuz
+        // instance and pull the file into the playback cache, then share
+        // from there. This may take several seconds for a typical FLAC —
+        // surface a Toast so the user knows the tap registered.
+        // PlayerViewModel.shareTrack drives this from viewModelScope so
+        // the fetch outlives the originating tap.
+        toast("Preparing ${track.title} for share…")
+        val fetched = runCatching {
+            qobuzCache.getOrFetch(track.id, AudioQuality.LOSSLESS)
+        }.getOrNull()
+        if (fetched != null) {
+            return@withContext shareLocalFile(fetched, track.title, mimeFor(fetched.name))
+        }
+        toast("No file available to share")
+        Log.i(TAG, "shareTrack: no local file and download-on-demand failed for trackId=${track.id}")
         false
+    }
+
+    private suspend fun toast(message: String) {
+        withContext(Dispatchers.Main) {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
     }
 
     fun shareDownloadedTrack(entity: DownloadedTrackEntity): Boolean {

--- a/app/src/main/java/tf/monochrome/android/share/TrackShareHelper.kt
+++ b/app/src/main/java/tf/monochrome/android/share/TrackShareHelper.kt
@@ -1,0 +1,125 @@
+package tf.monochrome.android.share
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import tf.monochrome.android.data.cache.QobuzStreamCacheManager
+import tf.monochrome.android.data.db.dao.DownloadDao
+import tf.monochrome.android.data.db.entity.DownloadedTrackEntity
+import tf.monochrome.android.domain.model.AudioQuality
+import tf.monochrome.android.domain.model.Track
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Builds and dispatches an `Intent.ACTION_SEND` carrying the actual audio
+ * file for a track so the user can hand the FLAC (or MP3) directly to any
+ * app on the share sheet.
+ *
+ * Resolution order:
+ *   1. DownloadedTrackEntity.filePath — the user-initiated download. If
+ *      the path is a content:// URI (SAF folder) it's shared as-is. If
+ *      it's an absolute file path, FileProvider wraps it.
+ *   2. QobuzStreamCacheManager — for tracks that have been streamed
+ *      through the cache-on-demand path. The cached file is always under
+ *      the app's cache dir, so FileProvider always wraps it.
+ *
+ * If neither source has a file, the call is a no-op and a warning is
+ * logged. We don't try to download on demand — surface a toast/snackbar
+ * upstream if you want to nudge the user to download first.
+ */
+@Singleton
+class TrackShareHelper @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val downloadDao: DownloadDao,
+    private val qobuzCache: QobuzStreamCacheManager,
+) {
+    /** Suspends only on the DB lookup; the intent dispatch is fire-and-forget. */
+    suspend fun shareTrack(track: Track): Boolean = withContext(Dispatchers.IO) {
+        val downloaded = runCatching { downloadDao.getDownloadedTrack(track.id) }.getOrNull()
+        if (downloaded != null) {
+            return@withContext shareDownloadedTrack(downloaded)
+        }
+        // Fall back to whatever's parked in the Qobuz cache. Try the qualities
+        // we actually save under — LOSSLESS first, then HI_RES, since the
+        // cache key encodes (id, quality) and we don't know which qualities
+        // the user has played at.
+        for (quality in arrayOf(AudioQuality.LOSSLESS, AudioQuality.HI_RES, AudioQuality.HIGH, AudioQuality.LOW)) {
+            val cached = runCatching { qobuzCache.peekCached(track.id, quality) }.getOrNull()
+            if (cached != null) {
+                return@withContext shareLocalFile(cached, track.title, mimeFor(cached.name))
+            }
+        }
+        Log.i(TAG, "shareTrack: no local file for trackId=${track.id}")
+        false
+    }
+
+    fun shareDownloadedTrack(entity: DownloadedTrackEntity): Boolean {
+        val uri = downloadedTrackUri(entity) ?: return false
+        return launchShare(uri, entity.title, mimeFor(entity.filePath))
+    }
+
+    private fun downloadedTrackUri(entity: DownloadedTrackEntity): Uri? {
+        return runCatching {
+            when {
+                entity.filePath.startsWith("content://") -> entity.filePath.toUri()
+                entity.filePath.startsWith("file://") -> entity.filePath.toUri()
+                else -> {
+                    val file = File(entity.filePath)
+                    if (!file.exists()) return null
+                    FileProvider.getUriForFile(context, fileProviderAuthority(), file)
+                }
+            }
+        }.getOrNull()
+    }
+
+    private fun shareLocalFile(file: File, title: String, mimeType: String): Boolean {
+        if (!file.exists()) return false
+        val uri = runCatching {
+            FileProvider.getUriForFile(context, fileProviderAuthority(), file)
+        }.getOrNull() ?: return false
+        return launchShare(uri, title, mimeType)
+    }
+
+    private fun launchShare(uri: Uri, title: String, mimeType: String): Boolean {
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, title)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        val chooser = Intent.createChooser(send, "Share track").apply {
+            // The share sheet is launched from a non-Activity context (the
+            // ApplicationContext-scoped helper), so it needs NEW_TASK.
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return runCatching {
+            context.startActivity(chooser)
+            true
+        }.onFailure { Log.w(TAG, "shareTrack: launch failed", it) }.getOrDefault(false)
+    }
+
+    private fun mimeFor(pathOrName: String): String {
+        val lower = pathOrName.lowercase()
+        return when {
+            lower.endsWith(".mp3") -> "audio/mpeg"
+            lower.endsWith(".m4a") || lower.endsWith(".aac") -> "audio/mp4"
+            lower.endsWith(".ogg") || lower.endsWith(".opus") -> "audio/ogg"
+            lower.endsWith(".wav") -> "audio/wav"
+            else -> "audio/flac"
+        }
+    }
+
+    private fun fileProviderAuthority(): String = "${context.packageName}.fileprovider"
+
+    companion object {
+        private const val TAG = "TrackShareHelper"
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.QueueMusic
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -49,6 +50,7 @@ fun TrackContextMenu(
     onToggleLike: () -> Unit,
     onAddToPlaylist: () -> Unit,
     onDownloadTrack: (() -> Unit)? = null,
+    onShareFile: (() -> Unit)? = null,
     onGoToAlbum: (() -> Unit)? = null,
     onGoToArtist: (() -> Unit)? = null,
     onShowTrackInfo: (() -> Unit)? = null
@@ -129,6 +131,18 @@ fun TrackContextMenu(
                     icon = Icons.Default.Download,
                     label = "Download",
                     onClick = { onDownloadTrack(); onDismiss() }
+                )
+            }
+
+            // Share the actual audio file when the caller provides a handler.
+            // The handler resolves to a downloaded copy or a Qobuz cache hit
+            // and dispatches Intent.ACTION_SEND with the file URI; if neither
+            // exists the action is a no-op (logged in TrackShareHelper).
+            if (onShareFile != null) {
+                ContextMenuItem(
+                    icon = Icons.Default.Share,
+                    label = "Share file",
+                    onClick = { onShareFile(); onDismiss() }
                 )
             }
 

--- a/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
@@ -74,6 +74,7 @@ fun AlbumDetailScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = null, // Already here
             onGoToArtist = track.artist?.id?.let { artistId ->
                 { navController.navigate(Screen.ArtistDetail.createRoute(artistId)) }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import tf.monochrome.android.data.api.QobuzIdRegistry
 import tf.monochrome.android.data.repository.MusicRepository
 import tf.monochrome.android.domain.model.AlbumDetail
 import javax.inject.Inject
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class AlbumDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val repository: MusicRepository
+    private val repository: MusicRepository,
+    private val qobuzIdRegistry: QobuzIdRegistry,
 ) : ViewModel() {
 
     private val albumId: Long = savedStateHandle.get<Long>("albumId") ?: 0L
@@ -33,11 +35,29 @@ class AlbumDetailViewModel @Inject constructor(
         loadAlbum()
     }
 
+    /**
+     * Qobuz-aware load: when the registry has an alphanumeric slug for this
+     * numeric id (i.e. the user navigated from a Qobuz search hit), hit the
+     * trypt-hifi /api/get-album endpoint. Otherwise — and on Qobuz failure
+     * — fall back to the TIDAL pool's /album endpoint. Either branch
+     * surfaces a clean error string instead of crashing on HTML responses,
+     * because both repository methods return Result.
+     */
     private fun loadAlbum() {
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
-            repository.getAlbum(albumId)
+
+            val qobuzSlug = qobuzIdRegistry.albumSlugFor(albumId)
+            val qobuzResult = qobuzSlug?.let { repository.getQobuzAlbum(it) }
+
+            val finalResult = if (qobuzResult?.isSuccess == true) {
+                qobuzResult
+            } else {
+                repository.getAlbum(albumId)
+            }
+
+            finalResult
                 .onSuccess { _albumDetail.value = it }
                 .onFailure { _error.value = it.message ?: "Failed to load album" }
             _isLoading.value = false

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
@@ -78,6 +78,7 @@ fun ArtistDetailScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import tf.monochrome.android.data.api.QobuzIdRegistry
 import tf.monochrome.android.data.repository.MusicRepository
 import tf.monochrome.android.domain.model.ArtistDetail
 import javax.inject.Inject
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val repository: MusicRepository
+    private val repository: MusicRepository,
+    private val qobuzIdRegistry: QobuzIdRegistry,
 ) : ViewModel() {
 
     private val artistId: Long = savedStateHandle.get<Long>("artistId") ?: 0L
@@ -33,11 +35,30 @@ class ArtistDetailViewModel @Inject constructor(
         loadArtist()
     }
 
+    /**
+     * Qobuz-aware load — same pattern as AlbumDetailViewModel. When the
+     * registry has tagged this id as Qobuz (i.e. the user navigated from a
+     * Qobuz search hit or top-track row), hit /api/get-artist on trypt-hifi
+     * first; on failure, or for non-Qobuz ids, fall through to the TIDAL
+     * pool's /artist endpoint. Result-wrapped at both layers so a parse
+     * failure surfaces as a clean error string instead of a crash.
+     */
     private fun loadArtist() {
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null
-            repository.getArtist(artistId)
+
+            val qobuzResult = if (qobuzIdRegistry.isQobuzArtist(artistId)) {
+                repository.getQobuzArtist(artistId)
+            } else null
+
+            val finalResult = if (qobuzResult?.isSuccess == true) {
+                qobuzResult
+            } else {
+                repository.getArtist(artistId)
+            }
+
+            finalResult
                 .onSuccess { _artistDetail.value = it }
                 .onFailure { _error.value = it.message ?: "Failed to load artist" }
             _isLoading.value = false

--- a/app/src/main/java/tf/monochrome/android/ui/detail/MixScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/MixScreen.kt
@@ -66,6 +66,7 @@ fun MixScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -122,6 +122,7 @@ fun HomeScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -116,6 +117,7 @@ fun DownloadsScreen(
                     val tappedUnified = track.toUnifiedTrack()
                     playerViewModel.playUnifiedTrack(tappedUnified, allUnified)
                 },
+                onShare = { playerViewModel.shareDownloadedTrack(track) },
                 onDelete = { viewModel.deleteDownload(track) },
             )
         }
@@ -162,6 +164,7 @@ private fun AlbumCard(
 private fun DownloadedTrackRow(
     track: DownloadedTrackEntity,
     onClick: () -> Unit,
+    onShare: () -> Unit,
     onDelete: () -> Unit,
 ) {
     Row(
@@ -196,7 +199,13 @@ private fun DownloadedTrackRow(
                 overflow = TextOverflow.Ellipsis
             )
         }
-        Spacer(modifier = Modifier.width(16.dp))
+        IconButton(onClick = onShare) {
+            Icon(
+                Icons.Default.Share,
+                contentDescription = "Share Download",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         IconButton(onClick = onDelete) {
             Icon(
                 Icons.Default.Delete,

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
@@ -1,5 +1,7 @@
 package tf.monochrome.android.ui.library
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -7,10 +9,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -25,82 +29,180 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import tf.monochrome.android.data.db.entity.DownloadedTrackEntity
 import tf.monochrome.android.ui.components.CoverImage
+import tf.monochrome.android.ui.player.PlayerViewModel
 
 @Composable
 fun DownloadsScreen(
     navController: NavController,
-    viewModel: DownloadsViewModel = hiltViewModel()
+    viewModel: DownloadsViewModel = hiltViewModel(),
+    playerViewModel: PlayerViewModel = hiltViewModel(),
 ) {
     val downloadedTracks by viewModel.downloadedTracks.collectAsState()
+    val albumGroups by viewModel.albumGroups.collectAsState()
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        if (downloadedTracks.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
+    if (downloadedTracks.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "No downloaded tracks found.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(24.dp)
+            )
+        }
+        return
+    }
+
+    // Materialize unified-track lists once per recomposition. The full list
+    // drives 'tap a track to play within the entire downloads queue', the
+    // per-album lists drive 'tap an album card to play that album in order'.
+    val allUnified = downloadedTracks.map { it.toUnifiedTrack() }
+
+    LazyColumn(
+        contentPadding = PaddingValues(bottom = 120.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        if (albumGroups.isNotEmpty()) {
+            item {
                 Text(
-                    text = "No downloaded tracks found.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(24.dp)
+                    text = "Albums",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
                 )
             }
-        } else {
-            LazyColumn(
-                contentPadding = PaddingValues(bottom = 120.dp),
-                modifier = Modifier.fillMaxSize()
-            ) {
-                items(downloadedTracks, key = { it.id }) { track ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        CoverImage(
-                            url = track.albumCover,
-                            contentDescription = track.title,
-                            modifier = Modifier
-                                .size(48.dp)
-                                .clip(RoundedCornerShape(8.dp))
+            item {
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(albumGroups, key = { it.title + it.artistName }) { group ->
+                        AlbumCard(
+                            group = group,
+                            onClick = {
+                                val groupUnified = group.tracks.map { it.toUnifiedTrack() }
+                                groupUnified.firstOrNull()?.let { first ->
+                                    playerViewModel.playUnifiedTrack(first, groupUnified)
+                                }
+                            },
                         )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = track.title,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            val mbSize = track.sizeBytes / (1024 * 1024)
-                            Text(
-                                text = "${track.artistName} • $mbSize MB",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(16.dp))
-                        IconButton(onClick = { viewModel.deleteDownload(track) }) {
-                            Icon(
-                                Icons.Default.Delete,
-                                contentDescription = "Delete Download",
-                                tint = MaterialTheme.colorScheme.error
-                            )
-                        }
                     }
                 }
             }
+            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item {
+                Text(
+                    text = "Tracks",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+            }
+        }
+
+        items(downloadedTracks, key = { it.id }) { track ->
+            DownloadedTrackRow(
+                track = track,
+                onClick = {
+                    val tappedUnified = track.toUnifiedTrack()
+                    playerViewModel.playUnifiedTrack(tappedUnified, allUnified)
+                },
+                onDelete = { viewModel.deleteDownload(track) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlbumCard(
+    group: DownloadedAlbumGroup,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .width(140.dp)
+            .clickable(onClick = onClick)
+            .padding(vertical = 4.dp),
+    ) {
+        CoverImage(
+            url = group.cover,
+            contentDescription = group.title,
+            modifier = Modifier
+                .size(140.dp)
+                .clip(RoundedCornerShape(10.dp)),
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = group.title,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = "${group.artistName} • ${group.trackCount}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun DownloadedTrackRow(
+    track: DownloadedTrackEntity,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 24.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CoverImage(
+            url = track.albumCover,
+            contentDescription = track.title,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = track.title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            val mbSize = track.sizeBytes / (1024 * 1024)
+            Text(
+                text = "${track.artistName} • $mbSize MB",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        IconButton(onClick = onDelete) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "Delete Download",
+                tint = MaterialTheme.colorScheme.error
+            )
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
@@ -7,12 +7,31 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.db.dao.DownloadDao
 import tf.monochrome.android.data.db.entity.DownloadedTrackEntity
+import tf.monochrome.android.domain.model.AudioCodec
+import tf.monochrome.android.domain.model.AudioQuality
+import tf.monochrome.android.domain.model.PlaybackSource
+import tf.monochrome.android.domain.model.SourceType
+import tf.monochrome.android.domain.model.UnifiedTrack
 import java.io.File
 import javax.inject.Inject
+
+/**
+ * Loose grouping of downloaded tracks for the Albums section. Album rows are
+ * keyed by (albumTitle, artistName) so a tracks-only download (album = null)
+ * collapses into a synthetic "Singles" bucket.
+ */
+data class DownloadedAlbumGroup(
+    val title: String,
+    val artistName: String,
+    val cover: String?,
+    val trackCount: Int,
+    val tracks: List<DownloadedTrackEntity>,
+)
 
 @HiltViewModel
 class DownloadsViewModel @Inject constructor(
@@ -22,6 +41,27 @@ class DownloadsViewModel @Inject constructor(
 
     val downloadedTracks: StateFlow<List<DownloadedTrackEntity>> =
         downloadDao.getDownloadedTracks()
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val albumGroups: StateFlow<List<DownloadedAlbumGroup>> =
+        downloadDao.getDownloadedTracks()
+            .map { entities ->
+                entities
+                    .groupBy { (it.albumTitle ?: SINGLES_LABEL) to it.artistName }
+                    .map { (key, list) ->
+                        val cover = list.firstNotNullOfOrNull { it.albumCover }
+                        DownloadedAlbumGroup(
+                            title = key.first,
+                            artistName = key.second,
+                            cover = cover,
+                            trackCount = list.size,
+                            // Within the album sort by trackNumber-equivalent
+                            // proxy (downloadedAt) so the play order is stable.
+                            tracks = list.sortedBy { it.downloadedAt },
+                        )
+                    }
+                    .sortedBy { it.title.lowercase() }
+            }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun deleteDownload(track: DownloadedTrackEntity) {
@@ -41,4 +81,38 @@ class DownloadsViewModel @Inject constructor(
             downloadDao.deleteDownloadedTrack(track.id)
         }
     }
+
+    companion object {
+        const val SINGLES_LABEL = "Singles"
+    }
+}
+
+// File-private extension: map a downloaded entity onto the unified track shape
+// the player expects. Codec/sample-rate are inferred from the saved quality
+// label; ExoPlayer sniffs the actual container so these are advisory.
+fun DownloadedTrackEntity.toUnifiedTrack(): UnifiedTrack {
+    val quality = runCatching { AudioQuality.valueOf(quality) }.getOrDefault(AudioQuality.LOSSLESS)
+    val (codec, sampleRate, bitDepth) = when (quality) {
+        AudioQuality.HI_RES -> Triple(AudioCodec.FLAC, 96_000, 24)
+        AudioQuality.LOSSLESS -> Triple(AudioCodec.FLAC, 44_100, 16)
+        AudioQuality.HIGH, AudioQuality.LOW -> Triple(AudioCodec.MP3, 44_100, null)
+    }
+    return UnifiedTrack(
+        id = "download_$id",
+        title = title,
+        durationSeconds = duration,
+        artistName = artistName.ifBlank { "Unknown Artist" },
+        artistNames = listOfNotNull(artistName.takeIf { it.isNotBlank() }),
+        albumArtistName = artistName.takeIf { it.isNotBlank() },
+        albumTitle = albumTitle,
+        albumId = albumTitle?.let { "download_album_${it.hashCode()}" },
+        artworkUri = albumCover,
+        source = PlaybackSource.LocalFile(
+            filePath = filePath,
+            codec = codec,
+            sampleRate = sampleRate,
+            bitDepth = bitDepth,
+        ),
+        sourceType = SourceType.LOCAL,
+    )
 }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -98,6 +98,7 @@ fun LibraryScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -88,6 +88,7 @@ fun PlaylistScreen(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
@@ -101,6 +102,7 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
+import coil3.request.crossfade
 import coil3.toBitmap
 import tf.monochrome.android.domain.model.Lyrics
 import tf.monochrome.android.domain.model.NowPlayingViewMode
@@ -475,12 +477,6 @@ fun NowPlayingScreen(
                             isDownloaded = isDownloaded,
                             onClick = { currentTrack?.let { playerViewModel.downloadTrack(it) } }
                         )
-                        IconButton(onClick = { showLyricsSheet = true }) {
-                            Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, "Lyrics", tint = Color.White)
-                        }
-                        IconButton(onClick = { showQueueSheet = true }) {
-                            Icon(Icons.AutoMirrored.Filled.QueueMusic, "Queue", tint = Color.White)
-                        }
                     }
 
                     DownloadStatusStrip(
@@ -847,7 +843,11 @@ private fun NowPlayingHero(
                         )
                         NowPlayingViewMode.LYRICS -> LyricsHeroPanel(
                             lyrics = lyrics,
-                            isLoading = isLyricsLoading
+                            isLoading = isLyricsLoading,
+                            coverUrl = currentTrack?.coverUrl,
+                            albumColors = albumColors,
+                            positionMs = playerViewModel.positionMs,
+                            onSeekTo = { ms -> playerViewModel.seekTo(ms) },
                         )
                         NowPlayingViewMode.QUEUE -> QueueHeroPanel(queuePreview = queuePreview)
                     }
@@ -1199,69 +1199,217 @@ private fun HeroCoverArt(
     }
 }
 
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
 @Composable
 private fun LyricsHeroPanel(
     lyrics: Lyrics?,
-    isLoading: Boolean
+    isLoading: Boolean,
+    coverUrl: String?,
+    albumColors: AlbumColors,
+    positionMs: kotlinx.coroutines.flow.StateFlow<Long>,
+    onSeekTo: (Long) -> Unit,
 ) {
-    val previewLines = lyrics?.lines?.take(5).orEmpty()
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                brush = Brush.linearGradient(
-                    colors = listOf(
-                        Color(0xFF111421),
-                        Color(0xFF0F2430),
-                        Color(0xFF15111D)
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Blurred album cover backdrop. Modifier.blur is API 31+; on older
+        // devices the modifier is silently a no-op so the cover still
+        // shows, just sharper. Either way we layer a dimming gradient on
+        // top so foreground text stays legible.
+        if (!coverUrl.isNullOrBlank()) {
+            SubcomposeAsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(coverUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .blur(40.dp)
+                    .graphicsLayer { alpha = 0.55f },
+            )
+        }
+        // Dim + tint overlay using the album's dominant palette colour.
+        // The vertical gradient keeps the active line area readable while
+        // letting the cover bleed in through the rest.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            albumColors.dominant.copy(alpha = 0.55f),
+                            Color.Black.copy(alpha = 0.78f),
+                            albumColors.dominant.copy(alpha = 0.65f),
+                        )
                     )
                 )
-            )
-            .padding(24.dp)
-    ) {
-        Column(
-            modifier = Modifier.align(Alignment.BottomStart),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Text(
-                text = "Lyrics",
-                style = MaterialTheme.typography.labelLarge,
-                color = Color.White.copy(alpha = 0.7f)
-            )
-            when {
-                isLoading -> {
-                    Text(
-                        text = "Loading synced lines...",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = Color.White
-                    )
-                }
+        )
 
-                previewLines.isEmpty() -> {
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
                     Text(
-                        text = "No lyrics for this track yet.",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = Color.White
+                        text = "Loading lyrics…",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color.White.copy(alpha = 0.85f),
                     )
-                }
-
-                else -> {
-                    previewLines.forEachIndexed { index, line ->
-                        Text(
-                            text = line.text.ifBlank { "..." },
-                            style = if (index == 0) {
-                                MaterialTheme.typography.headlineSmall
-                            } else {
-                                MaterialTheme.typography.bodyLarge
-                            },
-                            color = Color.White.copy(alpha = if (index == 0) 1f else 0.72f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
                 }
             }
+            lyrics == null || lyrics.lines.isEmpty() -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No lyrics available for this track.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.White.copy(alpha = 0.7f),
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                    )
+                }
+            }
+            lyrics.isSynced -> SyncedLyricsView(
+                lines = lyrics.lines,
+                positionMs = positionMs,
+                accent = albumColors.vibrant,
+                onSeekTo = onSeekTo,
+            )
+            else -> UnsyncedLyricsView(lines = lyrics.lines)
+        }
+    }
+}
+
+@Composable
+private fun SyncedLyricsView(
+    lines: List<tf.monochrome.android.domain.model.LyricLine>,
+    positionMs: kotlinx.coroutines.flow.StateFlow<Long>,
+    accent: Color,
+    onSeekTo: (Long) -> Unit,
+) {
+    val position by positionMs.collectAsState()
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    var currentLineIndex by remember { mutableStateOf(-1) }
+
+    LaunchedEffect(position, lines) {
+        // indexOfLast gives the most recent line whose start has passed —
+        // exactly the karaoke "current line" semantics. Cheap on lists of
+        // a few hundred lines; no need for binary search.
+        val newIndex = lines.indexOfLast { it.timeMs <= position }
+        if (newIndex != currentLineIndex && newIndex >= 0) currentLineIndex = newIndex
+    }
+
+    LaunchedEffect(currentLineIndex) {
+        if (currentLineIndex >= 0) {
+            listState.animateScrollToItem(
+                index = currentLineIndex,
+                scrollOffset = -300,
+            )
+        }
+    }
+
+    androidx.compose.foundation.lazy.LazyColumn(
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 28.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 80.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        androidx.compose.foundation.lazy.itemsIndexed(lines) { index, line ->
+            val isActive = index == currentLineIndex
+            if (line.words.isNotEmpty()) {
+                KaraokeWordLine(
+                    line = line,
+                    isActive = isActive,
+                    position = position,
+                    accent = accent,
+                    onClick = { onSeekTo(line.timeMs) },
+                )
+            } else {
+                val color by androidx.compose.animation.animateColorAsState(
+                    targetValue = when {
+                        isActive -> accent
+                        index < currentLineIndex -> Color.White.copy(alpha = 0.35f)
+                        else -> Color.White.copy(alpha = 0.62f)
+                    },
+                    label = "lyricColor",
+                )
+                Text(
+                    text = line.text.ifBlank { "♪" },
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = if (isActive) 24.sp else 18.sp,
+                        fontWeight = if (isActive) FontWeight.Bold else FontWeight.Medium,
+                    ),
+                    color = color,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSeekTo(line.timeMs) }
+                        .padding(vertical = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+@OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+@Composable
+private fun KaraokeWordLine(
+    line: tf.monochrome.android.domain.model.LyricLine,
+    isActive: Boolean,
+    position: Long,
+    accent: Color,
+    onClick: () -> Unit,
+) {
+    androidx.compose.foundation.layout.FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 6.dp),
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        line.words.forEach { word ->
+            val isWordActive = position in word.startMs until word.endMs
+            val wasWordPlayed = position >= word.endMs
+            val color by androidx.compose.animation.animateColorAsState(
+                targetValue = when {
+                    isWordActive -> accent
+                    wasWordPlayed && isActive -> accent.copy(alpha = 0.85f)
+                    isActive -> Color.White.copy(alpha = 0.45f)
+                    else -> Color.White.copy(alpha = 0.4f)
+                },
+                label = "wordColor",
+            )
+            Text(
+                text = word.text + " ",
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = if (isActive) 24.sp else 18.sp,
+                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Medium,
+                ),
+                color = color,
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnsyncedLyricsView(lines: List<tf.monochrome.android.domain.model.LyricLine>) {
+    androidx.compose.foundation.lazy.LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 28.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 60.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        androidx.compose.foundation.lazy.itemsIndexed(lines) { _, line ->
+            Text(
+                text = line.text.ifBlank { "" },
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp),
+                color = Color.White.copy(alpha = 0.85f),
+            )
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -23,8 +23,12 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import LazyColumn
+import itemsIndexed
+import rememberLazyListState
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -1297,7 +1301,7 @@ private fun SyncedLyricsView(
     onSeekTo: (Long) -> Unit,
 ) {
     val position by positionMs.collectAsState()
-    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val listState = rememberLazyListState()
     var currentLineIndex by remember { mutableStateOf(-1) }
 
     LaunchedEffect(position, lines) {
@@ -1317,15 +1321,15 @@ private fun SyncedLyricsView(
         }
     }
 
-    androidx.compose.foundation.lazy.LazyColumn(
+    LazyColumn(
         state = listState,
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 28.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 80.dp),
+        contentPadding = PaddingValues(vertical = 80.dp),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
-        androidx.compose.foundation.lazy.itemsIndexed(lines) { index, line ->
+        itemsIndexed(lines) { index, line ->
             val isActive = index == currentLineIndex
             if (line.words.isNotEmpty()) {
                 KaraokeWordLine(
@@ -1403,14 +1407,14 @@ private fun KaraokeWordLine(
 
 @Composable
 private fun UnsyncedLyricsView(lines: List<tf.monochrome.android.domain.model.LyricLine>) {
-    androidx.compose.foundation.lazy.LazyColumn(
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 28.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 60.dp),
+        contentPadding = PaddingValues(vertical = 60.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        androidx.compose.foundation.lazy.itemsIndexed(lines) { _, line ->
+        itemsIndexed(lines) { _, line ->
             Text(
                 text = line.text.ifBlank { "" },
                 style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp),

--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -23,12 +23,12 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import PaddingValues
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import LazyColumn
-import itemsIndexed
-import rememberLazyListState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons

--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -1,8 +1,12 @@
 package tf.monochrome.android.ui.player
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -13,6 +17,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,6 +37,9 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.DownloadDone
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -44,6 +52,7 @@ import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -166,6 +175,8 @@ fun NowPlayingScreen(
     val shuffleEnabled by playerViewModel.shuffleEnabled.collectAsState()
     val repeatMode by playerViewModel.repeatMode.collectAsState()
     val isLiked by playerViewModel.isCurrentTrackLiked.collectAsState()
+    val downloadState by playerViewModel.currentTrackDownloadState.collectAsState()
+    val isDownloaded by playerViewModel.isCurrentTrackDownloaded.collectAsState()
     val lyrics by playerViewModel.currentLyrics.collectAsState()
     val isLyricsLoading by playerViewModel.isLyricsLoading.collectAsState()
     val viewMode by playerViewModel.nowPlayingViewMode.collectAsState()
@@ -459,9 +470,11 @@ fun NowPlayingScreen(
                         IconButton(onClick = { showSpeedPanel = !showSpeedPanel }) {
                             Icon(Icons.Default.GraphicEq, "Audio/Speed", tint = Color.White)
                         }
-                        IconButton(onClick = { currentTrack?.let { playerViewModel.downloadTrack(it) } }) {
-                            Icon(Icons.Default.LibraryMusic, "Download", tint = Color.White)
-                        }
+                        DownloadActionButton(
+                            state = downloadState,
+                            isDownloaded = isDownloaded,
+                            onClick = { currentTrack?.let { playerViewModel.downloadTrack(it) } }
+                        )
                         IconButton(onClick = { showLyricsSheet = true }) {
                             Icon(Icons.AutoMirrored.Filled.FormatAlignLeft, "Lyrics", tint = Color.White)
                         }
@@ -469,6 +482,11 @@ fun NowPlayingScreen(
                             Icon(Icons.AutoMirrored.Filled.QueueMusic, "Queue", tint = Color.White)
                         }
                     }
+
+                    DownloadStatusStrip(
+                        state = downloadState,
+                        isDownloaded = isDownloaded,
+                    )
 
                     // Up Next glass strip
                     Column(
@@ -1651,6 +1669,148 @@ private fun VisualizerActionPill(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+        }
+    }
+}
+
+// Download button with state-driven icon, accent tint, and a circular
+// progress arc. The arc is determinate during DOWNLOADING (driven by
+// WorkManager.setProgress) and indeterminate during QUEUED so the user
+// sees motion even before WorkManager picks the job up.
+@Composable
+private fun DownloadActionButton(
+    state: tf.monochrome.android.data.downloads.TrackDownloadState,
+    isDownloaded: Boolean,
+    onClick: () -> Unit,
+) {
+    val status = state.status
+    val showCompleted = isDownloaded ||
+        status == tf.monochrome.android.data.downloads.DownloadStatus.COMPLETED
+    val isDownloading =
+        status == tf.monochrome.android.data.downloads.DownloadStatus.DOWNLOADING
+    val isQueued =
+        status == tf.monochrome.android.data.downloads.DownloadStatus.QUEUED
+    val isFailed =
+        status == tf.monochrome.android.data.downloads.DownloadStatus.FAILED
+
+    val targetTint = when {
+        isFailed -> Color(0xFFFF6B6B)
+        showCompleted -> PlayerGlowMint
+        isDownloading || isQueued -> PlayerGlowPink
+        else -> Color.White
+    }
+    val tint by animateColorAsState(targetTint, label = "downloadTint")
+    val animatedProgress by animateFloatAsState(
+        targetValue = state.progress.coerceIn(0f, 1f),
+        label = "downloadProgress"
+    )
+
+    Box(contentAlignment = Alignment.Center) {
+        when {
+            isDownloading -> CircularProgressIndicator(
+                progress = { animatedProgress.coerceAtLeast(0.02f) },
+                modifier = Modifier.size(38.dp),
+                color = tint,
+                trackColor = Color.White.copy(alpha = 0.18f),
+                strokeWidth = 2.dp,
+            )
+            isQueued -> CircularProgressIndicator(
+                modifier = Modifier.size(38.dp),
+                color = tint.copy(alpha = 0.6f),
+                trackColor = Color.White.copy(alpha = 0.10f),
+                strokeWidth = 2.dp,
+            )
+        }
+        IconButton(onClick = onClick) {
+            val icon = when {
+                isFailed -> Icons.Default.ErrorOutline
+                showCompleted -> Icons.Default.DownloadDone
+                else -> Icons.Default.Download
+            }
+            val description = when {
+                isFailed -> "Download failed — tap to retry"
+                showCompleted -> "Downloaded"
+                isDownloading -> "Downloading"
+                isQueued -> "Queued for download"
+                else -> "Download"
+            }
+            Icon(icon, contentDescription = description, tint = tint)
+        }
+    }
+}
+
+// Status pill underneath the action row. Fades in only while a download
+// is in flight (or just failed) so the player UI stays uncluttered for
+// idle and already-downloaded tracks. The percentage is rendered to the
+// nearest whole number to avoid jittery decimals during fast updates.
+@Composable
+private fun DownloadStatusStrip(
+    state: tf.monochrome.android.data.downloads.TrackDownloadState,
+    isDownloaded: Boolean,
+) {
+    val status = state.status
+    val visible =
+        status == tf.monochrome.android.data.downloads.DownloadStatus.DOWNLOADING ||
+        status == tf.monochrome.android.data.downloads.DownloadStatus.QUEUED ||
+        status == tf.monochrome.android.data.downloads.DownloadStatus.FAILED ||
+        (status == tf.monochrome.android.data.downloads.DownloadStatus.COMPLETED && !isDownloaded)
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        val accent = when (status) {
+            tf.monochrome.android.data.downloads.DownloadStatus.FAILED -> Color(0xFFFF6B6B)
+            tf.monochrome.android.data.downloads.DownloadStatus.COMPLETED -> PlayerGlowMint
+            else -> PlayerGlowPink
+        }
+        val percent = (state.progress.coerceIn(0f, 1f) * 100f).toInt()
+        val label = when (status) {
+            tf.monochrome.android.data.downloads.DownloadStatus.QUEUED -> "Download queued"
+            tf.monochrome.android.data.downloads.DownloadStatus.DOWNLOADING -> "Downloading $percent%"
+            tf.monochrome.android.data.downloads.DownloadStatus.COMPLETED -> "Download complete"
+            tf.monochrome.android.data.downloads.DownloadStatus.FAILED -> "Download failed — tap the icon to retry"
+            else -> ""
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .liquidGlass(
+                    shape = RoundedCornerShape(14.dp),
+                    tintAlpha = 0.10f,
+                    borderAlpha = 0.08f,
+                )
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = when (status) {
+                    tf.monochrome.android.data.downloads.DownloadStatus.FAILED -> Icons.Default.ErrorOutline
+                    tf.monochrome.android.data.downloads.DownloadStatus.COMPLETED -> Icons.Default.DownloadDone
+                    else -> Icons.Default.Download
+                },
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White.copy(alpha = 0.92f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            if (status == tf.monochrome.android.data.downloads.DownloadStatus.DOWNLOADING) {
+                Text(
+                    text = "$percent%",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = accent,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -408,7 +408,10 @@ fun NowPlayingScreen(
                         spectrumBins = spectrumBins,
                         spectrumColor = spectrumColor,
                         showSpectrum = showNpSpectrum,
-                        onToggleShowSpectrum = onToggleShowSpectrum
+                        onToggleShowSpectrum = onToggleShowSpectrum,
+                        albumColors = albumColors,
+                        positionMs = playerViewModel.positionMs,
+                        onSeekTo = playerViewModel::seekTo,
                     )
                 }
 
@@ -749,7 +752,10 @@ private fun NowPlayingHero(
     spectrumBins: FloatArray = FloatArray(0),
     spectrumColor: Color = Color(0xFF7EB6FF),
     showSpectrum: Boolean = true,
-    onToggleShowSpectrum: () -> Unit = {}
+    onToggleShowSpectrum: () -> Unit = {},
+    albumColors: AlbumColors,
+    positionMs: kotlinx.coroutines.flow.StateFlow<Long>,
+    onSeekTo: (Long) -> Unit,
 ) {
     var showOverlay by androidx.compose.runtime.remember(viewMode) {
         androidx.compose.runtime.mutableStateOf(viewMode == NowPlayingViewMode.VISUALIZER) 
@@ -844,10 +850,10 @@ private fun NowPlayingHero(
                         NowPlayingViewMode.LYRICS -> LyricsHeroPanel(
                             lyrics = lyrics,
                             isLoading = isLyricsLoading,
-                            coverUrl = currentTrack?.coverUrl,
+                            coverUrl = track?.coverUrl,
                             albumColors = albumColors,
-                            positionMs = playerViewModel.positionMs,
-                            onSeekTo = { ms -> playerViewModel.seekTo(ms) },
+                            positionMs = positionMs,
+                            onSeekTo = onSeekTo,
                         )
                         NowPlayingViewMode.QUEUE -> QueueHeroPanel(queuePreview = queuePreview)
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -53,6 +53,7 @@ class PlayerViewModel @Inject constructor(
     private val preferences: PreferencesManager,
     private val projectMEngineRepository: ProjectMEngineRepository,
     private val unifiedTrackRegistry: tf.monochrome.android.player.UnifiedTrackRegistry,
+    private val qobuzIdRegistry: tf.monochrome.android.data.api.QobuzIdRegistry,
     private val trackShareHelper: tf.monochrome.android.share.TrackShareHelper,
     val spectrumAnalyzer: SpectrumAnalyzerTap
 ) : ViewModel() {
@@ -502,8 +503,19 @@ class PlayerViewModel @Inject constructor(
         val track = queueManager.currentTrack.value ?: return
         viewModelScope.launch {
             try {
-                // Check if this track has a unified source (local file, collection, etc.)
+                // Resolution priority:
+                //   1. unifiedTrackRegistry — local files / collections / Qobuz
+                //      tracks already promoted to UnifiedTrack at queue time.
+                //   2. qobuzIdRegistry — synthesize a QobuzCached UnifiedTrack
+                //      for tracks whose ids came in via getQobuzAlbum /
+                //      getQobuzArtist / searchQobuz but were enqueued as
+                //      legacy Track (e.g. an album-detail screen tap). Without
+                //      this step the legacy path below would call TIDAL
+                //      /track/?id=<qobuzId> which either 404s or returns the
+                //      wrong track because the numeric id doesn't match.
+                //   3. Legacy TIDAL path.
                 val unifiedTrack = unifiedTrackRegistry[track.id]
+                    ?: synthesizeQobuzUnifiedTrack(track)
                 if (unifiedTrack != null) {
                     val resolved = streamResolver.resolveUnifiedTrack(unifiedTrack)
                     mediaController?.let { mc ->
@@ -525,6 +537,33 @@ class PlayerViewModel @Inject constructor(
                 skipToNext()
             }
         }
+    }
+
+    /**
+     * Build a transient UnifiedTrack with PlaybackSource.QobuzCached for a
+     * legacy Track whose id was previously registered as Qobuz. Used by
+     * resolveAndPlay so a tap on a Qobuz-album track row routes through the
+     * cache-on-demand path rather than TIDAL streaming.
+     */
+    private fun synthesizeQobuzUnifiedTrack(track: Track): UnifiedTrack? {
+        if (!qobuzIdRegistry.isQobuzTrack(track.id)) return null
+        return UnifiedTrack(
+            id = "qobuz_${track.id}",
+            title = track.title,
+            durationSeconds = track.duration,
+            trackNumber = track.trackNumber,
+            discNumber = track.volumeNumber,
+            explicit = track.explicit,
+            artistName = track.displayArtist.ifBlank { "Unknown Artist" },
+            artistNames = track.artists.map { it.name }
+                .ifEmpty { listOfNotNull(track.artist?.name) },
+            albumArtistName = track.artist?.name,
+            albumTitle = track.album?.title,
+            albumId = track.album?.id?.toString(),
+            artworkUri = track.coverUrl,
+            source = tf.monochrome.android.domain.model.PlaybackSource.QobuzCached(qobuzId = track.id),
+            sourceType = tf.monochrome.android.domain.model.SourceType.QOBUZ,
+        )
     }
 
     // --- Downloads ---

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -199,7 +199,10 @@ class PlayerViewModel @Inject constructor(
                         _currentLyrics.value = null
                         
                         launch {
-                            _currentLyrics.value = repository.getLyrics(track.id).getOrNull()
+                            // Pass the full Track so the repository can fall
+                            // back to LRCLib (track + artist + album +
+                            // duration) when TIDAL returns no lyrics.
+                            _currentLyrics.value = repository.getLyrics(track.id, track).getOrNull()
                             _isLyricsLoading.value = false
                         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -53,6 +53,7 @@ class PlayerViewModel @Inject constructor(
     private val preferences: PreferencesManager,
     private val projectMEngineRepository: ProjectMEngineRepository,
     private val unifiedTrackRegistry: tf.monochrome.android.player.UnifiedTrackRegistry,
+    private val trackShareHelper: tf.monochrome.android.share.TrackShareHelper,
     val spectrumAnalyzer: SpectrumAnalyzerTap
 ) : ViewModel() {
 
@@ -561,6 +562,21 @@ class PlayerViewModel @Inject constructor(
     fun downloadAllTracks(tracks: List<Track>) {
         downloadManager.downloadTracks(tracks)
         tracks.forEach { observeTrackDownload(it.id) }
+    }
+
+    /**
+     * Hand the track's local audio file to Android's share sheet. Resolves
+     * a downloaded copy first, then a Qobuz cache hit; if neither exists
+     * the call is a no-op (logged in TrackShareHelper).
+     */
+    fun shareTrack(track: Track) {
+        viewModelScope.launch {
+            trackShareHelper.shareTrack(track)
+        }
+    }
+
+    fun shareDownloadedTrack(entity: tf.monochrome.android.data.db.entity.DownloadedTrackEntity) {
+        trackShareHelper.shareDownloadedTrack(entity)
     }
 
     private fun observeTrackDownload(trackId: Long) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -12,11 +12,14 @@ import com.google.common.util.concurrent.MoreExecutors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
@@ -524,6 +527,31 @@ class PlayerViewModel @Inject constructor(
 
     private val _activeDownloads = MutableStateFlow<Map<Long, tf.monochrome.android.data.downloads.TrackDownloadState>>(emptyMap())
     val activeDownloads: StateFlow<Map<Long, tf.monochrome.android.data.downloads.TrackDownloadState>> = _activeDownloads.asStateFlow()
+
+    // Live download state for whichever track is currently playing — drives
+    // the player's download button visual feedback (queued/downloading arc,
+    // completed checkmark, failed indicator).
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val currentTrackDownloadState: StateFlow<tf.monochrome.android.data.downloads.TrackDownloadState> =
+        currentTrack
+            .flatMapLatest { track ->
+                if (track == null) flowOf(tf.monochrome.android.data.downloads.TrackDownloadState())
+                else downloadManager.observeDownloadState(track.id)
+            }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                tf.monochrome.android.data.downloads.TrackDownloadState()
+            )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val isCurrentTrackDownloaded: StateFlow<Boolean> =
+        currentTrack
+            .flatMapLatest { track ->
+                if (track == null) flowOf(false)
+                else libraryRepository.isDownloadedFlow(track.id)
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     fun downloadTrack(track: Track) {
         downloadManager.downloadTrack(track)

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -218,6 +218,7 @@ fun SearchResultsContent(
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
+            onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -335,7 +335,8 @@ fun SearchResultsContent(
                             isLiked = favoriteTrackIds.contains(track.toLegacyTrack().id),
                             onLikeClick = { playerViewModel.toggleFavorite(track.toLegacyTrack()) },
                             onClick = { playerViewModel.playUnifiedTrack(track, tracks) },
-                            onMoreClick = if (track.sourceType == SourceType.API) {
+                            onMoreClick = if (track.sourceType == SourceType.API ||
+                                track.sourceType == SourceType.QOBUZ) {
                                 { showContextMenuForTrack = track.toLegacyTrack() }
                             } else null
                         )
@@ -585,4 +586,5 @@ private fun SourceType.label(): String = when (this) {
     SourceType.API -> "TIDAL"
     SourceType.LOCAL -> "Local"
     SourceType.COLLECTION -> "Collection"
+    SourceType.QOBUZ -> "Qobuz"
 }

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -63,6 +63,7 @@ class SearchViewModel @Inject constructor(
     enum class SearchSourceFilter(val label: String, val sourceType: SourceType?) {
         ALL("All", null),
         TIDAL("TIDAL", SourceType.API),
+        QOBUZ("Qobuz", SourceType.QOBUZ),
         LOCAL("Local", SourceType.LOCAL),
         COLLECTION("Collection", SourceType.COLLECTION)
     }
@@ -171,14 +172,18 @@ class SearchViewModel @Inject constructor(
     private suspend fun performSearch(query: String) {
         _isSearching.value = true
         val trimmedQuery = query.trim()
-        val (searchResult, unifiedResultsResult) = coroutineScope {
+        // TIDAL, Qobuz, and the local/collection library all run in parallel.
+        // Qobuz failures (instance unset, network error, schema mismatch) are
+        // swallowed so the existing TIDAL flow keeps working unchanged.
+        val (searchResult, qobuzResult, unifiedResultsResult) = coroutineScope {
             val apiDeferred = async { runCatching { repository.search(trimmedQuery) } }
+            val qobuzDeferred = async { runCatching { repository.searchQobuz(trimmedQuery) } }
             val libraryDeferred = async { runCatching { unifiedLibrarySearch.search(trimmedQuery).first() } }
-            apiDeferred.await() to libraryDeferred.await()
+            Triple(apiDeferred.await(), qobuzDeferred.await(), libraryDeferred.await())
         }
         val unifiedResults = unifiedResultsResult.getOrNull()
 
-        if (searchResult.isFailure && unifiedResults == null) {
+        if (searchResult.isFailure && unifiedResults == null && qobuzResult.isFailure) {
             clearResults()
             _isSearching.value = false
             return
@@ -189,27 +194,45 @@ class SearchViewModel @Inject constructor(
             unifiedResults?.collectionTracks
         ).flatten()
 
+        val qobuzSearch = qobuzResult.getOrNull()?.getOrNull()
+        val qobuzTracks = qobuzSearch?.tracks?.map { it.toQobuzUnifiedTrack() } ?: emptyList()
+        val qobuzAlbums = qobuzSearch?.albums ?: emptyList()
+        val qobuzArtists = qobuzSearch?.artists ?: emptyList()
+        val qobuzPlaylists = qobuzSearch?.playlists ?: emptyList()
+
         if (searchResult.getOrNull()?.isSuccess == true) {
             val result = searchResult.getOrThrow().getOrThrow()
             _allTracks.value = scoreTracks(
                 query = trimmedQuery,
                 tracks = localAndCollectionTracks +
-                    result.tracks.map { it.toUnifiedTrack() }
+                    result.tracks.map { it.toUnifiedTrack() } +
+                    qobuzTracks
             )
-            _allAlbums.value = scoreItems(trimmedQuery, result.albums) { listOf(it.title, it.displayArtist) }
-            _allArtists.value = scoreItems(trimmedQuery, result.artists) { listOf(it.name) }
-            _allPlaylists.value = scoreItems(trimmedQuery, result.playlists) {
-                listOfNotNull(it.title, it.creator?.name, it.description)
-            }
+            _allAlbums.value = scoreItems(
+                trimmedQuery,
+                (result.albums + qobuzAlbums).distinctBy { it.id },
+            ) { listOf(it.title, it.displayArtist) }
+            _allArtists.value = scoreItems(
+                trimmedQuery,
+                (result.artists + qobuzArtists).distinctBy { it.id },
+            ) { listOf(it.name) }
+            _allPlaylists.value = scoreItems(
+                trimmedQuery,
+                (result.playlists + qobuzPlaylists).distinctBy { it.uuid },
+            ) { listOfNotNull(it.title, it.creator?.name, it.description) }
             preferences.addSearchHistoryQuery(trimmedQuery)
         } else {
+            // TIDAL is down — still surface Qobuz + local results so search
+            // doesn't feel broken when the public TIDAL pool is unreachable.
             _allTracks.value = scoreTracks(
                 query = trimmedQuery,
-                tracks = localAndCollectionTracks
+                tracks = localAndCollectionTracks + qobuzTracks
             )
-            _allAlbums.value = emptyList()
-            _allArtists.value = emptyList()
-            _allPlaylists.value = emptyList()
+            _allAlbums.value = scoreItems(trimmedQuery, qobuzAlbums) { listOf(it.title, it.displayArtist) }
+            _allArtists.value = scoreItems(trimmedQuery, qobuzArtists) { listOf(it.name) }
+            _allPlaylists.value = scoreItems(trimmedQuery, qobuzPlaylists) {
+                listOfNotNull(it.title, it.creator?.name, it.description)
+            }
         }
         _isSearching.value = false
     }
@@ -237,6 +260,26 @@ class SearchViewModel @Inject constructor(
         artworkUri = coverUrl,
         source = PlaybackSource.HiFiApi(tidalId = id),
         sourceType = SourceType.API
+    )
+
+    // Qobuz tracks share the Track shape with TIDAL but are tagged so the UI
+    // can label them and so the existing dedup (distinctBy id) doesn't collapse
+    // a Qobuz hit onto the same numeric ID from TIDAL.
+    private fun Track.toQobuzUnifiedTrack(): UnifiedTrack = UnifiedTrack(
+        id = "qobuz_$id",
+        title = title,
+        durationSeconds = duration,
+        trackNumber = trackNumber,
+        discNumber = volumeNumber,
+        explicit = explicit,
+        artistName = displayArtist.ifBlank { DEFAULT_ARTIST_NAME },
+        artistNames = artists.map { it.name }.ifEmpty { listOfNotNull(artist?.name) },
+        albumArtistName = artist?.name,
+        albumTitle = album?.title,
+        albumId = album?.id?.toString(),
+        artworkUri = coverUrl,
+        source = PlaybackSource.HiFiApi(tidalId = id),
+        sourceType = SourceType.QOBUZ,
     )
 
     private fun scoreTracks(
@@ -269,6 +312,9 @@ class SearchViewModel @Inject constructor(
         SourceType.LOCAL -> SOURCE_BOOST_LOCAL
         SourceType.COLLECTION -> SOURCE_BOOST_COLLECTION
         SourceType.API -> SOURCE_BOOST_API
+        // Qobuz is download-only — keep below TIDAL streaming so taps default
+        // to a playable result when both sources surface the same query.
+        SourceType.QOBUZ -> SOURCE_BOOST_API - 5
     }
 
     private fun scoreField(query: String, rawValue: String?, baseScore: Int): Int {

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -183,10 +183,28 @@ class SearchViewModel @Inject constructor(
         // Qobuz failures (instance unset, network error, schema mismatch) are
         // swallowed so the existing TIDAL flow keeps working unchanged.
         val (searchResult, qobuzResult, unifiedResultsResult) = coroutineScope {
-            val apiDeferred = async { runCatching { repository.search(trimmedQuery) } }
+            // Source mode (Settings → Instances → Source) gates which
+            // catalogs we fan out to. TIDAL_ONLY / QOBUZ_ONLY skip the
+            // disabled side; BOTH (default) keeps the existing behavior.
+            val sourceMode = preferences.sourceMode.first()
+            val apiDeferred = async {
+                if (sourceMode == tf.monochrome.android.data.preferences.SourceMode.QOBUZ_ONLY) {
+                    runCatching {
+                        Result.failure<tf.monochrome.android.domain.model.SearchResult>(
+                            IllegalStateException("TIDAL disabled by source mode")
+                        )
+                    }
+                } else {
+                    runCatching { repository.search(trimmedQuery) }
+                }
+            }
             val qobuzDeferred = async {
-                withTimeoutOrNull(QOBUZ_BUDGET_MS) {
-                    runCatching { repository.searchQobuz(trimmedQuery) }
+                if (sourceMode == tf.monochrome.android.data.preferences.SourceMode.TIDAL_ONLY) {
+                    null
+                } else {
+                    withTimeoutOrNull(QOBUZ_BUDGET_MS) {
+                        runCatching { repository.searchQobuz(trimmedQuery) }
+                    }
                 }
             }
             val libraryDeferred = async { runCatching { unifiedLibrarySearch.search(trimmedQuery).first() } }

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -208,9 +208,14 @@ class SearchViewModel @Inject constructor(
 
         val qobuzSearch = qobuzResult?.getOrNull()?.getOrNull()
         val qobuzTracks = qobuzSearch?.tracks?.map { it.toQobuzUnifiedTrack() } ?: emptyList()
-        val qobuzAlbums = qobuzSearch?.albums ?: emptyList()
-        val qobuzArtists = qobuzSearch?.artists ?: emptyList()
-        val qobuzPlaylists = qobuzSearch?.playlists ?: emptyList()
+        // Qobuz album/artist detail endpoints aren't wired yet — clicking a
+        // Qobuz album would route through getAlbum(qobuzId) on the TIDAL pool
+        // (or Dev Mode override) and either return HTML (SPA index) or 404,
+        // surfacing as a JSON parse error in the detail screen. Drop them
+        // from the merged results until /api/get-album and /api/get-artist
+        // are wired. Tracks are still surfaced because their playback path
+        // (PlaybackSource.QobuzCached → /api/download-music → app cache)
+        // doesn't depend on a detail endpoint.
 
         if (searchResult.getOrNull()?.isSuccess == true) {
             val result = searchResult.getOrThrow().getOrThrow()
@@ -220,31 +225,23 @@ class SearchViewModel @Inject constructor(
                     result.tracks.map { it.toUnifiedTrack() } +
                     qobuzTracks
             )
-            _allAlbums.value = scoreItems(
-                trimmedQuery,
-                (result.albums + qobuzAlbums).distinctBy { it.id },
-            ) { listOf(it.title, it.displayArtist) }
-            _allArtists.value = scoreItems(
-                trimmedQuery,
-                (result.artists + qobuzArtists).distinctBy { it.id },
-            ) { listOf(it.name) }
-            _allPlaylists.value = scoreItems(
-                trimmedQuery,
-                (result.playlists + qobuzPlaylists).distinctBy { it.uuid },
-            ) { listOfNotNull(it.title, it.creator?.name, it.description) }
+            _allAlbums.value = scoreItems(trimmedQuery, result.albums) { listOf(it.title, it.displayArtist) }
+            _allArtists.value = scoreItems(trimmedQuery, result.artists) { listOf(it.name) }
+            _allPlaylists.value = scoreItems(trimmedQuery, result.playlists) {
+                listOfNotNull(it.title, it.creator?.name, it.description)
+            }
             preferences.addSearchHistoryQuery(trimmedQuery)
         } else {
-            // TIDAL is down — still surface Qobuz + local results so search
-            // doesn't feel broken when the public TIDAL pool is unreachable.
+            // TIDAL is down — still surface Qobuz tracks + local results so
+            // search doesn't feel broken when the public TIDAL pool is
+            // unreachable.
             _allTracks.value = scoreTracks(
                 query = trimmedQuery,
                 tracks = localAndCollectionTracks + qobuzTracks
             )
-            _allAlbums.value = scoreItems(trimmedQuery, qobuzAlbums) { listOf(it.title, it.displayArtist) }
-            _allArtists.value = scoreItems(trimmedQuery, qobuzArtists) { listOf(it.name) }
-            _allPlaylists.value = scoreItems(trimmedQuery, qobuzPlaylists) {
-                listOfNotNull(it.title, it.creator?.name, it.description)
-            }
+            _allAlbums.value = emptyList()
+            _allArtists.value = emptyList()
+            _allPlaylists.value = emptyList()
         }
         _isSearching.value = false
     }
@@ -276,7 +273,9 @@ class SearchViewModel @Inject constructor(
 
     // Qobuz tracks share the Track shape with TIDAL but are tagged so the UI
     // can label them and so the existing dedup (distinctBy id) doesn't collapse
-    // a Qobuz hit onto the same numeric ID from TIDAL.
+    // a Qobuz hit onto the same numeric ID from TIDAL. Source is QobuzCached
+    // — playback fetches the file via /api/download-music into the app cache
+    // and ExoPlayer plays from the local file.
     private fun Track.toQobuzUnifiedTrack(): UnifiedTrack = UnifiedTrack(
         id = "qobuz_$id",
         title = title,
@@ -290,7 +289,7 @@ class SearchViewModel @Inject constructor(
         albumTitle = album?.title,
         albumId = album?.id?.toString(),
         artworkUri = coverUrl,
-        source = PlaybackSource.HiFiApi(tidalId = id),
+        source = PlaybackSource.QobuzCached(qobuzId = id),
         sourceType = SourceType.QOBUZ,
     )
 

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -208,14 +208,14 @@ class SearchViewModel @Inject constructor(
 
         val qobuzSearch = qobuzResult?.getOrNull()?.getOrNull()
         val qobuzTracks = qobuzSearch?.tracks?.map { it.toQobuzUnifiedTrack() } ?: emptyList()
-        // Qobuz album/artist detail endpoints aren't wired yet — clicking a
-        // Qobuz album would route through getAlbum(qobuzId) on the TIDAL pool
-        // (or Dev Mode override) and either return HTML (SPA index) or 404,
-        // surfacing as a JSON parse error in the detail screen. Drop them
-        // from the merged results until /api/get-album and /api/get-artist
-        // are wired. Tracks are still surfaced because their playback path
-        // (PlaybackSource.QobuzCached → /api/download-music → app cache)
-        // doesn't depend on a detail endpoint.
+        val qobuzAlbums = qobuzSearch?.albums ?: emptyList()
+        val qobuzArtists = qobuzSearch?.artists ?: emptyList()
+        // Qobuz album clicks are now wired through QobuzIdRegistry +
+        // AlbumDetailViewModel's Qobuz-first lookup. Artist clicks still fall
+        // through to the TIDAL artist endpoint until /api/get-artist's
+        // contract is verified — when that endpoint surfaces an unknown id
+        // it returns a Result.failure and the screen renders an error
+        // (handled, not a crash).
 
         if (searchResult.getOrNull()?.isSuccess == true) {
             val result = searchResult.getOrThrow().getOrThrow()
@@ -225,22 +225,27 @@ class SearchViewModel @Inject constructor(
                     result.tracks.map { it.toUnifiedTrack() } +
                     qobuzTracks
             )
-            _allAlbums.value = scoreItems(trimmedQuery, result.albums) { listOf(it.title, it.displayArtist) }
-            _allArtists.value = scoreItems(trimmedQuery, result.artists) { listOf(it.name) }
+            _allAlbums.value = scoreItems(
+                trimmedQuery,
+                (result.albums + qobuzAlbums).distinctBy { it.id },
+            ) { listOf(it.title, it.displayArtist) }
+            _allArtists.value = scoreItems(
+                trimmedQuery,
+                (result.artists + qobuzArtists).distinctBy { it.id },
+            ) { listOf(it.name) }
             _allPlaylists.value = scoreItems(trimmedQuery, result.playlists) {
                 listOfNotNull(it.title, it.creator?.name, it.description)
             }
             preferences.addSearchHistoryQuery(trimmedQuery)
         } else {
-            // TIDAL is down — still surface Qobuz tracks + local results so
-            // search doesn't feel broken when the public TIDAL pool is
-            // unreachable.
+            // TIDAL is down — still surface Qobuz + local results so search
+            // doesn't feel broken when the public TIDAL pool is unreachable.
             _allTracks.value = scoreTracks(
                 query = trimmedQuery,
                 tracks = localAndCollectionTracks + qobuzTracks
             )
-            _allAlbums.value = emptyList()
-            _allArtists.value = emptyList()
+            _allAlbums.value = scoreItems(trimmedQuery, qobuzAlbums) { listOf(it.title, it.displayArtist) }
+            _allArtists.value = scoreItems(trimmedQuery, qobuzArtists) { listOf(it.name) }
             _allPlaylists.value = emptyList()
         }
         _isSearching.value = false

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -40,6 +41,12 @@ class SearchViewModel @Inject constructor(
      */
     companion object {
         private const val SEARCH_DEBOUNCE_MS = 250L
+        // Hard ceiling on the Qobuz fan-out so the TIDAL flow can never be
+        // blocked behind a slow or hung Qobuz instance (coroutineScope waits
+        // for all children, so an unbounded child would freeze the whole
+        // search). HiFiApiClient.searchQobuz already times out per
+        // sub-request — this is a belt-and-suspenders ceiling.
+        private const val QOBUZ_BUDGET_MS = 7_000L
         private const val SCORE_WEIGHT_PRIMARY = 4_000
         private const val SCORE_WEIGHT_SECONDARY = 1_800
         private const val SCORE_WEIGHT_TERTIARY = 1_200
@@ -177,13 +184,18 @@ class SearchViewModel @Inject constructor(
         // swallowed so the existing TIDAL flow keeps working unchanged.
         val (searchResult, qobuzResult, unifiedResultsResult) = coroutineScope {
             val apiDeferred = async { runCatching { repository.search(trimmedQuery) } }
-            val qobuzDeferred = async { runCatching { repository.searchQobuz(trimmedQuery) } }
+            val qobuzDeferred = async {
+                withTimeoutOrNull(QOBUZ_BUDGET_MS) {
+                    runCatching { repository.searchQobuz(trimmedQuery) }
+                }
+            }
             val libraryDeferred = async { runCatching { unifiedLibrarySearch.search(trimmedQuery).first() } }
             Triple(apiDeferred.await(), qobuzDeferred.await(), libraryDeferred.await())
         }
         val unifiedResults = unifiedResultsResult.getOrNull()
 
-        if (searchResult.isFailure && unifiedResults == null && qobuzResult.isFailure) {
+        val qobuzAvailable = qobuzResult?.isSuccess == true
+        if (searchResult.isFailure && unifiedResults == null && !qobuzAvailable) {
             clearResults()
             _isSearching.value = false
             return
@@ -194,7 +206,7 @@ class SearchViewModel @Inject constructor(
             unifiedResults?.collectionTracks
         ).flatten()
 
-        val qobuzSearch = qobuzResult.getOrNull()?.getOrNull()
+        val qobuzSearch = qobuzResult?.getOrNull()?.getOrNull()
         val qobuzTracks = qobuzSearch?.tracks?.map { it.toQobuzUnifiedTrack() } ?: emptyList()
         val qobuzAlbums = qobuzSearch?.albums ?: emptyList()
         val qobuzArtists = qobuzSearch?.artists ?: emptyList()

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1050,14 +1050,16 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
     val apiInstances by viewModel.apiInstances.collectAsState()
     val streamingInstances by viewModel.streamingInstances.collectAsState()
     val customEndpoint by viewModel.customEndpoint.collectAsState()
+    val qobuzEndpoint by viewModel.qobuzEndpoint.collectAsState()
     val devModeEnabled by viewModel.devModeEnabled.collectAsState()
     val refreshing by viewModel.instancesRefreshing.collectAsState()
     var customInput by remember(customEndpoint) { mutableStateOf(customEndpoint ?: "") }
+    var qobuzInput by remember(qobuzEndpoint) { mutableStateOf(qobuzEndpoint ?: "") }
 
     SettingsTabContent {
         SettingSwitchItem(
             title = "Dev Mode",
-            subtitle = "Route all API requests through a local Tidal HiFi API server. Requires a compatible server running at the specified URL.",
+            subtitle = "Route all Tidal API/streaming requests through your own server. Requires a compatible Tidal HiFi instance at the URL below.",
             checked = devModeEnabled,
             onCheckedChange = { viewModel.setDevModeEnabled(it) }
         )
@@ -1068,12 +1070,12 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Dev Mode API URL",
+                    text = "Tidal HiFi URL",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Text(
-                    text = "The URL of your local Tidal HiFi API instance",
+                    text = "Used for search, browse, and streaming when Dev Mode is on",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1106,6 +1108,52 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
                             val trimmed = latestInput.value.trim().ifBlank { null }
                             if (trimmed != latestSaved.value) {
                                 viewModel.setCustomEndpoint(trimmed)
+                            }
+                        }
+                    }
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Qobuz URL",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "Used for downloads. Honored whenever set, independent of Dev Mode.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            val latestQobuzInput = rememberUpdatedState(qobuzInput)
+            val latestQobuzSaved = rememberUpdatedState(qobuzEndpoint)
+            OutlinedTextField(
+                value = qobuzInput,
+                onValueChange = { qobuzInput = it },
+                placeholder = {
+                    Text(
+                        "https://your-qobuz-instance",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    viewModel.setQobuzEndpoint(latestQobuzInput.value.trim().ifBlank { null })
+                }),
+                modifier = Modifier
+                    .widthIn(max = 240.dp)
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) {
+                            val trimmed = latestQobuzInput.value.trim().ifBlank { null }
+                            if (trimmed != latestQobuzSaved.value) {
+                                viewModel.setQobuzEndpoint(trimmed)
                             }
                         }
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -45,6 +45,9 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -1053,12 +1056,49 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
     val qobuzEndpoint by viewModel.qobuzEndpoint.collectAsState()
     val qobuzCookie by viewModel.qobuzCookie.collectAsState()
     val devModeEnabled by viewModel.devModeEnabled.collectAsState()
+    val sourceMode by viewModel.sourceMode.collectAsState()
     val refreshing by viewModel.instancesRefreshing.collectAsState()
     var customInput by remember(customEndpoint) { mutableStateOf(customEndpoint ?: "") }
     var qobuzInput by remember(qobuzEndpoint) { mutableStateOf(qobuzEndpoint ?: "") }
     var qobuzCookieInput by remember(qobuzCookie) { mutableStateOf(qobuzCookie ?: "") }
 
     SettingsTabContent {
+        // Source mode picker — controls which catalogs feed search/discovery.
+        // Plays/downloads still follow the per-track PlaybackSource so a
+        // download you triggered earlier keeps working regardless of this
+        // setting.
+        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+            Text(
+                text = "Catalog source",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Which catalogs power Search and Browse.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            val sourceOptions = listOf(
+                tf.monochrome.android.data.preferences.SourceMode.BOTH to "Both",
+                tf.monochrome.android.data.preferences.SourceMode.TIDAL_ONLY to "TIDAL only",
+                tf.monochrome.android.data.preferences.SourceMode.QOBUZ_ONLY to "Qobuz only",
+            )
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                sourceOptions.forEachIndexed { index, (mode, label) ->
+                    SegmentedButton(
+                        selected = sourceMode == mode,
+                        onClick = { viewModel.setSourceMode(mode) },
+                        shape = SegmentedButtonDefaults.itemShape(index, sourceOptions.size),
+                    ) {
+                        Text(label)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
         SettingSwitchItem(
             title = "Dev Mode",
             subtitle = "Route all Tidal API/streaming requests through your own server. Requires a compatible Tidal HiFi instance at the URL below.",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1051,10 +1051,12 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
     val streamingInstances by viewModel.streamingInstances.collectAsState()
     val customEndpoint by viewModel.customEndpoint.collectAsState()
     val qobuzEndpoint by viewModel.qobuzEndpoint.collectAsState()
+    val qobuzCookie by viewModel.qobuzCookie.collectAsState()
     val devModeEnabled by viewModel.devModeEnabled.collectAsState()
     val refreshing by viewModel.instancesRefreshing.collectAsState()
     var customInput by remember(customEndpoint) { mutableStateOf(customEndpoint ?: "") }
     var qobuzInput by remember(qobuzEndpoint) { mutableStateOf(qobuzEndpoint ?: "") }
+    var qobuzCookieInput by remember(qobuzCookie) { mutableStateOf(qobuzCookie ?: "") }
 
     SettingsTabContent {
         SettingSwitchItem(
@@ -1154,6 +1156,52 @@ private fun InstancesTab(viewModel: SettingsViewModel) {
                             val trimmed = latestQobuzInput.value.trim().ifBlank { null }
                             if (trimmed != latestQobuzSaved.value) {
                                 viewModel.setQobuzEndpoint(trimmed)
+                            }
+                        }
+                    }
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Qobuz Auth Cookie",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "Optional. Paste the GAESA=… session cookie from the trypt-hifi web app's DevTools → Application → Cookies if the API requires auth.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            val latestCookieInput = rememberUpdatedState(qobuzCookieInput)
+            val latestCookieSaved = rememberUpdatedState(qobuzCookie)
+            OutlinedTextField(
+                value = qobuzCookieInput,
+                onValueChange = { qobuzCookieInput = it },
+                placeholder = {
+                    Text(
+                        "GAESA=…",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = {
+                    viewModel.setQobuzCookie(latestCookieInput.value.trim().ifBlank { null })
+                }),
+                modifier = Modifier
+                    .widthIn(max = 240.dp)
+                    .onFocusChanged { focusState ->
+                        if (!focusState.isFocused) {
+                            val trimmed = latestCookieInput.value.trim().ifBlank { null }
+                            if (trimmed != latestCookieSaved.value) {
+                                viewModel.setQobuzCookie(trimmed)
                             }
                         }
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -170,6 +170,8 @@ class SettingsViewModel @Inject constructor(
     val streamingInstances: StateFlow<List<Instance>> = _streamingInstances.asStateFlow()
     val customEndpoint: StateFlow<String?> = preferences.customApiEndpoint
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val qobuzEndpoint: StateFlow<String?> = preferences.qobuzInstanceUrl
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     val devModeEnabled: StateFlow<Boolean> = preferences.devModeEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     private val _instancesRefreshing = MutableStateFlow(false)
@@ -429,6 +431,12 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             preferences.setCustomApiEndpoint(endpoint)
             loadInstances()
+        }
+    }
+
+    fun setQobuzEndpoint(endpoint: String?) {
+        viewModelScope.launch {
+            preferences.setQobuzInstanceUrl(endpoint)
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -176,6 +176,12 @@ class SettingsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     val devModeEnabled: StateFlow<Boolean> = preferences.devModeEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+    val sourceMode: StateFlow<tf.monochrome.android.data.preferences.SourceMode> =
+        preferences.sourceMode.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            tf.monochrome.android.data.preferences.SourceMode.BOTH,
+        )
     private val _instancesRefreshing = MutableStateFlow(false)
     val instancesRefreshing: StateFlow<Boolean> = _instancesRefreshing.asStateFlow()
 
@@ -445,6 +451,13 @@ class SettingsViewModel @Inject constructor(
     fun setQobuzCookie(cookie: String?) {
         viewModelScope.launch {
             preferences.setQobuzAuthCookie(cookie)
+        }
+    }
+
+    fun setSourceMode(mode: tf.monochrome.android.data.preferences.SourceMode) {
+        viewModelScope.launch {
+            preferences.setSourceMode(mode)
+            loadInstances()
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -172,6 +172,8 @@ class SettingsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     val qobuzEndpoint: StateFlow<String?> = preferences.qobuzInstanceUrl
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+    val qobuzCookie: StateFlow<String?> = preferences.qobuzAuthCookie
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     val devModeEnabled: StateFlow<Boolean> = preferences.devModeEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     private val _instancesRefreshing = MutableStateFlow(false)
@@ -437,6 +439,12 @@ class SettingsViewModel @Inject constructor(
     fun setQobuzEndpoint(endpoint: String?) {
         viewModelScope.launch {
             preferences.setQobuzInstanceUrl(endpoint)
+        }
+    }
+
+    fun setQobuzCookie(cookie: String?) {
+        viewModelScope.launch {
+            preferences.setQobuzAuthCookie(cookie)
         }
     }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- DownloadWorker writes here when no SAF folder is configured. -->
+    <external-files-path
+        name="downloads"
+        path="downloads/" />
+
+    <!-- QobuzStreamCacheManager parks fetched stream files here. -->
+    <cache-path
+        name="qobuz_stream"
+        path="qobuz_stream/" />
+
+    <!-- Local library files scanned by MediaStore. Granting from the root
+         of external storage is the simplest path; FileProvider grants are
+         per-URI and time-limited, so the share sheet only ever exposes the
+         specific track URI we hand out. -->
+    <external-path
+        name="external"
+        path="." />
+</paths>


### PR DESCRIPTION
Adds InstanceType.DOWNLOAD pinned to trypt-hifi-dl (Cloud Run), kept out
of the general API/streaming pool so playback search/browse stays on the
TIDAL instances. DownloadWorker now requests the stream manifest via the
download instance, so saved files come from the project-owned Qobuz
backend instead of whichever public TIDAL mirror happens to be live.