### PR TITLE
uac2: surface diagnostics + categorised errors to settings

### DIFF
--- a/app/src/main/cpp/usb/libusb_uac_driver.cpp
+++ b/app/src/main/cpp/usb/libusb_uac_driver.cpp
@@ -92,6 +92,42 @@ LibusbUacDriver::~LibusbUacDriver() {
     }
 }
 
+std::string LibusbUacDriver::lastErrorDetail() const {
+    std::lock_guard<std::mutex> lock(errorMutex_);
+    return lastErrorDetail_;
+}
+
+std::vector<ClockRateRange> LibusbUacDriver::supportedRates() const {
+    std::lock_guard<std::mutex> lock(errorMutex_);
+    return supportedRates_;
+}
+
+namespace {
+
+// Members `lastError_` / `lastErrorDetail_` are private, so we route
+// through a small lambda created at the failure site. Keeping the
+// mechanism inline (rather than a setter method) avoids polluting the
+// public surface with something only the implementation needs.
+
+} // namespace
+
+// Sets [code] + [detail], logs at WARN. Internal-only — every call site
+// in this file calls it through a lambda capture so the lock + log
+// stay co-located with the failure context.
+namespace {
+struct ErrorSink {
+    std::atomic<StartError>* code;
+    std::mutex* m;
+    std::string* detail;
+    void operator()(StartError c, std::string text) const {
+        code->store(c, std::memory_order_release);
+        std::lock_guard<std::mutex> lock(*m);
+        *detail = std::move(text);
+        LOGW("start error %d: %s", static_cast<int>(c), detail->c_str());
+    }
+};
+} // namespace
+
 bool LibusbUacDriver::ensureContext() {
     if (contextReady_.load(std::memory_order_acquire)) return true;
     std::lock_guard<std::mutex> lock(mutex_);
@@ -300,7 +336,64 @@ bool LibusbUacDriver::selectAltSetting(int sampleRateHz, int bitsPerSample,
                             // verify the requested rate is supported.
                             // Type=0 means continuous [lo, hi]; other
                             // values are the discrete rate count.
-                            if (len >= 8) {
+                            //
+                            // Also push every advertised rate into
+                            // supportedRates_ so the UI can list what
+                            // this UAC1 device supports — UAC1 has no
+                            // clock entities, so we use clockId=0 as
+                            // the synthetic "endpoint clock" marker.
+                            // Only do this for alts that match our
+                            // requested channels/bits, otherwise an
+                            // unrelated 5.1 alt would pollute the list.
+                            if (len >= 8 && altChannels == channels
+                                && altBits == bitsPerSample) {
+                                int kind = p[7];
+                                int reqRate = sampleRateHz;
+                                if (kind == 0 && len >= 14) {
+                                    auto rd24 = [](const uint8_t* q) {
+                                        return static_cast<uint32_t>(q[0]) |
+                                               (static_cast<uint32_t>(q[1]) << 8) |
+                                               (static_cast<uint32_t>(q[2]) << 16);
+                                    };
+                                    uint32_t lo = rd24(p + 8);
+                                    uint32_t hi = rd24(p + 11);
+                                    rateSupportedByDescriptor =
+                                        (static_cast<uint32_t>(reqRate) >= lo &&
+                                         static_cast<uint32_t>(reqRate) <= hi);
+                                    std::lock_guard<std::mutex> elock(errorMutex_);
+                                    bool dup = false;
+                                    for (const auto& e : supportedRates_) {
+                                        if (e.minHz == lo && e.maxHz == hi) {
+                                            dup = true; break;
+                                        }
+                                    }
+                                    if (!dup) supportedRates_.push_back({0, lo, hi, 0});
+                                } else if (kind > 0) {
+                                    rateSupportedByDescriptor = false;
+                                    std::lock_guard<std::mutex> elock(errorMutex_);
+                                    for (int k = 0; k < kind; ++k) {
+                                        int off = 8 + k * 3;
+                                        if (off + 3 > len) break;
+                                        uint32_t hz =
+                                            static_cast<uint32_t>(p[off]) |
+                                            (static_cast<uint32_t>(p[off + 1]) << 8) |
+                                            (static_cast<uint32_t>(p[off + 2]) << 16);
+                                        if (static_cast<int>(hz) == reqRate) {
+                                            rateSupportedByDescriptor = true;
+                                        }
+                                        bool dup = false;
+                                        for (const auto& e : supportedRates_) {
+                                            if (e.minHz == hz && e.maxHz == hz) {
+                                                dup = true; break;
+                                            }
+                                        }
+                                        if (!dup) supportedRates_.push_back({0, hz, hz, 0});
+                                    }
+                                }
+                            } else if (len >= 8) {
+                                // Channels/bits don't match — keep the
+                                // rate-supported check working without
+                                // polluting the inventory.
                                 int kind = p[7];
                                 int reqRate = sampleRateHz;
                                 if (kind == 0 && len >= 14) {
@@ -488,6 +581,42 @@ bool LibusbUacDriver::selectAltSetting(int sampleRateHz, int bitsPerSample,
     return found;
 }
 
+void LibusbUacDriver::captureRangeForClock(uint8_t clockId) {
+    if (clockId == 0 || !device_) return;
+    uint8_t rng[256] = {0};
+    int gr = libusb_control_transfer(
+        device_, /*bmRequestType=*/0xA1, /*RANGE=*/0x02,
+        static_cast<uint16_t>(CS_SAM_FREQ_CONTROL_SEL << 8),
+        static_cast<uint16_t>(
+            (clockId << 8) | format_.controlInterfaceNum),
+        rng, sizeof(rng), 1000);
+    if (gr < 2) {
+        LOGW("captureRangeForClock(%u): GET_RANGE returned %d (no rate "
+             "inventory available — UI won't show supported rates)",
+             clockId, gr);
+        return;
+    }
+    int n = rng[0] | (rng[1] << 8);
+    std::lock_guard<std::mutex> elock(errorMutex_);
+    for (int i = 0; i < n && (2 + (i + 1) * 12) <= gr; ++i) {
+        const uint8_t* t = rng + 2 + i * 12;
+        uint32_t mn = uint32_t(t[0]) | (uint32_t(t[1]) << 8) |
+                      (uint32_t(t[2]) << 16) | (uint32_t(t[3]) << 24);
+        uint32_t mx = uint32_t(t[4]) | (uint32_t(t[5]) << 8) |
+                      (uint32_t(t[6]) << 16) | (uint32_t(t[7]) << 24);
+        uint32_t res = uint32_t(t[8]) | (uint32_t(t[9]) << 8) |
+                       (uint32_t(t[10]) << 16) | (uint32_t(t[11]) << 24);
+        bool dup = false;
+        for (const auto& e : supportedRates_) {
+            if (e.minHz == mn && e.maxHz == mx && e.resHz == res) {
+                dup = true; break;
+            }
+        }
+        if (!dup) supportedRates_.push_back({clockId, mn, mx, res});
+    }
+    LOGI("captureRangeForClock(%u): %d subrange(s) cached", clockId, n);
+}
+
 bool LibusbUacDriver::setSampleRate(uint32_t hz) {
     if (format_.uacVersion >= 0x0200) {
         // UAC2 §5.2.5.1.1 — SET_CUR(SAM_FREQ_CONTROL) on a clock
@@ -536,6 +665,12 @@ bool LibusbUacDriver::setSampleRate(uint32_t hz) {
                      winningId, format_.clockSourceId);
                 format_.clockSourceId = winningId;
             }
+            // Capture the rate inventory on the success path too so
+            // the Settings UI can show "supports 44.1 / 48 / 88.2 /
+            // 96 / 176.4 / 192 kHz" beneath the active rate. Failures
+            // already get this via the diagnostic loop below; on
+            // success we only need to ask the winning clock entity.
+            captureRangeForClock(winningId);
             return true;
         }
         // STALL or I/O error: many UAC2 DACs (Focal Bathys included)
@@ -581,13 +716,27 @@ bool LibusbUacDriver::setSampleRate(uint32_t hz) {
                      id, hzGot, gr);
                 if (gr >= 2) {
                     int n = rng[0] | (rng[1] << 8);
+                    std::lock_guard<std::mutex> elock(errorMutex_);
                     for (int i = 0; i < n && (2 + (i + 1) * 12) <= gr; ++i) {
                         const uint8_t* t = rng + 2 + i * 12;
                         uint32_t mn = uint32_t(t[0]) | (uint32_t(t[1]) << 8) |
                                       (uint32_t(t[2]) << 16) | (uint32_t(t[3]) << 24);
                         uint32_t mx = uint32_t(t[4]) | (uint32_t(t[5]) << 8) |
                                       (uint32_t(t[6]) << 16) | (uint32_t(t[7]) << 24);
-                        LOGI("    range[%d]: %u..%u Hz", i, mn, mx);
+                        uint32_t res = uint32_t(t[8]) | (uint32_t(t[9]) << 8) |
+                                       (uint32_t(t[10]) << 16) | (uint32_t(t[11]) << 24);
+                        LOGI("    range[%d]: %u..%u Hz res=%u", i, mn, mx, res);
+                        // Avoid duplicating entries if a previous
+                        // candidate clock already reported the same
+                        // subrange — happens on devices where the
+                        // SELECTOR mirrors the SOURCE's range.
+                        bool dup = false;
+                        for (const auto& e : supportedRates_) {
+                            if (e.minHz == mn && e.maxHz == mx && e.resHz == res) {
+                                dup = true; break;
+                            }
+                        }
+                        if (!dup) supportedRates_.push_back({id, mn, mx, res});
                     }
                 }
             }
@@ -650,8 +799,20 @@ bool LibusbUacDriver::setSampleRate(uint32_t hz) {
 
 bool LibusbUacDriver::start(int sampleRateHz, int bitsPerSample, int channels) {
     std::lock_guard<std::mutex> lock(mutex_);
+    ErrorSink err{&lastError_, &errorMutex_, &lastErrorDetail_};
+    // Optimistic clear; failure sites overwrite. Successful return
+    // also clears at the bottom.
+    lastError_.store(StartError::Ok, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> elock(errorMutex_);
+        lastErrorDetail_.clear();
+        // Drop the previous start's rate inventory — we'll repopulate
+        // on this start (or leave empty if the device returns nothing).
+        supportedRates_.clear();
+    }
     if (!device_) {
-        LOGE("start() called before open()");
+        err(StartError::NoDevice, "start() called before open() — "
+            "no UsbDeviceConnection wrapped yet");
         return false;
     }
     if (streaming_.load(std::memory_order_acquire)) {
@@ -665,6 +826,12 @@ bool LibusbUacDriver::start(int sampleRateHz, int bitsPerSample, int channels) {
 
     StreamFormat fmt{};
     if (!selectAltSetting(sampleRateHz, bitsPerSample, channels, &fmt)) {
+        err(StartError::NoMatchingAlt,
+            "no AS alt setting matches " +
+            std::to_string(sampleRateHz) + " Hz / " +
+            std::to_string(bitsPerSample) + "-bit / " +
+            std::to_string(channels) + "ch — DAC may not support "
+            "this rate at this bit depth");
         return false;
     }
 
@@ -680,12 +847,20 @@ bool LibusbUacDriver::start(int sampleRateHz, int bitsPerSample, int channels) {
         }
         int rc = libusb_claim_interface(device_, fmt.interfaceNumber);
         if (rc != LIBUSB_SUCCESS) {
+            const char* libErr = libusb_strerror(rc);
             LOGE("claim_interface(%u) -> %d (%s) — Developer Options "
                  "'Disable USB audio routing' must be ON, AND the "
                  "older 'USB DAC bit-perfect routing' toggle must be "
                  "OFF (it grabs the device via the framework and "
                  "fights us for the claim)",
-                 fmt.interfaceNumber, rc, libusb_strerror(rc));
+                 fmt.interfaceNumber, rc, libErr);
+            err(StartError::ClaimInterfaceFailed,
+                std::string("libusb_claim_interface(") +
+                std::to_string(fmt.interfaceNumber) + ") -> " +
+                libErr + ". Most likely Android's audio HAL still " +
+                "owns the streaming interface — turn ON Developer " +
+                "Options → Disable USB audio routing, and ensure " +
+                "the framework-routing toggle (above) is OFF.");
             return false;
         }
         interfaceClaimed_ = true;
@@ -725,9 +900,20 @@ bool LibusbUacDriver::start(int sampleRateHz, int bitsPerSample, int channels) {
     if (rc != LIBUSB_SUCCESS) {
         LOGE("set_interface_alt_setting(%u, %u) -> %d",
              format_.interfaceNumber, format_.altSetting, rc);
+        err(StartError::SetAltFailed,
+            std::string("libusb_set_interface_alt_setting(iface=") +
+            std::to_string(format_.interfaceNumber) + ", alt=" +
+            std::to_string(format_.altSetting) + ") -> " +
+            libusb_strerror(rc));
         return false;
     }
     if (!setSampleRate(static_cast<uint32_t>(sampleRateHz))) {
+        err(StartError::SetSampleRateFailed,
+            "no clock entity accepted SET_CUR(" +
+            std::to_string(sampleRateHz) +
+            " Hz) and GET_CUR didn't already report this rate. "
+            "Check the GET_RANGE log lines for what rates each "
+            "clock supports.");
         return false;
     }
 
@@ -739,6 +925,12 @@ bool LibusbUacDriver::start(int sampleRateHz, int bitsPerSample, int channels) {
     stopRequested_.store(false, std::memory_order_relaxed);
 
     if (!startIsoPump()) {
+        // startIsoPump() sets the specific subcategory itself based
+        // on whether alloc or submit failed. Don't overwrite here.
+        if (lastError_.load(std::memory_order_relaxed) == StartError::Ok) {
+            err(StartError::IsoPumpAllocFailed,
+                "iso pump failed to start (see logcat for details)");
+        }
         return false;
     }
     streaming_.store(true, std::memory_order_release);
@@ -845,10 +1037,19 @@ bool LibusbUacDriver::startIsoPump() {
     transfers_.reserve(kNumTransfers);
     transferBuffers_.reserve(kNumTransfers);
 
+    auto setErr = [this](StartError c, const std::string& d) {
+        lastError_.store(c, std::memory_order_release);
+        std::lock_guard<std::mutex> lock(errorMutex_);
+        lastErrorDetail_ = d;
+    };
+
     for (int t = 0; t < kNumTransfers; ++t) {
         libusb_transfer* xfr = libusb_alloc_transfer(kPacketsPerTransfer);
         if (!xfr) {
             LOGE("libusb_alloc_transfer failed at #%d", t);
+            setErr(StartError::IsoPumpAllocFailed,
+                   "libusb_alloc_transfer returned null at transfer #" +
+                   std::to_string(t) + " — likely OOM");
             stopIsoPump();
             return false;
         }
@@ -882,6 +1083,9 @@ bool LibusbUacDriver::startIsoPump() {
             libusb_transfer* fxfr = libusb_alloc_transfer(/*iso pkts=*/1);
             if (!fxfr) {
                 LOGE("alloc feedback transfer %d failed", t);
+                setErr(StartError::IsoPumpAllocFailed,
+                       "libusb_alloc_transfer (feedback) returned null at #" +
+                       std::to_string(t));
                 stopIsoPump();
                 return false;
             }
@@ -918,6 +1122,9 @@ bool LibusbUacDriver::startIsoPump() {
         int rc = libusb_submit_transfer(fxfr);
         if (rc != LIBUSB_SUCCESS) {
             LOGE("initial submit feedback -> %d", rc);
+            setErr(StartError::IsoPumpSubmitFailed,
+                   std::string("libusb_submit_transfer (feedback) -> ") +
+                   libusb_strerror(rc));
             stopRequested_.store(true, std::memory_order_release);
             stopIsoPump();
             return false;
@@ -928,6 +1135,9 @@ bool LibusbUacDriver::startIsoPump() {
         int rc = libusb_submit_transfer(xfr);
         if (rc != LIBUSB_SUCCESS) {
             LOGE("initial submit_transfer -> %d", rc);
+            setErr(StartError::IsoPumpSubmitFailed,
+                   std::string("libusb_submit_transfer -> ") +
+                   libusb_strerror(rc));
             stopRequested_.store(true, std::memory_order_release);
             stopIsoPump();
             return false;

--- a/app/src/main/cpp/usb/libusb_uac_driver.h
+++ b/app/src/main/cpp/usb/libusb_uac_driver.h
@@ -18,12 +18,44 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
 #include <libusb.h>
 
 namespace monotrypt::usb {
+
+// Categorised reason the most recent start() returned false. Surfaced
+// to Kotlin so the Settings screen can show actionable text instead of
+// the prior "kernel still owns it" boilerplate which was wrong about
+// half the time (rate negotiation failures, clock STALLs, alloc
+// failures all looked the same to the user). Order matches Kotlin's
+// LibusbUacDriver.StartError enum.
+enum class StartError : int {
+    Ok = 0,
+    NoDevice,                  // start() before open()
+    NoMatchingAlt,             // selectAltSetting found nothing
+    ClaimInterfaceFailed,      // libusb_claim_interface (most common
+                               // — kernel UAC driver owns the iface)
+    SetAltFailed,              // libusb_set_interface_alt_setting
+    SetSampleRateFailed,       // SET_CUR/GET_CUR all fell through
+    IsoPumpAllocFailed,        // libusb_alloc_transfer returned null
+    IsoPumpSubmitFailed,       // initial libusb_submit_transfer
+};
+
+// One subrange entry returned by GET_RANGE on a clock entity. UAC2
+// §5.2.1 RANGE attribute — wNumSubRanges followed by N triples of
+// (dMIN, dMAX, dRES) each 4-byte LE. Most DACs report each supported
+// discrete rate as its own subrange with min==max; some (like USB
+// audio interfaces with a continuous PLL) report a single subrange
+// covering a range. We surface both honestly.
+struct ClockRateRange {
+    uint8_t clockId = 0;
+    uint32_t minHz = 0;
+    uint32_t maxHz = 0;
+    uint32_t resHz = 0;
+};
 
 // Negotiated PCM stream parameters (output of UAC2 enumeration).
 struct StreamFormat {
@@ -146,6 +178,26 @@ public:
 
     const StreamFormat& currentFormat() const { return format_; }
 
+    // Reason the most recent start() returned false, or Ok if it
+    // succeeded / hasn't been attempted. Reset to Ok on the next
+    // successful start.
+    StartError lastError() const {
+        return lastError_.load(std::memory_order_acquire);
+    }
+
+    // Best-effort detail string accompanying [lastError]. May be empty.
+    // Holds the libusb_strerror text or a contextual line written at
+    // the failure site.
+    std::string lastErrorDetail() const;
+
+    // Snapshot of the GET_RANGE table reported by the device's clock
+    // entities. Populated during start(); empty before any start
+    // attempt or if the device returned nothing readable. Used by the
+    // Settings UI to show what rates the DAC actually supports —
+    // people want to know whether their hi-res 24/192 file is going
+    // bit-perfect or quietly being downsampled to 48k.
+    std::vector<ClockRateRange> supportedRates() const;
+
 private:
     // Walks the active config, finds an Audio Streaming alt-setting
     // whose AS_GENERAL/AS_FORMAT_TYPE descriptors match the request,
@@ -157,6 +209,13 @@ private:
     // control transfer to the clock source entity. UAC2 puts the rate
     // on a clock-source unit, not on the endpoint like UAC1 did.
     bool setSampleRate(uint32_t hz);
+
+    // Issues GET_RANGE on the given clock entity and appends decoded
+    // (min, max, res) subranges into supportedRates_. No-op if the
+    // device returns less than the 2-byte wNumSubRanges header. Used
+    // on the success path of setSampleRate so the UI can list "44.1 /
+    // 48 / 88.2 / 96 / 176.4 / 192 kHz" beneath the active rate.
+    void captureRangeForClock(uint8_t clockId);
 
     bool startIsoPump();
     void stopIsoPump();
@@ -235,6 +294,22 @@ private:
 
     static void LIBUSB_CALL onFeedbackTrampoline(libusb_transfer* xfr);
     void onFeedback(libusb_transfer* xfr);
+
+    // Persist the most recent failure category + a human-readable
+    // detail line. Mutated only from start()'s call stack (under
+    // mutex_) and from setSampleRate; read from any thread via
+    // lastError() / lastErrorDetail() so we don't have to plumb a
+    // result code back through several layers. Reset to Ok at the
+    // top of every start() call.
+    std::atomic<StartError> lastError_{StartError::Ok};
+    mutable std::mutex errorMutex_;
+    std::string lastErrorDetail_;
+
+    // Filled at start() time by setSampleRate's GET_RANGE pass. Read
+    // by the JNI getter to surface to the UI. Guarded by the same
+    // errorMutex_ — readers and the start() writer don't race on the
+    // hot path.
+    std::vector<ClockRateRange> supportedRates_;
 };
 
 } // namespace monotrypt::usb

--- a/app/src/main/cpp/usb/usb_jni.cpp
+++ b/app/src/main/cpp/usb/usb_jni.cpp
@@ -107,4 +107,100 @@ Java_tf_monochrome_android_audio_usb_LibusbUacDriver_nativePendingFrames(
     return static_cast<jlong>(w > p ? w - p : 0);
 }
 
+// --- Diagnostics surface ---------------------------------------------
+//
+// These getters back the BypassDiagnostics StateFlow surfaced to the
+// Settings UI. They're snapshot-cheap on the read side: lastError() is
+// an atomic load; lastErrorDetail() and supportedRates() each take the
+// driver's errorMutex_ briefly, which only contends with start() (a
+// rare, off-the-hot-path event).
+
+JNIEXPORT jint JNICALL
+Java_tf_monochrome_android_audio_usb_LibusbUacDriver_nativeLastErrorCode(
+    JNIEnv*, jobject) {
+    return static_cast<jint>(driver().lastError());
+}
+
+JNIEXPORT jstring JNICALL
+Java_tf_monochrome_android_audio_usb_LibusbUacDriver_nativeLastErrorDetail(
+    JNIEnv* env, jobject) {
+    std::string s = driver().lastErrorDetail();
+    return env->NewStringUTF(s.c_str());
+}
+
+// Returns a flat int[] of (clockId, minHz, maxHz, resHz) quads — one
+// quad per ClockRateRange. Length is always a multiple of 4. Empty
+// array if the driver hasn't started yet, the device returned no
+// GET_RANGE data (UAC1 with no descriptor table), or every clock
+// entity refused both SET_CUR and GET_CUR.
+//
+// Why a flat int[] instead of a typed object[]: keeps the JNI binding
+// dependency-free (no FindClass / NewObject for a packed struct) and
+// makes the marshalling unambiguous — the Kotlin side rebuilds typed
+// objects in one pass over groups of 4.
+JNIEXPORT jintArray JNICALL
+Java_tf_monochrome_android_audio_usb_LibusbUacDriver_nativeSupportedRates(
+    JNIEnv* env, jobject) {
+    auto ranges = driver().supportedRates();
+    jintArray arr = env->NewIntArray(static_cast<jsize>(ranges.size() * 4));
+    if (!arr || ranges.empty()) return arr;
+    std::vector<jint> packed;
+    packed.reserve(ranges.size() * 4);
+    for (const auto& r : ranges) {
+        packed.push_back(static_cast<jint>(r.clockId));
+        // GET_RANGE values are 32-bit unsigned (per UAC2 §5.2.1).
+        // Hz values fit in 31 bits comfortably (max valid is ~768k),
+        // so the unsigned-to-signed cast is safe in practice.
+        packed.push_back(static_cast<jint>(r.minHz));
+        packed.push_back(static_cast<jint>(r.maxHz));
+        packed.push_back(static_cast<jint>(r.resHz));
+    }
+    env->SetIntArrayRegion(arr, 0, static_cast<jsize>(packed.size()), packed.data());
+    return arr;
+}
+
+// Returns a long[] packing the negotiated stream parameters in a
+// fixed order so the Kotlin side can deserialize without tagged
+// fields. Order:
+//   [0] sampleRateHz
+//   [1] bitsPerSample
+//   [2] channels
+//   [3] interfaceNumber
+//   [4] altSetting
+//   [5] endpointAddress
+//   [6] maxPacketSize
+//   [7] bInterval
+//   [8] uacVersion (0x0100 = UAC1, 0x0200 = UAC2)
+//   [9] clockSourceId (0 if UAC1 / no resolved clock)
+//   [10] feedbackEndpointAddress (0 if absent)
+//   [11] isHighSpeed (1/0)
+//   [12] bytesPerSample (subslot size)
+// Returns null when the driver isn't streaming — caller should hide
+// the diagnostics block.
+JNIEXPORT jlongArray JNICALL
+Java_tf_monochrome_android_audio_usb_LibusbUacDriver_nativeActiveStream(
+    JNIEnv* env, jobject) {
+    if (!driver().isStreaming()) return nullptr;
+    const auto& f = driver().currentFormat();
+    jlong packed[13] = {
+        static_cast<jlong>(f.sampleRateHz),
+        static_cast<jlong>(f.bitsPerSample),
+        static_cast<jlong>(f.channels),
+        static_cast<jlong>(f.interfaceNumber),
+        static_cast<jlong>(f.altSetting),
+        static_cast<jlong>(f.endpointAddress),
+        static_cast<jlong>(f.maxPacketSize),
+        static_cast<jlong>(f.bInterval),
+        static_cast<jlong>(f.uacVersion),
+        static_cast<jlong>(f.clockSourceId),
+        static_cast<jlong>(f.feedbackEndpointAddress),
+        f.isHighSpeed ? jlong{1} : jlong{0},
+        static_cast<jlong>(f.bytesPerSample),
+    };
+    jlongArray arr = env->NewLongArray(13);
+    if (!arr) return nullptr;
+    env->SetLongArrayRegion(arr, 0, 13, packed);
+    return arr;
+}
+
 } // extern "C"

--- a/app/src/main/java/tf/monochrome/android/audio/usb/BypassDiagnostics.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/usb/BypassDiagnostics.kt
@@ -1,0 +1,216 @@
+package tf.monochrome.android.audio.usb
+
+/**
+ * Snapshot of what the libusb iso pump is actually doing. Surfaced to
+ * the Settings UI so the user can verify their hi-res file isn't being
+ * silently downsampled — "192 kHz · 24-bit · async feedback ✓" beats a
+ * binary "Streaming" badge.
+ *
+ * Mirrors the native [LibusbUacDriver::nativeActiveStream] long[]
+ * layout. The native side packs in a fixed order; [fromLongArray]
+ * decodes by position. Adding fields means appending to both ends in
+ * lockstep — no tagged-field tolerance, so don't reorder.
+ */
+data class BypassDiagnostics(
+    val sampleRateHz: Int,
+    val bitsPerSample: Int,
+    val channels: Int,
+    val interfaceNumber: Int,
+    val altSetting: Int,
+    val endpointAddress: Int,
+    val maxPacketSize: Int,
+    /** Iso transfer interval. HS: 2^(bInterval-1) microframes; FS: ms. */
+    val bInterval: Int,
+    /** 0x0100 = UAC1, 0x0200 = UAC2. */
+    val uacVersion: Int,
+    /** UAC2 clock-source entity ID that accepted SET_CUR. 0 = UAC1 / unset. */
+    val clockSourceId: Int,
+    /** Async feedback IN endpoint address; 0 means the device is sync/adaptive. */
+    val feedbackEndpointAddress: Int,
+    val isHighSpeed: Boolean,
+    val bytesPerSample: Int,
+) {
+    val hasFeedbackEndpoint: Boolean get() = feedbackEndpointAddress != 0
+    val isUac2: Boolean get() = uacVersion >= 0x0200
+
+    /** "192 kHz" / "44.1 kHz" / "1.5 MHz". */
+    fun rateLabel(): String {
+        val hz = sampleRateHz
+        return when {
+            hz <= 0 -> "—"
+            hz % 1000 == 0 -> "${hz / 1000} kHz"
+            else -> "%.1f kHz".format(hz / 1000.0)
+        }
+    }
+
+    /** "USB 2.0 High-Speed" / "USB 1.1 Full-Speed". */
+    fun speedLabel(): String =
+        if (isHighSpeed) "USB 2.0 HS" else "USB 1.1 FS"
+
+    /** "UAC2" / "UAC1" — what spec version the device negotiated under. */
+    fun uacLabel(): String = if (isUac2) "UAC2" else "UAC1"
+
+    companion object {
+        /** Field count in the long[] returned by nativeActiveStream. */
+        private const val FIELD_COUNT = 13
+
+        fun fromLongArray(packed: LongArray?): BypassDiagnostics? {
+            if (packed == null || packed.size < FIELD_COUNT) return null
+            return BypassDiagnostics(
+                sampleRateHz = packed[0].toInt(),
+                bitsPerSample = packed[1].toInt(),
+                channels = packed[2].toInt(),
+                interfaceNumber = packed[3].toInt(),
+                altSetting = packed[4].toInt(),
+                endpointAddress = packed[5].toInt(),
+                maxPacketSize = packed[6].toInt(),
+                bInterval = packed[7].toInt(),
+                uacVersion = packed[8].toInt(),
+                clockSourceId = packed[9].toInt(),
+                feedbackEndpointAddress = packed[10].toInt(),
+                isHighSpeed = packed[11] != 0L,
+                bytesPerSample = packed[12].toInt(),
+            )
+        }
+    }
+}
+
+/**
+ * One subrange entry from the device's GET_RANGE table on a clock
+ * entity. UAC2 §5.2.1: most DACs report each supported discrete rate
+ * with min == max; some interfaces with a continuous PLL report a
+ * proper [min, max] window with a non-zero resolution step.
+ *
+ * For UAC1 devices (no clock entities), the native side synthesises
+ * entries with [clockId] = 0 from the AS_FORMAT_TYPE descriptor's
+ * sample-frequency table.
+ */
+data class ClockRateRange(
+    val clockId: Int,
+    val minHz: Int,
+    val maxHz: Int,
+    val resHz: Int,
+) {
+    val isDiscrete: Boolean get() = minHz == maxHz
+
+    /** "44.1 kHz" for discrete, "44.1–768 kHz" for continuous. */
+    fun label(): String {
+        fun fmt(hz: Int) = when {
+            hz <= 0 -> "—"
+            hz % 1000 == 0 -> "${hz / 1000} kHz"
+            else -> "%.1f kHz".format(hz / 1000.0)
+        }
+        return if (isDiscrete) fmt(minHz)
+        else "${fmt(minHz)}–${fmt(maxHz)}"
+    }
+
+    companion object {
+        /** Decodes the flat int[] (clockId, minHz, maxHz, resHz)+ packing. */
+        fun decodeAll(packed: IntArray?): List<ClockRateRange> {
+            if (packed == null || packed.size < 4) return emptyList()
+            val out = ArrayList<ClockRateRange>(packed.size / 4)
+            var i = 0
+            while (i + 4 <= packed.size) {
+                out.add(
+                    ClockRateRange(
+                        clockId = packed[i],
+                        minHz = packed[i + 1],
+                        maxHz = packed[i + 2],
+                        resHz = packed[i + 3],
+                    )
+                )
+                i += 4
+            }
+            return out
+        }
+    }
+}
+
+/**
+ * Categorised reason the most recent [LibusbUacDriver.start] failed.
+ * Order MUST match the native [StartError] enum in libusb_uac_driver.h.
+ *
+ * Each value carries enough context for the UI to write actionable
+ * advice without having to parse the detail string. The detail string
+ * is a separate field on [LibusbUacDriver.lastStartError] for the
+ * cases where the category isn't enough.
+ */
+enum class StartError(val code: Int) {
+    Ok(0),
+
+    /** start() called before open() — driver bug or torn-down state. */
+    NoDevice(1),
+
+    /** Descriptor walk found no AS alt with the requested rate/bits/channels. */
+    NoMatchingAlt(2),
+
+    /** libusb_claim_interface failed — usually the kernel UAC driver
+     *  still owns the streaming interface. Fix: Developer Options →
+     *  Disable USB audio routing → ON. */
+    ClaimInterfaceFailed(3),
+
+    /** libusb_set_interface_alt_setting failed — rare, suggests the
+     *  device went away mid-negotiation. */
+    SetAltFailed(4),
+
+    /** SET_CUR / GET_CUR fell through every clock candidate. The
+     *  device runs a fixed-rate clock that doesn't match the source
+     *  file, or the clock-entity topology is non-obvious. */
+    SetSampleRateFailed(5),
+
+    /** libusb_alloc_transfer returned null — OOM or libusb internal failure. */
+    IsoPumpAllocFailed(6),
+
+    /** Initial libusb_submit_transfer failed — broken endpoint
+     *  configuration on the device, or the kernel reclaimed the
+     *  interface between claim and submit. */
+    IsoPumpSubmitFailed(7);
+
+    companion object {
+        fun fromCode(c: Int): StartError = entries.firstOrNull { it.code == c } ?: Ok
+    }
+}
+
+/**
+ * Pair of [StartError] code + native detail message. The Settings UI
+ * looks up [actionableMessage] for the headline, then optionally
+ * shows [detail] as a "see logs" expandable.
+ */
+data class StartFailure(
+    val code: StartError,
+    val detail: String,
+) {
+    /** User-facing one-liner derived purely from the category. */
+    fun actionableMessage(): String = when (code) {
+        StartError.Ok ->
+            ""
+        StartError.NoDevice ->
+            "DAC handle isn't open yet — re-toggle Exclusive USB DAC " +
+            "after the DAC is plugged in."
+        StartError.NoMatchingAlt ->
+            "Your DAC doesn't advertise this track's sample rate at " +
+            "this bit depth. Try a track at a rate the DAC supports " +
+            "(see the supported-rates list below), or fall back to " +
+            "the framework router which will resample."
+        StartError.ClaimInterfaceFailed ->
+            "Android's audio HAL still owns the streaming interface. " +
+            "Turn ON Developer Options → Disable USB audio routing, " +
+            "then re-toggle Exclusive USB DAC. If the framework " +
+            "routing toggle (above) is on, turn that off too — they " +
+            "fight each other for the DAC."
+        StartError.SetAltFailed ->
+            "USB negotiation failed mid-handshake. Unplug and re-plug " +
+            "the DAC, then re-toggle Exclusive USB DAC."
+        StartError.SetSampleRateFailed ->
+            "Your DAC's clock won't accept this rate. It probably runs " +
+            "at a fixed hardware clock. Try a track at the DAC's " +
+            "native rate (see supported rates below)."
+        StartError.IsoPumpAllocFailed ->
+            "Couldn't allocate USB transfers (memory pressure?). Close " +
+            "background apps and try again."
+        StartError.IsoPumpSubmitFailed ->
+            "USB transfer submission failed — the device may have " +
+            "been unplugged or the kernel reclaimed the interface. " +
+            "Re-plug the DAC and re-toggle."
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/audio/usb/LibusbUacDriver.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/usb/LibusbUacDriver.kt
@@ -52,14 +52,34 @@ class LibusbUacDriver @Inject constructor(
 
     /**
      * Reason the most recent [start] failed, or null if it
-     * succeeded / hasn't been attempted. Lets the controller flip
-     * to a meaningful Status.Error state with a human-readable
-     * reason instead of the prior generic "DAC handle acquired"
-     * (which was misleading when claim_interface had actually
-     * failed under us).
+     * succeeded / hasn't been attempted. Carries both the categorised
+     * code and the native-side detail line so the UI can render
+     * actionable text without having to fish through logcat.
      */
-    private val _lastStartError = MutableStateFlow<String?>(null)
-    val lastStartError: StateFlow<String?> = _lastStartError.asStateFlow()
+    private val _lastStartError = MutableStateFlow<StartFailure?>(null)
+    val lastStartError: StateFlow<StartFailure?> = _lastStartError.asStateFlow()
+
+    /**
+     * Snapshot of the iso pump's current state: negotiated rate, bit
+     * depth, alt setting, clock entity, feedback endpoint presence,
+     * UAC version. Null when not streaming. Refreshed on every
+     * [start]/[stop] transition.
+     *
+     * The Settings UI binds to this to show "192 kHz · 24-bit · async
+     * feedback ✓ · clock #9 · UAC2 HS" beneath the toggle so the user
+     * has visible proof of what they're getting.
+     */
+    private val _diagnostics = MutableStateFlow<BypassDiagnostics?>(null)
+    val diagnostics: StateFlow<BypassDiagnostics?> = _diagnostics.asStateFlow()
+
+    /**
+     * Per-clock-entity GET_RANGE table snapshot. Empty list before
+     * any [start] succeeds, or if every clock entity refused both
+     * SET_CUR and GET_RANGE. UAC1 devices return synthetic entries
+     * (clockId=0) sourced from the AS_FORMAT_TYPE rate table.
+     */
+    private val _supportedRates = MutableStateFlow<List<ClockRateRange>>(emptyList())
+    val supportedRates: StateFlow<List<ClockRateRange>> = _supportedRates.asStateFlow()
 
     /** Device the driver currently owns, or null. */
     private val _device = MutableStateFlow<UsbDevice?>(null)
@@ -176,22 +196,31 @@ class LibusbUacDriver @Inject constructor(
     fun start(sampleRate: Int, bitsPerSample: Int, channels: Int): Boolean {
         val ok = nativeStart(sampleRate, bitsPerSample, channels)
         _isStreaming.value = ok
-        // Best-effort error categorisation — the native side already
-        // logged the actual libusb error code with details. We just
-        // need the controller to know whether claim_interface was
-        // the failure (the common kernel-still-owns-it case) vs.
-        // descriptor / rate negotiation (rare, device-specific).
-        _lastStartError.value = if (ok) null else
-            "Couldn't claim the DAC's streaming interface. Most likely " +
-            "Android's audio HAL still owns it — turn ON Developer " +
-            "Options → Disable USB audio routing, then re-toggle " +
-            "Exclusive USB DAC."
+        // Always pull the rate inventory: native populates it during
+        // start whether we succeeded or not (failure path's GET_RANGE
+        // diagnostic loop also caches into supportedRates_), and the
+        // UI wants to show "your DAC supports X / Y / Z kHz" even
+        // when the requested rate isn't one of them.
+        _supportedRates.value = ClockRateRange.decodeAll(nativeSupportedRates())
+        if (ok) {
+            _diagnostics.value = BypassDiagnostics.fromLongArray(nativeActiveStream())
+            _lastStartError.value = null
+        } else {
+            // No active stream — but we still want the UI to render
+            // the failure category. Diagnostics stays null so the
+            // "currently active" block hides.
+            _diagnostics.value = null
+            val code = StartError.fromCode(nativeLastErrorCode())
+            val detail = nativeLastErrorDetail().orEmpty()
+            _lastStartError.value = StartFailure(code, detail)
+        }
         return ok
     }
 
     fun stop() {
         nativeStop()
         _isStreaming.value = false
+        _diagnostics.value = null
         _lastStartError.value = null
     }
 
@@ -245,6 +274,16 @@ class LibusbUacDriver @Inject constructor(
     private external fun nativeWritableFrames(): Int
     private external fun nativePlayedFrames(): Long
     private external fun nativePendingFrames(): Long
+    /** Numeric category — see [StartError]; 0 = Ok / no failure recorded. */
+    private external fun nativeLastErrorCode(): Int
+    /** Free-form detail string from the native failure site. May be empty. */
+    private external fun nativeLastErrorDetail(): String?
+    /** Flat (clockId, minHz, maxHz, resHz) quads from the device's GET_RANGE,
+     *  or null/empty when no clock-entity rate inventory is available. */
+    private external fun nativeSupportedRates(): IntArray?
+    /** Packed long[] of negotiated stream parameters; null when not streaming.
+     *  See [BypassDiagnostics.fromLongArray] for the field layout. */
+    private external fun nativeActiveStream(): LongArray?
 
     companion object {
         private const val TAG = "LibusbUacDriver"

--- a/app/src/main/java/tf/monochrome/android/audio/usb/UsbExclusiveController.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/usb/UsbExclusiveController.kt
@@ -68,6 +68,19 @@ class UsbExclusiveController @Inject constructor(
     private val _status = MutableStateFlow(Status.Disabled)
     val status: StateFlow<Status> = _status.asStateFlow()
 
+    /** What the iso pump is currently doing — null when not streaming.
+     *  Forwarded straight from the driver so the UI binds to one place
+     *  (the controller) for everything bypass-related instead of
+     *  reaching into the driver from ViewModels. */
+    val diagnostics: StateFlow<BypassDiagnostics?> = driver.diagnostics
+
+    /** Categorised + detailed reason the most recent start() failed.
+     *  Null when bypass is succeeding or hasn't been attempted. */
+    val lastStartError: StateFlow<StartFailure?> = driver.lastStartError
+
+    /** GET_RANGE inventory — what rates the DAC actually supports. */
+    val supportedRates: StateFlow<List<ClockRateRange>> = driver.supportedRates
+
     private val usbManager = appContext.getSystemService(Context.USB_SERVICE) as UsbManager
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1033,12 +1033,166 @@ private fun UsbBitPerfectToggle(viewModel: SettingsViewModel) {
 
     val exclusiveEnabled by viewModel.usbExclusiveBitPerfectEnabled.collectAsState()
     val exclusiveStatus by viewModel.usbExclusiveStatus.collectAsState()
+    val diagnostics by viewModel.usbBypassDiagnostics.collectAsState()
+    val failure by viewModel.usbBypassFailure.collectAsState()
+    val supportedRates by viewModel.usbBypassSupportedRates.collectAsState()
     SettingSwitchItem(
         title = "Exclusive USB DAC (bypass Android audio)",
-        subtitle = exclusiveSubtitle(exclusiveEnabled, exclusiveStatus),
+        subtitle = exclusiveSubtitle(
+            exclusiveEnabled, exclusiveStatus, failure
+        ),
         checked = exclusiveEnabled,
         onCheckedChange = { viewModel.setUsbExclusiveBitPerfectEnabled(it) },
     )
+    // Only render the diagnostic card when the toggle is on AND we
+    // have something honest to say — either an active stream, a
+    // categorised failure, or a known rate inventory. Hidden the rest
+    // of the time so the toggle row stays clean.
+    if (exclusiveEnabled &&
+        (diagnostics != null || failure != null || supportedRates.isNotEmpty())) {
+        BypassDiagnosticsCard(
+            diagnostics = diagnostics,
+            failure = failure,
+            supportedRates = supportedRates,
+        )
+    }
+}
+
+/**
+ * Renders a compact info card beneath the exclusive-USB toggle:
+ *   - Active stream specs (when streaming): rate / bits / channels /
+ *     UAC version / device speed / async-feedback presence / clock id
+ *   - Failure detail (when not streaming and a start attempt failed)
+ *   - Supported-rates list from the device's GET_RANGE table
+ *
+ * Card styling matches the existing Settings cards. Stays terse: a
+ * Bathys at 192/24 should fit the active-stream block in two lines so
+ * the toggle below it isn't pushed off-screen.
+ */
+@Composable
+private fun BypassDiagnosticsCard(
+    diagnostics: tf.monochrome.android.audio.usb.BypassDiagnostics?,
+    failure: tf.monochrome.android.audio.usb.StartFailure?,
+    supportedRates: List<tf.monochrome.android.audio.usb.ClockRateRange>,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            if (diagnostics != null) {
+                Text(
+                    text = "Active stream",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = buildString {
+                        append(diagnostics.rateLabel())
+                        append(" · ")
+                        append(diagnostics.bitsPerSample)
+                        append("-bit · ")
+                        append(diagnostics.channels)
+                        append("ch · ")
+                        append(diagnostics.uacLabel())
+                        append(" ")
+                        append(diagnostics.speedLabel())
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    // Second line: less critical metadata. Async
+                    // feedback presence is the big one — it's the
+                    // difference between rate-locked playback and the
+                    // host drifting against the DAC's clock.
+                    text = buildString {
+                        append("alt ")
+                        append(diagnostics.altSetting)
+                        if (diagnostics.clockSourceId != 0) {
+                            append(" · clock #")
+                            append(diagnostics.clockSourceId)
+                        }
+                        append(" · ")
+                        append(
+                            if (diagnostics.hasFeedbackEndpoint)
+                                "async feedback ✓"
+                            else "no feedback EP (open-loop)"
+                        )
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else if (failure != null && failure.code !=
+                tf.monochrome.android.audio.usb.StartError.Ok) {
+                Text(
+                    text = "Bypass failed",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = failure.actionableMessage(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (failure.detail.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        // The native detail is technical (libusb error
+                        // codes, control-transfer info). Useful for
+                        // anyone debugging via logcat — render in mono
+                        // to make it visually distinct from the
+                        // user-facing actionable message above.
+                        text = failure.detail,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            if (supportedRates.isNotEmpty()) {
+                if (diagnostics != null || failure != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                Text(
+                    text = "Supported rates",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    // Most DACs expose discrete rates with min==max,
+                    // so deduplicating on the label produces the clean
+                    // "44.1 / 48 / 88.2 / 96 / 176.4 / 192 kHz" line
+                    // that Hi-Fi people care about. Continuous-range
+                    // PLLs render as "44.1–768 kHz" untouched.
+                    text = supportedRates
+                        .map { it.label() }
+                        .distinct()
+                        .joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
 }
 
 /**
@@ -1054,6 +1208,7 @@ private fun UsbBitPerfectToggle(viewModel: SettingsViewModel) {
 private fun exclusiveSubtitle(
     enabled: Boolean,
     status: tf.monochrome.android.audio.usb.UsbExclusiveController.Status,
+    failure: tf.monochrome.android.audio.usb.StartFailure?,
 ): String {
     if (!enabled) {
         return "Off — UAPP-style libusb output. Needs Developer Options " +
@@ -1074,11 +1229,16 @@ private fun exclusiveSubtitle(
             "Streaming interface claimed ✓"
         tf.monochrome.android.audio.usb.UsbExclusiveController.Status.Streaming ->
             "Bit-perfect: bypassing Android audio ✓ (EQ / DSP still active)"
+        // The Error subtitle used to hardcode the kernel-claim story.
+        // Now we defer to whichever StartFailure category the native
+        // side reported — claim failures, rate-negotiation failures,
+        // alloc failures all surface as their own actionable line. If
+        // somehow we're in Error with no failure recorded (shouldn't
+        // happen but: defensive), fall back to the old text.
         tf.monochrome.android.audio.usb.UsbExclusiveController.Status.Error ->
-            "Couldn't claim the DAC's streaming interface — Android's " +
-            "audio HAL still owns it. Turn ON Developer Options → " +
-            "Disable USB audio routing, then re-toggle Exclusive USB DAC. " +
-            "Audio is currently flowing through the standard sink."
+            failure?.actionableMessage()?.takeIf { it.isNotBlank() }
+                ?: ("Bypass couldn't engage — see logcat tagged " +
+                    "'LibusbUacDriver' for details.")
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -55,6 +55,21 @@ class SettingsViewModel @Inject constructor(
     val usbExclusiveStatus: StateFlow<tf.monochrome.android.audio.usb.UsbExclusiveController.Status> =
         usbExclusiveController.status
 
+    /** Negotiated stream parameters when bypass is live. Settings UI
+     *  renders "192 kHz · 24-bit · UAC2 HS · async feedback ✓" from this. */
+    val usbBypassDiagnostics: StateFlow<tf.monochrome.android.audio.usb.BypassDiagnostics?> =
+        usbExclusiveController.diagnostics
+
+    /** Categorised reason the bypass failed, when it did. The UI shows
+     *  [tf.monochrome.android.audio.usb.StartFailure.actionableMessage]
+     *  in the Error subtitle. */
+    val usbBypassFailure: StateFlow<tf.monochrome.android.audio.usb.StartFailure?> =
+        usbExclusiveController.lastStartError
+
+    /** What rates the DAC actually supports, per its GET_RANGE table. */
+    val usbBypassSupportedRates: StateFlow<List<tf.monochrome.android.audio.usb.ClockRateRange>> =
+        usbExclusiveController.supportedRates
+
     /** Shared live FFT bins from the audio pipeline — same source the NowPlaying overlay uses. */
     val spectrumBins: StateFlow<FloatArray> = spectrumAnalyzerTap.spectrumBins
 


### PR DESCRIPTION
The Settings screen used to show a binary 'Streaming' badge and one hardcoded 'kernel still owns it' error message that was wrong about half the time. Native side knew the truth — actual negotiated rate, alt setting, clock entity, feedback EP presence, UAC version, what GET_RANGE reports — none of it surfaced.

Native (libusb_uac_driver):
- Added StartError enum (NoDevice / NoMatchingAlt / ClaimInterfaceFailed / SetAltFailed / SetSampleRateFailed / IsoPumpAllocFailed / IsoPumpSubmitFailed) with categorised setter at every failure site.
- Added ClockRateRange struct + supportedRates_ field, populated during start() — captureRangeForClock() runs on the SET_CUR success path, the existing GET_RANGE diagnostic loop now also caches into it on failure. UAC1 path harvests rates from AS_FORMAT_TYPE.
- Public getters: lastError(), lastErrorDetail(), supportedRates().

JNI (usb_jni):
- nativeLastErrorCode / nativeLastErrorDetail / nativeSupportedRates (flat int[] of clockId/min/max/res quads) / nativeActiveStream (long[] packing format_ fields).

Kotlin:
- New BypassDiagnostics.kt: typed mirror of nativeActiveStream, ClockRateRange decoder, StartError enum, StartFailure with per-category actionableMessage().
- LibusbUacDriver: lastStartError type changed from String? to StartFailure?; added diagnostics + supportedRates StateFlows refreshed every start()/stop().
- UsbExclusiveController: forwards driver flows so SettingsViewModel has one place to bind for everything bypass-related.
- SettingsViewModel exposes usbBypassDiagnostics / usbBypassFailure / usbBypassSupportedRates.

UI (SettingsScreen):
- New BypassDiagnosticsCard composable beneath the exclusive toggle. Active-stream block: '192 kHz · 24-bit · 2ch · UAC2 USB 2.0 HS' on line 1, 'alt 1 · clock #9 · async feedback ✓' on line 2. Failure block uses the StartFailure category for actionable text plus a monospace native-detail line for log spelunking. Bottom: deduped supported-rates list ('44.1 / 48 / 88.2 / 96 / 176.4 / 192 kHz').
- exclusiveSubtitle now defers to StartFailure.actionableMessage() for Error state instead of the old hardcoded claim-failure text.

Verified: g++ -fsyntax-only clean on libusb_uac_driver.cpp + usb_jni.cpp; kotlinc 2.1.0 clean compile on BypassDiagnostics.kt.