### PR TITLE
Add album/artist downloads + global progress pill and monitor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,8 +50,8 @@ android {
         applicationId = "tf.monotrypt.android"
         minSdk = 26
         targetSdk = 36
-        versionCode = 160
-        versionName = "1.6.0"
+        versionCode = 162
+        versionName = "1.6.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/assets/devedit_default_layout.json
+++ b/app/src/main/assets/devedit_default_layout.json
@@ -101,5 +101,6 @@
     "snapToGrid": true,
     "gridStep": 16.0,
     "refWidthDp": 428.0,
-    "refHeightDp": 932.0
+    "refHeightDp": 932.0,
+    "version": 1
 }

--- a/app/src/main/assets/devedit_default_layout.json
+++ b/app/src/main/assets/devedit_default_layout.json
@@ -89,6 +89,12 @@
             "offsetY": 16.0,
             "scale": 1.0,
             "hidden": false
+        },
+        "player/sourceTag": {
+            "offsetX": 0.0,
+            "offsetY": 0.0,
+            "scale": 1.0,
+            "hidden": true
         }
     },
     "boxes": {},

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadManager.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import tf.monochrome.android.domain.model.Track
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,11 +26,27 @@ data class TrackDownloadState(
     val progress: Float = 0f
 )
 
+/** A single in-flight download with the metadata needed to render it (pill / monitor). */
+data class ActiveDownload(
+    val trackId: Long,
+    val title: String,
+    val artistName: String,
+    val artworkUri: String?,
+    val status: DownloadStatus,
+    val progress: Float,
+)
+
 @Singleton
 class DownloadManager @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     private val workManager = WorkManager.getInstance(context)
