### PR TITLE
Refactor NowPlayingHero to accept player state as parameters

### DIFF
--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -408,7 +408,10 @@ fun NowPlayingScreen(
                         spectrumBins = spectrumBins,
                         spectrumColor = spectrumColor,
                         showSpectrum = showNpSpectrum,
-                        onToggleShowSpectrum = onToggleShowSpectrum
+                        onToggleShowSpectrum = onToggleShowSpectrum,
+                        albumColors = albumColors,
+                        positionMs = playerViewModel.positionMs,
+                        onSeekTo = playerViewModel::seekTo,
                     )
                 }
 
@@ -749,7 +752,10 @@ private fun NowPlayingHero(
     spectrumBins: FloatArray = FloatArray(0),
     spectrumColor: Color = Color(0xFF7EB6FF),
     showSpectrum: Boolean = true,
-    onToggleShowSpectrum: () -> Unit = {}
+    onToggleShowSpectrum: () -> Unit = {},
+    albumColors: AlbumColors,
+    positionMs: kotlinx.coroutines.flow.StateFlow<Long>,
+    onSeekTo: (Long) -> Unit,
 ) {
     var showOverlay by androidx.compose.runtime.remember(viewMode) {
         androidx.compose.runtime.mutableStateOf(viewMode == NowPlayingViewMode.VISUALIZER) 
@@ -844,10 +850,10 @@ private fun NowPlayingHero(
                         NowPlayingViewMode.LYRICS -> LyricsHeroPanel(
                             lyrics = lyrics,
                             isLoading = isLyricsLoading,
-                            coverUrl = currentTrack?.coverUrl,
+                            coverUrl = track?.coverUrl,
                             albumColors = albumColors,
-                            positionMs = playerViewModel.positionMs,
-                            onSeekTo = { ms -> playerViewModel.seekTo(ms) },
+                            positionMs = positionMs,
+                            onSeekTo = onSeekTo,
                         )
                         NowPlayingViewMode.QUEUE -> QueueHeroPanel(queuePreview = queuePreview)
                     }


### PR DESCRIPTION
## Summary
Refactored the `NowPlayingHero` composable to accept player state (album colors, position, and seek callback) as parameters instead of accessing them directly from `playerViewModel`. This improves testability and reduces tight coupling to the view model.

## Key Changes
- Added three new parameters to `NowPlayingHero`:
  - `albumColors: AlbumColors` - album color information
  - `positionMs: StateFlow<Long>` - current playback position
  - `onSeekTo: (Long) -> Unit` - callback for seeking to a position
- Updated the call site in `NowPlayingScreen` to pass these parameters from the player view model
- Fixed a bug in `LyricsHeroPanel` call where `currentTrack?.coverUrl` is now correctly referenced as `track?.coverUrl`
- Replaced direct view model method calls with the injected callback (`onSeekTo` instead of `playerViewModel.seekTo()`)

## Implementation Details
- The refactoring maintains the same functionality while improving separation of concerns
- `NowPlayingHero` is now more composable-friendly by accepting dependencies as parameters rather than accessing them from a view model instance
- This change makes the composable easier to test and preview with different state values

https://claude.ai/code/session_01PB1E59uhWca3RrmvoPNtVZ