### PR TITLE
fix(usb): watchdog false-trips after flushRing reset

### DIFF
--- a/app/src/main/java/tf/monochrome/android/audio/usb/LibusbAudioSink.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/usb/LibusbAudioSink.kt
@@ -327,7 +327,16 @@ class LibusbAudioSink(
             return
         }
         val played = driver.playedFrames()
-        if (played > lastPlayedFrames) {
+        // != not > : driver.flushRing() (called on our own pause()
+        // override and on Media3-driven flushes) zeros the C++ side
+        // playedFrames_ counter, so a healthy pump can legitimately
+        // produce played < lastPlayedFrames right after a flush.
+        // Treating that as "stuck" causes a false trip + fallback to
+        // the delegate sink mid-stream — which the user perceives
+        // as audio "fighting" itself between two paths every time
+        // they pause / skip / seek. Any change at all means the
+        // pump is alive; only zero-progress is a genuine wedge.
+        if (played != lastPlayedFrames) {
             lastPlayedFrames = played
             lastPlayedAdvanceNs = now
             return


### PR DESCRIPTION
Field log f51505c9-monotryptdebug20260502223951.log shows the iso pump is working perfectly on the OnePlus / Bathys combo — heartbeat confirms playedFrames advances at exactly the sample rate, ring maintains a healthy ~1 MB depth, frames written tracks frames played. But the watchdog was tripping anyway:

  22:39:36.757 cb=31000: played=320475 written=580723 ring=1048224
  22:39:37.6   user taps skip
  22:39:37.757 cb=32000: played=6880   written=4096   ring=0
  22:39:38.612 W: iso pump wedged — playedFrames=44541 stuck for
                  1010 ms after 623151 frames written; falling back
                  to delegate sink

The check used `played > lastPlayedFrames` to mean "advancing", which is wrong: driver.flushRing() (called from our own pause() override and from Media3-driven flushes on skip / seek / track transitions) zeros the C++ playedFrames_ counter. After a flush a healthy pump produces played < lastPlayedFrames, the watchdog reads that as zero-progress, and ~800 ms later it latches bypassActive off — until the next configure flips it back on. The user perceives this as audio "fighting" itself: bypass works, flush, fallback to delegate, configure, bypass again, on every pause/skip/seek.

Switch to `played != lastPlayedFrames`. Any change means the pump is alive (a reset is a deliberate state change, not a stall); only zero-progress over warmup+stall ms is a genuine wedge.