### PR TITLE
fix(imports): restore fully-qualified import paths

### DIFF
--- a/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/NowPlayingScreen.kt
@@ -23,12 +23,12 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import PaddingValues
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import LazyColumn
-import itemsIndexed
-import rememberLazyListState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons


### PR DESCRIPTION
Previous sed rewrite collapsed the fully-qualified package paths in the import statements themselves, leaving 'import PaddingValues' etc., which the compiler can't resolve.