+
+    // Track metadata for rendering active downloads (title/artist/cover). WorkInfo
+    // can't carry it, so we keep it here, keyed by track id. Process-scoped: a
+    // download still in flight after a restart falls back to a generic label.
+    private data class DownloadMeta(val title: String, val artistName: String, val artworkUri: String?)
+    private val meta = ConcurrentHashMap<Long, DownloadMeta>()
 
     fun downloadTrack(track: Track) {
         enqueueDownload(track)
@@ -39,7 +56,22 @@ class DownloadManager @Inject constructor(
         tracks.forEach { enqueueDownload(it) }
     }
 
+    /** Cancel a single in-flight download. */
+    fun cancel(trackId: Long) {
+        workManager.cancelUniqueWork("download_$trackId")
+    }
+
+    /** Cancel everything still downloading or queued. */
+    fun cancelAll() {
+        workManager.cancelAllWorkByTag("download")
+    }
+
     private fun enqueueDownload(track: Track) {
+        meta[track.id] = DownloadMeta(
+            title = track.title,
+            artistName = track.artist?.name ?: track.displayArtist.ifBlank { "Unknown Artist" },
+            artworkUri = track.coverUrl,
+        )
         val inputData = workDataOf(
             DownloadWorker.KEY_TRACK_ID to track.id,
             DownloadWorker.KEY_TRACK_TITLE to track.title,
@@ -57,6 +89,9 @@ class DownloadManager @Inject constructor(
             .setInputData(inputData)
             .setConstraints(constraints)
             .addTag("download")
+            // Per-track tag so the aggregate observer can recover the track id
+            // from WorkInfo (which doesn't expose the unique work name).
+            .addTag("download_${track.id}")
             .build()
 
         workManager.enqueueUniqueWork(
@@ -115,4 +150,30 @@ class DownloadManager @Inject constructor(
                     .toMap()
             }
     }
+
+    /**
+     * Active downloads (queued + running) enriched with title/artist/cover, ready
+     * to render in the progress pill and the downloads monitor. Sorted with the
+     * currently-downloading items first.
+     */
+    fun observeActiveDownloads(): Flow<List<ActiveDownload>> =
+        observeAllActiveDownloads().map { stateById ->
+            stateById.entries
+                .map { (id, state) ->
+                    val m = meta[id]
+                    ActiveDownload(
+                        trackId = id,
+                        title = m?.title ?: "Track $id",
+                        artistName = m?.artistName ?: "",
+                        artworkUri = m?.artworkUri,
+                        status = state.status,
+                        progress = state.progress,
+                    )
+                }
+                .sortedWith(
+                    compareByDescending<ActiveDownload> { it.status == DownloadStatus.DOWNLOADING }
+                        .thenByDescending { it.progress }
+                        .thenBy { it.title }
+                )
+        }
 }

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
@@ -89,14 +89,17 @@ class DownloadWorker @AssistedInject constructor(
             }
             val audioData = output.toByteArray()
 
-            // Determine save location + container from the selected quality:
-            // LOW/HIGH download as MP3 (Qobuz code 5); LOSSLESS/HI_RES as FLAC.
-            // Saving the right extension/mime keeps lossy downloads from being
-            // mislabelled as .flac (which breaks MediaStore + other players).
+            // Detect what the backend actually delivered (not just what was
+            // requested): the download instance can downgrade HI_RES→LOSSLESS,
+            // and LOW/HIGH come back as MP3. Basing the extension/mime and the
+            // stored record on the real bytes keeps lossy files from being
+            // mislabelled .flac (breaks MediaStore + other players) and makes the
+            // saved quality accurate.
             val customFolderUri = preferences.downloadFolderUri.first()
-            val isLossless = quality == AudioQuality.LOSSLESS || quality == AudioQuality.HI_RES
-            val fileExt = if (isLossless) "flac" else "mp3"
-            val audioMime = if (isLossless) "audio/flac" else "audio/mpeg"
+            val actualQuality = detectActualQuality(audioData, quality)
+            val isFlac = actualQuality == AudioQuality.LOSSLESS || actualQuality == AudioQuality.HI_RES
+            val fileExt = if (isFlac) "flac" else "mp3"
+            val audioMime = if (isFlac) "audio/flac" else "audio/mpeg"
             val sanitizedTitle = "${artistName} - ${trackTitle}".replace(Regex("[\\\\/:*?\"<>|]"), "_")
             val fileName = "$sanitizedTitle.$fileExt"
             val filePath: String
@@ -201,7 +204,7 @@ class DownloadWorker @AssistedInject constructor(
                     albumTitle = albumTitle,
                     albumCover = albumCover,
                     filePath = filePath,
-                    quality = quality.name,
+                    quality = actualQuality.name,
                     sizeBytes = audioData.size.toLong(),
                     downloadedAt = System.currentTimeMillis()
                 )
@@ -287,6 +290,29 @@ class DownloadWorker @AssistedInject constructor(
                 null,
             )
         }
+    }
+
+    /**
+     * Infer the format actually delivered from the file bytes, so the saved record
+     * reflects reality rather than the requested tier:
+     *  - "fLaC" magic → FLAC; read bits-per-sample from STREAMINFO to tell
+     *    HI_RES (≥24-bit) from LOSSLESS (16-bit), catching a HI_RES→LOSSLESS downgrade.
+     *  - anything else → lossy (MP3) → report as HIGH.
+     * Falls back to [requested] if the bytes are too short to classify.
+     */
+    private fun detectActualQuality(data: ByteArray, requested: AudioQuality): AudioQuality {
+        if (data.size < 4) return requested
+        val isFlac = data[0] == 'f'.code.toByte() && data[1] == 'L'.code.toByte() &&
+            data[2] == 'a'.code.toByte() && data[3] == 'C'.code.toByte()
+        if (!isFlac) return AudioQuality.HIGH
+        // STREAMINFO begins at byte 8 (4 magic + 4 block header). Bits-per-sample
+        // is the 5-bit field straddling bytes 20 (low bit) and 21 (high 4 bits),
+        // stored as value-1.
+        if (data.size < 22) return AudioQuality.LOSSLESS
+        val b20 = data[20].toInt() and 0xFF
+        val b21 = data[21].toInt() and 0xFF
+        val bitsPerSample = (((b20 and 0x01) shl 4) or (b21 shr 4)) + 1
+        return if (bitsPerSample >= 24) AudioQuality.HI_RES else AudioQuality.LOSSLESS
     }
 
     private fun saveToInternal(trackId: Long, ext: String, data: ByteArray): String {

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadWorker.kt
@@ -89,10 +89,16 @@ class DownloadWorker @AssistedInject constructor(
             }
             val audioData = output.toByteArray()
 
-            // Determine save location
+            // Determine save location + container from the selected quality:
+            // LOW/HIGH download as MP3 (Qobuz code 5); LOSSLESS/HI_RES as FLAC.
+            // Saving the right extension/mime keeps lossy downloads from being
+            // mislabelled as .flac (which breaks MediaStore + other players).
             val customFolderUri = preferences.downloadFolderUri.first()
+            val isLossless = quality == AudioQuality.LOSSLESS || quality == AudioQuality.HI_RES
+            val fileExt = if (isLossless) "flac" else "mp3"
+            val audioMime = if (isLossless) "audio/flac" else "audio/mpeg"
             val sanitizedTitle = "${artistName} - ${trackTitle}".replace(Regex("[\\\\/:*?\"<>|]"), "_")
-            val fileName = "$sanitizedTitle.flac"
+            val fileName = "$sanitizedTitle.$fileExt"
             val filePath: String
 
             if (customFolderUri != null) {
@@ -102,7 +108,7 @@ class DownloadWorker @AssistedInject constructor(
                 if (docFile != null && docFile.canWrite()) {
                     val existing = docFile.findFile(fileName)
                     existing?.delete()
-                    val newFile = docFile.createFile("audio/flac", sanitizedTitle)
+                    val newFile = docFile.createFile(audioMime, sanitizedTitle)
                     if (newFile != null) {
                         context.contentResolver.openOutputStream(newFile.uri)?.use { out ->
                             out.write(audioData)
@@ -110,13 +116,13 @@ class DownloadWorker @AssistedInject constructor(
                         filePath = newFile.uri.toString()
                     } else {
                         // Fallback to internal
-                        filePath = saveToInternal(trackId, fileName, audioData)
+                        filePath = saveToInternal(trackId, fileExt, audioData)
                     }
                 } else {
-                    filePath = saveToInternal(trackId, fileName, audioData)
+                    filePath = saveToInternal(trackId, fileExt, audioData)
                 }
             } else {
-                filePath = saveToInternal(trackId, fileName, audioData)
+                filePath = saveToInternal(trackId, fileExt, audioData)
             }
 
             // Save lyrics if enabled. TIDAL is preferred (best quality
@@ -283,10 +289,10 @@ class DownloadWorker @AssistedInject constructor(
         }
     }
 
-    private fun saveToInternal(trackId: Long, fileName: String, data: ByteArray): String {
+    private fun saveToInternal(trackId: Long, ext: String, data: ByteArray): String {
         val downloadsDir = File(context.getExternalFilesDir(null), "downloads")
         if (!downloadsDir.exists()) downloadsDir.mkdirs()
-        val targetFile = File(downloadsDir, "$trackId.flac")
+        val targetFile = File(downloadsDir, "$trackId.$ext")
         targetFile.writeBytes(data)
         return targetFile.absolutePath
     }

--- a/app/src/main/java/tf/monochrome/android/devedit/DevEditModels.kt
+++ b/app/src/main/java/tf/monochrome/android/devedit/DevEditModels.kt
@@ -15,6 +15,11 @@ data class DevEditLayout(
     val boxes: Map<String, List<FreeformBox>> = emptyMap(),
     val snapToGrid: Boolean = false,
     val gridStep: Float = 16f,
+    // Version of the *bundled* default. When the asset's version is newer than
+    // what a device last force-applied, the bundled layout overwrites local edits
+    // once (see DevEditRepository.load). Bump this in the asset to push a new
+    // forced default to everyone. 0 = unversioned/local.
+    val version: Int = 0,
     // Screen size (in dp) the layout was designed on. When > 0, element offsets
     // are scaled to the current screen relative to this, so the arrangement
     // holds across phone sizes. 0 = treat offsets as absolute dp (no scaling).

--- a/app/src/main/java/tf/monochrome/android/devedit/DevEditRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/devedit/DevEditRepository.kt
@@ -25,23 +25,43 @@ class DevEditRepository @Inject constructor(
     }
 
     private val file: File get() = File(context.filesDir, FILE_NAME)
+    private val versionFile: File get() = File(context.filesDir, VERSION_FILE_NAME)
 
     fun load(): DevEditLayout {
+        val bundled = loadBundled()
+
+        // 0. Forced default: when the bundled layout's version is newer than the
+        //    one this device last applied, push it to EVERYONE — overwriting any
+        //    local edits — exactly once. Bump `version` in the asset to re-force.
+        if (bundled != null && bundled.version > lastForcedVersion()) {
+            save(bundled)
+            writeForcedVersion(bundled.version)
+            return bundled
+        }
+
         // 1. Per-device user edits take priority once they exist.
         if (file.exists()) {
             runCatching {
                 return json.decodeFromString(DevEditLayout.serializer(), file.readText())
             }
         }
-        // 2. Otherwise use the layout bundled with the app — the shipped default
-        //    that every user sees before editing anything with DevEdit.
-        runCatching {
-            context.assets.open(DEFAULT_ASSET).bufferedReader().use { reader ->
-                return json.decodeFromString(DevEditLayout.serializer(), reader.readText())
-            }
-        }
-        // 3. Nothing bundled yet → empty (pure code layout).
+        // 2. Otherwise the shipped default.
+        if (bundled != null) return bundled
+        // 3. Nothing bundled → empty (pure code layout).
         return DevEditLayout()
+    }
+
+    private fun loadBundled(): DevEditLayout? = runCatching {
+        context.assets.open(DEFAULT_ASSET).bufferedReader().use { reader ->
+            json.decodeFromString(DevEditLayout.serializer(), reader.readText())
+        }
+    }.getOrNull()
+
+    private fun lastForcedVersion(): Int =
+        runCatching { versionFile.readText().trim().toInt() }.getOrDefault(0)
+
+    private fun writeForcedVersion(version: Int) {
+        runCatching { versionFile.writeText(version.toString()) }
     }
 
     fun save(layout: DevEditLayout) {
@@ -58,6 +78,7 @@ class DevEditRepository @Inject constructor(
 
     private companion object {
         const val FILE_NAME = "devedit_layout.json"
+        const val VERSION_FILE_NAME = "devedit_forced_version"
         const val DEFAULT_ASSET = "devedit_default_layout.json"
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -198,6 +199,19 @@ fun AlbumDetailScreen(
                                     Icon(
                                         Icons.Default.Shuffle,
                                         contentDescription = "Shuffle",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                FilledIconButton(
+                                    onClick = { viewModel.downloadAll() },
+                                    modifier = Modifier.size(48.dp),
+                                    colors = IconButtonDefaults.filledIconButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                    )
+                                ) {
+                                    Icon(
+                                        Icons.Default.Download,
+                                        contentDescription = "Download album",
                                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
                                 }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.api.QobuzIdRegistry
+import tf.monochrome.android.data.downloads.DownloadManager
 import tf.monochrome.android.data.repository.MusicRepository
 import tf.monochrome.android.domain.model.AlbumDetail
 import javax.inject.Inject
@@ -18,6 +19,7 @@ class AlbumDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repository: MusicRepository,
     private val qobuzIdRegistry: QobuzIdRegistry,
+    private val downloadManager: DownloadManager,
 ) : ViewModel() {
 
     private val albumId: Long = savedStateHandle.get<Long>("albumId") ?: 0L
@@ -65,4 +67,10 @@ class AlbumDetailViewModel @Inject constructor(
     }
 
     fun retry() = loadAlbum()
+
+    /** Queue every track on the loaded album for download. */
+    fun downloadAll() {
+        _albumDetail.value?.tracks?.takeIf { it.isNotEmpty() }
+            ?.let { downloadManager.downloadTracks(it) }
+    }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -118,11 +120,29 @@ fun ArtistDetailScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        val isDownloadingAll by viewModel.isDownloadingAll.collectAsState()
         TopAppBar(
             title = {},
             navigationIcon = {
                 IconButton(onClick = { navController.popBackStack() }) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+            actions = {
+                if (artistDetail != null) {
+                    IconButton(
+                        onClick = { viewModel.downloadAllReleases() },
+                        enabled = !isDownloadingAll,
+                    ) {
+                        if (isDownloadingAll) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(Icons.Default.Download, contentDescription = "Download all releases")
+                        }
+                    }
                 }
             },
             colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
@@ -22,12 +22,14 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -74,6 +76,34 @@ fun ArtistDetailScreen(
     var showAddToPlaylistForTrack by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<tf.monochrome.android.domain.model.Track?>(null) }
     var showCreatePlaylistDialog by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     var showAllTopTracks by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+    var showDownloadConfirm by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+
+    if (showDownloadConfirm) {
+        val detail = artistDetail
+        val releaseCount = detail?.let { it.albums.size + it.eps.size + it.singles.size } ?: 0
+        AlertDialog(
+            onDismissRequest = { showDownloadConfirm = false },
+            icon = { Icon(Icons.Default.Download, contentDescription = null) },
+            title = { Text("Download all releases?") },
+            text = {
+                Text(
+                    "This will download every track from $releaseCount " +
+                        (if (releaseCount == 1) "release" else "releases") +
+                        " by ${detail?.artist?.name ?: "this artist"}. " +
+                        "Large discographies can use significant storage and data."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDownloadConfirm = false
+                    viewModel.downloadAllReleases()
+                }) { Text("Download") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDownloadConfirm = false }) { Text("Cancel") }
+            },
+        )
+    }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -131,7 +161,7 @@ fun ArtistDetailScreen(
             actions = {
                 if (artistDetail != null) {
                     IconButton(
-                        onClick = { viewModel.downloadAllReleases() },
+                        onClick = { showDownloadConfirm = true },
                         enabled = !isDownloadingAll,
                     ) {
                         if (isDownloadingAll) {

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
@@ -8,7 +8,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import tf.monochrome.android.data.api.QobuzIdRegistry
+import tf.monochrome.android.data.downloads.DownloadManager
 import tf.monochrome.android.data.repository.MusicRepository
 import tf.monochrome.android.domain.model.ArtistDetail
 import javax.inject.Inject
@@ -18,6 +21,7 @@ class ArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val repository: MusicRepository,
     private val qobuzIdRegistry: QobuzIdRegistry,
+    private val downloadManager: DownloadManager,
 ) : ViewModel() {
 
     private val artistId: Long = savedStateHandle.get<Long>("artistId") ?: 0L
@@ -79,4 +83,40 @@ class ArtistDetailViewModel @Inject constructor(
     }
 
     fun retry() = loadArtist()
+
+    private val _isDownloadingAll = MutableStateFlow(false)
+    val isDownloadingAll: StateFlow<Boolean> = _isDownloadingAll.asStateFlow()
+
+    /**
+     * Download every release for this artist. The artist payload carries albums but
+     * not their tracks, so each release is resolved (Qobuz slug first, else TIDAL)
+     * in parallel, then all resulting tracks are queued.
+     */
+    fun downloadAllReleases() {
+        val detail = _artistDetail.value ?: return
+        if (_isDownloadingAll.value) return
+        val releases = detail.albums + detail.eps + detail.singles
+        if (releases.isEmpty()) return
+        viewModelScope.launch {
+            _isDownloadingAll.value = true
+            try {
+                val tracks = coroutineScope {
+                    releases.map { album ->
+                        async {
+                            val slug = qobuzIdRegistry.albumSlugFor(album.id)
+                            val result = if (slug != null) {
+                                repository.getQobuzAlbum(slug)
+                            } else {
+                                repository.getAlbum(album.id)
+                            }
+                            result.getOrNull()?.tracks.orEmpty()
+                        }
+                    }.flatMap { it.await() }
+                }.distinctBy { it.id }
+                if (tracks.isNotEmpty()) downloadManager.downloadTracks(tracks)
+            } finally {
+                _isDownloadingAll.value = false
+            }
+        }
+    }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
@@ -1,0 +1,210 @@
+package tf.monochrome.android.ui.downloads
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import tf.monochrome.android.data.downloads.ActiveDownload
+import tf.monochrome.android.data.downloads.DownloadStatus
+import tf.monochrome.android.ui.components.CoverImage
+
+/**
+ * Floating, dismissible pill that surfaces the current download and its progress.
+ * Tapping it opens the full monitor; the X hides it until the next download starts.
+ */
+@Composable
+fun DownloadProgressPill(
+    downloads: List<ActiveDownload>,
+    onClick: () -> Unit,
+    onHide: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val current = downloads.firstOrNull { it.status == DownloadStatus.DOWNLOADING }
+        ?: downloads.firstOrNull() ?: return
+    val remaining = downloads.size
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shadowElevation = 10.dp,
+        tonalElevation = 6.dp,
+        onClick = onClick,
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CoverImage(
+                    url = current.artworkUri,
+                    contentDescription = null,
+                    size = 38.dp,
+                    cornerRadius = 8.dp,
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = if (remaining > 1) "Downloading · $remaining left" else "Downloading",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = current.title,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                IconButton(onClick = onHide) {
+                    Icon(Icons.Default.Close, contentDescription = "Hide downloads")
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            if (current.status == DownloadStatus.DOWNLOADING && current.progress > 0f) {
+                LinearProgressIndicator(
+                    progress = { current.progress },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+        }
+    }
+}
+
+/**
+ * Compact top-bar indicator: a determinate ring (overall progress) wrapping a
+ * download glyph. Hidden when nothing is in flight; tap opens the monitor.
+ */
+@Composable
+fun DownloadTopBarIndicator(
+    activeCount: Int,
+    overallProgress: Float,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (activeCount == 0) return
+    IconButton(onClick = onClick, modifier = modifier) {
+        Box(contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                progress = { overallProgress.coerceIn(0f, 1f) },
+                modifier = Modifier.size(28.dp),
+                strokeWidth = 2.5.dp,
+            )
+            Icon(
+                imageVector = Icons.Default.Download,
+                contentDescription = "Downloads",
+                modifier = Modifier.size(15.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+/** Bottom-sheet monitor listing every in-flight download with per-track progress. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DownloadsMonitorSheet(
+    downloads: List<ActiveDownload>,
+    onCancel: (Long) -> Unit,
+    onCancelAll: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Downloads" + if (downloads.isNotEmpty()) " · ${downloads.size}" else "",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                if (downloads.isNotEmpty()) {
+                    TextButton(onClick = onCancelAll) { Text("Cancel all") }
+                }
+            }
+            if (downloads.isEmpty()) {
+                Text(
+                    text = "No active downloads.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                downloads.forEach { d ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CoverImage(
+                            url = d.artworkUri,
+                            contentDescription = null,
+                            size = 44.dp,
+                            cornerRadius = 8.dp,
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = d.title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = if (d.status == DownloadStatus.DOWNLOADING) d.artistName else "Queued",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Spacer(Modifier.height(6.dp))
+                            if (d.status == DownloadStatus.DOWNLOADING && d.progress > 0f) {
+                                LinearProgressIndicator(
+                                    progress = { d.progress },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            } else {
+                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                            }
+                        }
+                        IconButton(onClick = { onCancel(d.trackId) }) {
+                            Icon(Icons.Default.Close, contentDescription = "Cancel")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterViewModel.kt
@@ -1,0 +1,34 @@
+package tf.monochrome.android.ui.downloads
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import tf.monochrome.android.data.downloads.ActiveDownload
+import tf.monochrome.android.data.downloads.DownloadManager
+import javax.inject.Inject
+
+/**
+ * Shared view of in-flight downloads, consumed by the floating progress pill, the
+ * top-bar circular indicator, and the downloads monitor sheet. Backed by the
+ * singleton [DownloadManager] flow so every surface sees the same live state.
+ */
+@HiltViewModel
+class DownloadCenterViewModel @Inject constructor(
+    private val downloadManager: DownloadManager,
+) : ViewModel() {
+
+    val active: StateFlow<List<ActiveDownload>> = downloadManager.observeActiveDownloads()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Mean progress across all in-flight downloads, for the aggregate indicator. */
+    val overallProgress: StateFlow<Float> = active
+        .map { list -> if (list.isEmpty()) 0f else list.map { it.progress }.average().toFloat() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0f)
+
+    fun cancel(trackId: Long) = downloadManager.cancel(trackId)
+    fun cancelAll() = downloadManager.cancelAll()
+}

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -88,8 +88,14 @@ fun HomeScreen(
     navController: NavController,
     playerViewModel: PlayerViewModel,
     viewModel: HomeViewModel = hiltViewModel(),
-    searchViewModel: SearchViewModel = hiltViewModel()
+    searchViewModel: SearchViewModel = hiltViewModel(),
+    downloadCenter: tf.monochrome.android.ui.downloads.DownloadCenterViewModel = hiltViewModel()
 ) {
+    val activeDownloads by downloadCenter.active.collectAsState()
+    val downloadProgress by downloadCenter.overallProgress.collectAsState()
+    var showDownloadsMonitor by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf(false)
+    }
     val recentTracks by viewModel.recentTracks.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val discoveryRows by viewModel.discoveryRows.collectAsState()
@@ -168,6 +174,15 @@ fun HomeScreen(
         )
     }
 
+    if (showDownloadsMonitor) {
+        tf.monochrome.android.ui.downloads.DownloadsMonitorSheet(
+            downloads = activeDownloads,
+            onCancel = downloadCenter::cancel,
+            onCancelAll = downloadCenter::cancelAll,
+            onDismiss = { showDownloadsMonitor = false },
+        )
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         tf.monochrome.android.devedit.DevEditable("home_header", Modifier.fillMaxWidth()) {
             TopAppBar(
@@ -179,6 +194,11 @@ fun HomeScreen(
                     )
                 },
                 actions = {
+                    tf.monochrome.android.ui.downloads.DownloadTopBarIndicator(
+                        activeCount = activeDownloads.size,
+                        overallProgress = downloadProgress,
+                        onClick = { showDownloadsMonitor = true },
+                    )
                     IconButton(onClick = { navController.navigate(Screen.Settings.createRoute()) }) {
                         Icon(
                             Icons.Default.Settings,

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -34,6 +34,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
@@ -489,6 +492,40 @@ fun MonochromeNavHost() {
                     hazeState = hazeState
                 )
             }
+        }
+
+        // ── Layer 3: Download progress pill + monitor (global chrome) ──
+        val downloadCenter: tf.monochrome.android.ui.downloads.DownloadCenterViewModel = hiltViewModel()
+        val activeDownloads by downloadCenter.active.collectAsState()
+        var pillHidden by rememberSaveable { mutableStateOf(false) }
+        var showDownloadsMonitor by rememberSaveable { mutableStateOf(false) }
+        // Re-show the pill whenever a fresh batch of downloads begins.
+        LaunchedEffect(activeDownloads.isNotEmpty()) {
+            if (activeDownloads.isNotEmpty()) pillHidden = false
+        }
+        val onChromeScreen = currentDestination?.route != Screen.NowPlaying.route &&
+            currentDestination?.route != Screen.Mixer.route
+        if (onChromeScreen && activeDownloads.isNotEmpty() && !pillHidden) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = navBarHeight + if (showMiniPlayer) 80.dp else 12.dp)
+                    .padding(horizontal = 8.dp)
+            ) {
+                tf.monochrome.android.ui.downloads.DownloadProgressPill(
+                    downloads = activeDownloads,
+                    onClick = { showDownloadsMonitor = true },
+                    onHide = { pillHidden = true },
+                )
+            }
+        }
+        if (showDownloadsMonitor) {
+            tf.monochrome.android.ui.downloads.DownloadsMonitorSheet(
+                downloads = activeDownloads,
+                onCancel = downloadCenter::cancel,
+                onCancelAll = downloadCenter::cancelAll,
+                onDismiss = { showDownloadsMonitor = false },
+            )
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1734,7 +1734,7 @@ private fun AboutTab() {
             }
             Spacer(modifier = Modifier.height(32.dp))
             Text(
-                text = "Tryptify version 1.6.0 · 2026",
+                text = "Tryptify version 1.6.2 · 2026",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface
             )


### PR DESCRIPTION
- Album detail: download button queues every track on the album.
- Artist detail: download-all-releases button resolves each release's tracks
  (Qobuz slug first, else TIDAL) in parallel and queues them; shows a spinner
  while resolving.
- DownloadManager: per-track metadata + observeActiveDownloads() (title/artist/
  cover/status/progress), a per-track tag so WorkInfo maps back to the id, and
  cancel/cancelAll.
- New DownloadCenterViewModel + UI: a dismissible progress pill (current track +
  bar) floating above the mini-player globally, a circular progress indicator in
  the Home top bar, and a downloads monitor bottom sheet (per-track progress,
  cancel / cancel-all) opened from either.