### PR TITLE
chore(release): Tryptify 1.5.0 rebrand

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,8 +50,8 @@ android {
         applicationId = "tf.monotrypt.android"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 150
+        versionName = "1.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.22.1)
 project("monochrome_native")
 
+# projectM v4's FilesystemSupport.cmake probes for std::filesystem via
+# check_source_compiles. Under the Android NDK that probe links a tiny
+# try_compile executable without -lc++_shared, so the link step fails
+# with "undefined symbol: std::__ndk1::basic_string::~basic_string" even
+# though NDK 28 fully supports <filesystem> for API >= 26. Pre-cache the
+# probe result so the projectM helper skips it and uses std::filesystem.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(STD_FILESYSTEM_EXISTS TRUE CACHE INTERNAL "Forced: NDK 28 supports std::filesystem")
+set(ENABLE_BOOST_FILESYSTEM OFF CACHE BOOL "Use std::filesystem instead of Boost")
+
 # ── ProjectM Visualizer ──────────────────────────────────────────────────
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/projectm
     ${CMAKE_CURRENT_BINARY_DIR}/projectm)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">MonoTrypT</string>
+    <string name="app_name">Tryptify</string>
     <string name="widget_description">Now playing controls</string>
 </resources>


### PR DESCRIPTION
## Summary

- App display name **MonoTrypT → Tryptify**
- Version **1.0.0 → 1.5.0** (`versionCode 1 → 150`)
- Pre-cache `STD_FILESYSTEM_EXISTS=TRUE` in `app/src/main/cpp/CMakeLists.txt` so projectM's `check_source_compiles` probe short-circuits — the probe otherwise fails to link the `try_compile` executable against `libc++_shared` under NDK 28, even though `std::filesystem` is fully supported for `minSdk = 26`. Fix lives at the *boundary* (the parent CMakeLists where `add_subdirectory(third_party/projectm ...)` is invoked) rather than inside the vendored submodule, so the third_party tree stays clean.

## Test plan

- [ ] `./gradlew assembleDebug` completes without the `<filesystem>`/`std::__ndk1::basic_string` link error from projectM's CMake configure.
- [ ] APK installs and launches; launcher tile reads **Tryptify**.
- [ ] System Settings → Apps shows **Tryptify** at version **1.5.0** (build 150).
- [ ] Existing playback / DSP / USB DAC paths unchanged (no functional code touched).