### PR TITLE
Polish mixer + finger-tracking reveal gestures

### DIFF
--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -160,6 +160,7 @@ class PreferencesManager @Inject constructor(
         // DSP Mixer
         private val DSP_ENABLED = booleanPreferencesKey("dsp_enabled")
         private val DSP_STATE_JSON = stringPreferencesKey("dsp_state_json")
+        private val MIXER_CHANNEL_DYNAMIC = booleanPreferencesKey("mixer_channel_dynamic")
         private val DSP_BLOCK_SIZE = intPreferencesKey("dsp_block_size")
         private val USB_BIT_PERFECT_ENABLED = booleanPreferencesKey("usb_bit_perfect_enabled")
         private val USB_EXCLUSIVE_BIT_PERFECT_ENABLED =
@@ -795,6 +796,16 @@ class PreferencesManager @Inject constructor(
             if (json.isNullOrBlank()) it.remove(DSP_STATE_JSON)
             else it[DSP_STATE_JSON] = json
         }
+    }
+
+    /**
+     * Mixer channel coloring mode. false (default) = curated fixed palette
+     * (distinct per-bus colors); true = colors derived from the current
+     * album/theme accent so the strips track the dynamic player color.
+     */
+    val mixerChannelDynamic: Flow<Boolean> = dataStore.data.map { it[MIXER_CHANNEL_DYNAMIC] ?: false }
+    suspend fun setMixerChannelDynamic(enabled: Boolean) {
+        dataStore.edit { it[MIXER_CHANNEL_DYNAMIC] = enabled }
     }
 
     /**

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,31 +15,35 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.Text
 import tf.monochrome.android.audio.dsp.model.BusConfig
 import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.ui.components.bounceClick
+import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.player.PlayerDesignTokens
+
+/** Fixed fader travel so strips stay compact instead of stretching the whole
+ *  screen height; the strip is centred in its row and the meters match it. */
+private val FaderTravel = 280.dp
 
 /**
- * FL Studio-styled channel strip with dark DAW colors.
- *
- * Uses [FLColors] for the authentic FL Studio look:
- *  - Dark strip background with subtle border
- *  - Green/yellow VU meters behind the fader
- *  - Lime green accent text for active elements
- *  - Red mute / yellow solo buttons
- *
- * Master strip is wider (72 dp) with dual VU meters.
+ * Compact DAW channel strip styled to match the main player: a solid glass
+ * panel, theme-driven accents, a weighted fader cap and clean VU metering.
  */
 @Composable
 fun FLChannelStrip(
@@ -48,161 +51,197 @@ fun FLChannelStrip(
     isSelected: Boolean,
     modifier: Modifier = Modifier,
     levels: BusLevels = BusLevels(),
+    accentColor: Color = MaterialTheme.colorScheme.primary,
     onSelect: () -> Unit,
     onGainChange: (Float) -> Unit,
     onPanChange: (Float) -> Unit,
     onToggleMute: () -> Unit,
     onToggleSolo: () -> Unit,
 ) {
+    val colors = MaterialTheme.colorScheme
     val isMaster = bus.isMaster
-    val stripWidth = if (isMaster) 72.dp else 56.dp
-    val stripShape = RoundedCornerShape(4.dp)
+    val stripWidth = if (isMaster) 78.dp else 60.dp
+    val stripShape = RoundedCornerShape(PlayerDesignTokens.GlassCornerSmall)
+    val accent = if (isMaster) colors.primary else accentColor
+    val onAccent = if (accent.luminance() > 0.55f) Color.Black else Color.White
+
+    // Near-opaque panel so the album glow sits BEHIND the strip instead of
+    // washing through it. A faint accent tint up top gives each channel life.
+    val panelTop = lerp(colors.surfaceContainerHigh, accent, if (isSelected) 0.16f else 0.07f)
+    val panelBottom = lerp(colors.surface, Color.Black, 0.28f)
+    val stripBrush = Brush.verticalGradient(
+        colors = listOf(
+            panelTop.copy(alpha = 0.97f),
+            colors.surfaceContainerHigh.copy(alpha = 0.95f),
+            panelBottom.copy(alpha = 0.97f)
+        )
+    )
+    val meterWidth = 7.dp
+    val inactiveButton = colors.surfaceContainerHighest.copy(alpha = 0.88f)
 
     Column(
         modifier = modifier
             .width(stripWidth)
-            .fillMaxHeight()
-            .clip(stripShape)
-            .background(if (isSelected) FLColors.stripBgSelected else FLColors.stripBg)
+            .shadow(
+                elevation = if (isSelected) 20.dp else 10.dp,
+                shape = stripShape,
+                clip = false
+            )
+            .background(stripBrush, stripShape)
+            .liquidGlass(
+                shape = stripShape,
+                tintAlpha = PlayerDesignTokens.GlassTintSoft,
+                borderAlpha = if (isSelected) 0.16f else 0.06f,
+                showRefraction = isSelected
+            )
             .border(
-                width = 1.dp,
-                color = if (isSelected) FLColors.accent.copy(alpha = 0.4f) else FLColors.stripBorder,
+                width = if (isSelected) 1.5.dp else 1.dp,
+                color = if (isSelected) accent.copy(alpha = 0.70f) else colors.outline.copy(alpha = 0.14f),
                 shape = stripShape
             )
             .bounceClick(onClick = onSelect)
-            .padding(horizontal = 3.dp, vertical = 4.dp),
+            .padding(horizontal = 4.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp)
+        verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        // ── Channel number badge ───────────────────────────────────────
+        // ── Channel number badge ──────────────────────────────────────────
         Box(
             modifier = Modifier
-                .size(22.dp)
+                .size(26.dp)
                 .clip(CircleShape)
-                .background(
-                    if (isSelected) FLColors.accent.copy(alpha = 0.25f)
-                    else FLColors.insertSlotBg
+                .background(if (isSelected) accent else colors.surfaceContainerHighest.copy(alpha = 0.85f))
+                .then(
+                    if (isSelected) Modifier
+                    else Modifier.border(1.5.dp, accent.copy(alpha = 0.85f), CircleShape)
                 ),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = if (isMaster) "M" else "${bus.index + 1}",
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
-                color = if (isSelected) FLColors.textBright else FLColors.textWhite
+                color = if (isSelected) onAccent else Color.White
             )
         }
 
-        // ── Channel name ───────────────────────────────────────────────
+        // ── Channel name ──────────────────────────────────────────────────
         Text(
             text = bus.name,
-            fontSize = 8.sp,
-            fontWeight = FontWeight.Medium,
-            color = if (isSelected) FLColors.textBright else FLColors.textActive,
+            fontSize = 10.sp,
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+            color = Color.White.copy(alpha = if (isSelected) 1f else 0.82f),
             textAlign = TextAlign.Center,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.fillMaxWidth()
         )
 
-        // ── Plugin count badge ─────────────────────────────────────────
+        // ── FX count ──────────────────────────────────────────────────────
         if (bus.plugins.isNotEmpty()) {
             Text(
                 text = "${bus.plugins.size} fx",
-                fontSize = 8.sp,
-                color = FLColors.textDim
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Medium,
+                color = accent.copy(alpha = 0.95f)
             )
         } else {
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(11.dp))
         }
 
-        // ── Meter + Fader area ─────────────────────────────────────────
-        Box(
+        // ── Meter ▏ Fader ▏ Meter ─────────────────────────────────────────
+        Row(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 2.dp),
-            contentAlignment = Alignment.Center
+                .height(FaderTravel)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterHorizontally)
         ) {
-            // VU meters behind — using actual audio levels
-            Row(
-                modifier = Modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                VuMeter(
-                    levelDb = levels.peakDbL,
-                    muted = bus.muted,
-                    modifier = Modifier.fillMaxHeight()
-                )
-                if (isMaster) {
-                    Spacer(modifier = Modifier.width(1.dp))
-                    VuMeter(
-                        levelDb = levels.peakDbR,
-                        muted = bus.muted,
-                        modifier = Modifier.fillMaxHeight()
-                    )
-                }
+            if (isMaster) {
+                VuMeter(levelDb = levels.peakDbL, muted = bus.muted, accentColor = accent)
+            } else {
+                Spacer(modifier = Modifier.width(meterWidth))
             }
 
-            // Fader overlaid
             VerticalFader(
                 gainDb = bus.gainDb,
                 onGainChange = onGainChange,
-                accentColor = FLColors.accent,
-                modifier = Modifier.fillMaxSize()
+                accentColor = accent,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            )
+
+            VuMeter(
+                levelDb = if (isMaster) levels.peakDbR else levels.peakDbL,
+                muted = bus.muted,
+                accentColor = accent
             )
         }
 
-        // ── dB readout ─────────────────────────────────────────────────
-        Text(
-            text = if (bus.gainDb <= -60f) "-inf" else "%.1f".format(bus.gainDb),
-            fontSize = 9.sp,
-            color = FLColors.textActive,
-            textAlign = TextAlign.Center
-        )
+        // ── dB readout ────────────────────────────────────────────────────
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(Color.Black.copy(alpha = 0.30f))
+                .padding(horizontal = 7.dp, vertical = 2.dp)
+        ) {
+            Text(
+                text = if (bus.gainDb <= -60f) "-inf" else "%.1f".format(bus.gainDb),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White.copy(alpha = 0.90f),
+                textAlign = TextAlign.Center
+            )
+        }
 
-        // ── Pan knob ──────────────────────────────────────────────────
         PanKnob(
             value = bus.pan,
-            onValueChange = onPanChange
+            onValueChange = onPanChange,
+            accentColor = accent
         )
 
-        Spacer(modifier = Modifier.height(2.dp))
-
-        // ── Mute / Solo buttons ────────────────────────────────────────
-        Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
-            // Mute
+        // ── Mute / Solo ───────────────────────────────────────────────────
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             Box(
                 modifier = Modifier
-                    .size(24.dp)
+                    .size(26.dp)
                     .clip(CircleShape)
-                    .background(if (bus.muted) FLColors.muteActive else FLColors.muteInactive)
+                    .background(if (bus.muted) colors.error else inactiveButton)
+                    .border(
+                        width = 1.dp,
+                        color = if (bus.muted) colors.error.copy(alpha = 0.75f) else colors.outline.copy(alpha = 0.12f),
+                        shape = CircleShape
+                    )
                     .bounceClick(onClick = onToggleMute),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = "M",
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     fontWeight = FontWeight.Bold,
-                    color = if (bus.muted) Color.White else FLColors.textDim
+                    color = if (bus.muted) colors.onError else colors.onSurfaceVariant
                 )
             }
 
-            // Solo (not on master)
             if (!isMaster) {
                 Box(
                     modifier = Modifier
-                        .size(24.dp)
+                        .size(26.dp)
                         .clip(CircleShape)
-                        .background(if (bus.soloed) FLColors.soloActive else FLColors.soloInactive)
+                        .background(if (bus.soloed) accent else inactiveButton)
+                        .border(
+                            width = 1.dp,
+                            color = if (bus.soloed) accent.copy(alpha = 0.78f) else colors.outline.copy(alpha = 0.12f),
+                            shape = CircleShape
+                        )
                         .bounceClick(onClick = onToggleSolo),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = "S",
-                        fontSize = 10.sp,
+                        fontSize = 11.sp,
                         fontWeight = FontWeight.Bold,
-                        color = if (bus.soloed) Color.Black else FLColors.textDim
+                        color = if (bus.soloed) onAccent else colors.onSurfaceVariant
                     )
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
@@ -5,9 +5,17 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,38 +26,94 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import tf.monochrome.android.audio.dsp.model.BusConfig
+import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.audio.dsp.model.MixPreset
+import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.player.DynamicAlbumGlow
+import tf.monochrome.android.ui.player.PlayerDesignTokens
+import tf.monochrome.android.ui.player.dynamicPlayerBackground
 import tf.monochrome.android.ui.theme.MonoDimens
+
+/** Curated per-bus channel colours (master keeps the album-derived primary).
+ *  Replaces the muted theme `secondary`, which rendered bus strips as washed
+ *  grey ghosts against the dynamic background. */
+private val BusAccentPalette = listOf(
+    Color(0xFF6EA8FF), // blue
+    Color(0xFF49E0B0), // teal
+    Color(0xFFB98CFF), // violet
+    Color(0xFFFF8A6B), // coral
+    Color(0xFFFFC857), // amber
+)
+
+/**
+ * Dynamic per-bus accent derived from the current player/theme color [base]:
+ * each channel is the base hue rotated by a fixed step, so the strips track
+ * the album-dynamic color while staying distinguishable. Falls back to the
+ * curated palette when [base] is essentially greyscale (e.g. the Monochrome
+ * theme with album colors off), where there is no hue to vary.
+ */
+private fun dynamicBusColor(base: Color, index: Int): Color {
+    val hsv = FloatArray(3)
+    android.graphics.Color.colorToHSV(base.toArgb(), hsv)
+    if (hsv[1] < 0.12f) return BusAccentPalette[index % BusAccentPalette.size]
+    hsv[0] = (hsv[0] + 24f + index * 34f) % 360f
+    hsv[1] = hsv[1].coerceIn(0.50f, 0.95f)
+    hsv[2] = hsv[2].coerceIn(0.62f, 0.92f)
+    return Color(android.graphics.Color.HSVToColor(hsv))
+}
+
+private fun busAccent(dynamic: Boolean, base: Color, index: Int): Color =
+    if (dynamic) dynamicBusColor(base, index)
+    else BusAccentPalette[index % BusAccentPalette.size]
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,19 +123,79 @@ fun MixerScreen(
 ) {
     val enabled by viewModel.enabled.collectAsState()
     val buses by viewModel.buses.collectAsState()
-    val busLevels by viewModel.busLevels.collectAsState()
     val selectedBusIndex by viewModel.selectedBusIndex.collectAsState()
     val showPluginPicker by viewModel.showPluginPicker.collectAsState()
     val editingPlugin by viewModel.editingPlugin.collectAsState()
     val presets by viewModel.presets.collectAsState()
     val currentPresetName by viewModel.currentPresetName.collectAsState()
     val canvasState by viewModel.canvasState.collectAsState()
+    val channelDynamicColor by viewModel.channelDynamicColor.collectAsState()
 
     val selectedBus = buses.getOrNull(selectedBusIndex)
     val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val colorScheme = MaterialTheme.colorScheme
+    val accent = colorScheme.primary
+    val headerShape = RoundedCornerShape(
+        bottomStart = PlayerDesignTokens.GlassCornerLarge,
+        bottomEnd = PlayerDesignTokens.GlassCornerLarge
+    )
 
     var showInsertRack by remember { mutableStateOf(false) }
-    var showCanvas by remember { mutableStateOf(false) }
+
+    // ── Mixer ⇆ DSP-canvas drag-to-reveal transition ────────────────────
+    // progress 0 = mixer fully shown, 1 = canvas fully shown. The two pages
+    // are stacked as a filmstrip and translated by `progress`; a header-only
+    // vertical drag writes `progress` synchronously (zero-lag tracking) and on
+    // release it settles to 0/1 by fling velocity (else position). `progress`
+    // is read ONLY inside graphicsLayer{} (draw phase) and derivedStateOf, so
+    // sliding never recomposes the page content.
+    val scope = rememberCoroutineScope()
+    var progress by remember { mutableFloatStateOf(0f) }
+    var heightPx by remember { mutableFloatStateOf(0f) }
+    var dragging by remember { mutableStateOf(false) }
+    var settleJob by remember { mutableStateOf<Job?>(null) }
+    val settleSpec = remember {
+        spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow)
+    }
+    val animateProgressTo: (Float, Float) -> Unit = { target, initialVel ->
+        settleJob?.cancel()
+        settleJob = scope.launch {
+            // Coerce the animated value: a fast fling into the critically-damped
+            // spring can overshoot the endpoint, which would briefly expose a
+            // background gap at the top/bottom edge.
+            animate(progress, target, initialVel, settleSpec) { value, _ -> progress = value.coerceIn(0f, 1f) }
+        }
+    }
+    val dragState = rememberDraggableState { delta ->
+        if (heightPx > 0f) progress = (progress + delta / heightPx).coerceIn(0f, 1f)
+    }
+    val onDragStarted: suspend CoroutineScope.(Offset) -> Unit = {
+        settleJob?.cancel()
+        dragging = true
+    }
+    val onDragStopped: suspend CoroutineScope.(Float) -> Unit = { velocity ->
+        val vNorm = if (heightPx > 0f) velocity / heightPx else 0f
+        val target = when {
+            vNorm > 0.8f -> 1f           // flick down → canvas
+            vNorm < -0.8f -> 0f          // flick up → mixer
+            progress > 0.5f -> 1f        // dragged past halfway → canvas
+            else -> 0f
+        }
+        // Only carry velocity that agrees with the target, so a gentle
+        // sub-threshold flick the "wrong" way doesn't lurch before settling.
+        val settleVel = if ((target == 1f) == (vNorm > 0f)) vNorm else 0f
+        dragging = false
+        animateProgressTo(target, settleVel)
+    }
+    // Coarse, boundary-only flags (derivedStateOf recomposes only when the bool
+    // flips). `|| dragging` keeps BOTH pages composed for the whole gesture, so
+    // the page that owns the active drag handle is never disposed mid-drag
+    // (which would cancel its scope and skip the settle).
+    val composeCanvas by remember { derivedStateOf { progress > 0.0001f || dragging } }
+    val composeMixer by remember { derivedStateOf { progress < 0.9999f || dragging } }
+    // Plugin-editor sheet appears only once the reveal has settled on the
+    // canvas — not at the 0.5 midpoint mid-drag.
+    val canvasSettled by remember { derivedStateOf { progress > 0.9999f } }
 
     // ── Preset import / export (SAF document pickers) ───────────────────
     val context = LocalContext.current
@@ -113,25 +237,45 @@ fun MixerScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(FLColors.background)
+            .background(dynamicPlayerBackground(accent))
+            .onSizeChanged { heightPx = it.height.toFloat() }
     ) {
-        if (showCanvas) {
-            // ── DSP Canvas View ─────────────────────────────────────────
+        DynamicAlbumGlow(accent)
+        if (composeCanvas) {
+            // ── DSP Canvas View (slides down from the top) ───────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { translationY = (progress - 1f) * heightPx }
+            ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(FLColors.headerBg)
+                        .shadow(elevation = 18.dp, shape = headerShape, clip = false)
+                        .background(colorScheme.surface.copy(alpha = 0.90f), headerShape)
+                        .liquidGlass(
+                            shape = headerShape,
+                            tintAlpha = PlayerDesignTokens.GlassTintMedium,
+                            borderAlpha = PlayerDesignTokens.GlassTintSoft
+                        )
                         .padding(top = statusBarPadding)
+                        // Swipe up here to slide the mixer back over the canvas.
+                        .draggable(
+                            state = dragState,
+                            orientation = Orientation.Vertical,
+                            onDragStarted = onDragStarted,
+                            onDragStopped = onDragStopped
+                        )
                         .padding(horizontal = MonoDimens.spacingMd, vertical = MonoDimens.spacingSm),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(onClick = { showCanvas = false }, modifier = Modifier.size(32.dp)) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = FLColors.textWhite, modifier = Modifier.size(20.dp))
+                        IconButton(onClick = { animateProgressTo(0f, 0f) }, modifier = Modifier.size(32.dp)) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = colorScheme.onSurface, modifier = Modifier.size(20.dp))
                         }
-                        Text("DSP Canvas", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = FLColors.textWhite)
+                        Text("DSP Canvas", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = colorScheme.onSurface)
                     }
                 }
                 Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -156,77 +300,87 @@ fun MixerScreen(
                     )
                 }
             }
-        } else {
+            }
+        }
+        if (composeMixer) {
             // ── FL Studio Console View ──────────────────────────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { translationY = progress * heightPx }
+            ) {
             Column(modifier = Modifier.fillMaxSize()) {
 
-                // ── Header ──────────────────────────────────────────────
+                // ── Header (swipe down anywhere to reveal the DSP canvas) ───
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(FLColors.headerBg)
+                        .shadow(elevation = 22.dp, shape = headerShape, clip = false)
+                        .background(colorScheme.surface.copy(alpha = 0.90f), headerShape)
+                        .liquidGlass(
+                            shape = headerShape,
+                            tintAlpha = PlayerDesignTokens.GlassTintMedium,
+                            borderAlpha = PlayerDesignTokens.GlassTintSoft
+                        )
+                        // Inset first so the drag area excludes the status-bar
+                        // strip and doesn't fight the system notification shade.
                         .padding(top = statusBarPadding)
+                        // Drag down here to slide the DSP canvas in from the top.
+                        .draggable(
+                            state = dragState,
+                            orientation = Orientation.Vertical,
+                            onDragStarted = onDragStarted,
+                            onDragStopped = onDragStopped
+                        )
                 ) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = MonoDimens.spacingSm, vertical = MonoDimens.spacingXs),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(MonoDimens.spacingSm)
+                        horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
-                        // Back button
-                        IconButton(onClick = { navController.popBackStack() }, modifier = Modifier.size(32.dp)) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = FLColors.textWhite, modifier = Modifier.size(20.dp))
-                        }
+                        NavIconButton(
+                            icon = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            onClick = { navController.popBackStack() }
+                        )
 
-                        // Title
                         Text(
                             text = "Mixer",
-                            style = MaterialTheme.typography.headlineSmall,
+                            style = MaterialTheme.typography.titleLarge,
                             fontWeight = FontWeight.Bold,
-                            color = FLColors.textBright
+                            color = colorScheme.onSurface,
+                            modifier = Modifier.padding(start = 2.dp)
                         )
 
                         Box(modifier = Modifier.weight(1f))
 
-                        // Insert-rack toggle
-                        IconButton(onClick = { showInsertRack = !showInsertRack }, modifier = Modifier.size(32.dp)) {
-                            Icon(
-                                Icons.Default.Tune, "Insert Rack",
-                                tint = if (showInsertRack) FLColors.accent else FLColors.textDim,
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
+                        NavIconButton(
+                            icon = Icons.Default.Tune,
+                            contentDescription = "Insert Rack",
+                            active = showInsertRack,
+                            accent = accent,
+                            onClick = { showInsertRack = !showInsertRack }
+                        )
+                        NavIconButton(
+                            icon = Icons.Default.Palette,
+                            contentDescription = if (channelDynamicColor) "Channel color: dynamic" else "Channel color: palette",
+                            active = channelDynamicColor,
+                            accent = accent,
+                            onClick = { viewModel.setChannelDynamicColor(!channelDynamicColor) }
+                        )
+                        NavIconButton(
+                            icon = Icons.Default.AccountTree,
+                            contentDescription = "DSP Canvas",
+                            onClick = { animateProgressTo(1f, 0f) }
+                        )
 
-                        // Canvas toggle
-                        IconButton(onClick = { showCanvas = true }, modifier = Modifier.size(32.dp)) {
-                            Icon(
-                                Icons.Default.AccountTree, "DSP Canvas",
-                                tint = FLColors.textDim,
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
-
-                        // DSP on/off
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                text = if (enabled) "ON" else "OFF",
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = if (enabled) FLColors.accent else FLColors.textDim
-                            )
-                            Switch(
-                                checked = enabled,
-                                onCheckedChange = { viewModel.setEnabled(it) },
-                                colors = SwitchDefaults.colors(
-                                    checkedTrackColor = FLColors.accent,
-                                    checkedThumbColor = FLColors.background
-                                )
-                            )
-                        }
+                        DspPowerToggle(
+                            enabled = enabled,
+                            accent = accent,
+                            onToggle = { viewModel.setEnabled(!enabled) }
+                        )
                     }
 
                     // Preset bar
@@ -248,38 +402,43 @@ fun MixerScreen(
                         )
                     }
 
-                    HorizontalDivider(color = FLColors.stripBorder, modifier = Modifier.padding(horizontal = MonoDimens.spacingSm))
+                    // Pull-down handle — tap or swipe down to open the DSP canvas
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { animateProgressTo(1f, 0f) }
+                            .padding(top = 2.dp, bottom = 7.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(40.dp)
+                                .height(4.dp)
+                                .clip(CircleShape)
+                                .background(colorScheme.onSurfaceVariant.copy(alpha = 0.40f))
+                        )
+                    }
                 }
 
                 // ── Channel strips + insert rack ────────────────────────
                 Row(modifier = Modifier.weight(1f).fillMaxWidth()) {
 
-                    // Horizontal-scrolling channel strips
-                    LazyRow(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight(),
-                        contentPadding = PaddingValues(horizontal = MonoDimens.spacingXs),
-                        horizontalArrangement = Arrangement.spacedBy(MonoDimens.spacingXs)
-                    ) {
-                        itemsIndexed(buses) { index, bus ->
-                            tf.monochrome.android.devedit.DevEditable("channel_strip_$index", Modifier) {
-                                FLChannelStrip(
-                                    bus = bus,
-                                    isSelected = index == selectedBusIndex,
-                                    levels = busLevels.getOrNull(index) ?: tf.monochrome.android.audio.dsp.model.BusLevels(),
-                                    onSelect = {
-                                        viewModel.selectBus(index)
-                                        showInsertRack = true
-                                    },
-                                    onGainChange = { viewModel.setBusGain(index, it) },
-                                    onPanChange = { viewModel.setBusPan(index, it) },
-                                    onToggleMute = { viewModel.toggleMute(index) },
-                                    onToggleSolo = { viewModel.toggleSolo(index) }
-                                )
-                            }
-                        }
-                    }
+                    // Horizontal-scrolling channel strips. Hoisted into its own
+                    // composable that collects the 60Hz busLevels flow LOCALLY,
+                    // so meter frames recompose only the strips — never the
+                    // header, the DSP-canvas page, or the transition gating.
+                    ChannelStripRow(
+                        viewModel = viewModel,
+                        buses = buses,
+                        selectedBusIndex = selectedBusIndex,
+                        accent = accent,
+                        channelDynamicColor = channelDynamicColor,
+                        onSelectBus = { index ->
+                            viewModel.selectBus(index)
+                            showInsertRack = true
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
 
                     // Insert rack — right panel
                     AnimatedVisibility(
@@ -313,6 +472,7 @@ fun MixerScreen(
                     }
                 }
             }
+            }
         }
     }
 
@@ -325,7 +485,7 @@ fun MixerScreen(
     }
 
     // ── Plugin editor sheet (canvas view) ───────────────────────────────
-    if (showCanvas) {
+    if (canvasSettled) {
         editingPlugin?.let { (busIdx, slotIdx) ->
             val bus = buses.getOrNull(busIdx)
             val plugin = bus?.plugins?.getOrNull(slotIdx)
@@ -336,6 +496,123 @@ fun MixerScreen(
                     slotIndex = slotIdx,
                     onParameterChange = { b, s, p, v -> viewModel.setParameter(b, s, p, v) },
                     onDismiss = { viewModel.dismissPluginEditor() }
+                )
+            }
+        }
+    }
+}
+
+/** Consistent circular glass action button for the mixer header. */
+@Composable
+private fun NavIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    active: Boolean = false,
+    accent: Color = MaterialTheme.colorScheme.primary
+) {
+    val colors = MaterialTheme.colorScheme
+    Box(
+        modifier = modifier
+            .size(38.dp)
+            .clip(CircleShape)
+            .background(
+                if (active) accent.copy(alpha = 0.20f)
+                else colors.surfaceContainerHighest.copy(alpha = 0.40f)
+            )
+            .border(
+                width = 1.dp,
+                color = if (active) accent.copy(alpha = 0.55f) else colors.outline.copy(alpha = 0.14f),
+                shape = CircleShape
+            )
+            .bounceClick(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = if (active) accent else colors.onSurfaceVariant,
+            modifier = Modifier.size(19.dp)
+        )
+    }
+}
+
+/** Polished pill replacing the stock DSP on/off switch. */
+@Composable
+private fun DspPowerToggle(
+    enabled: Boolean,
+    accent: Color,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colors = MaterialTheme.colorScheme
+    val onAccent = if (accent.luminance() > 0.55f) Color.Black else Color.White
+    val contentColor = if (enabled) onAccent else colors.onSurfaceVariant
+    Row(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(if (enabled) accent else colors.surfaceContainerHighest.copy(alpha = 0.50f))
+            .border(
+                width = 1.dp,
+                color = if (enabled) Color.White.copy(alpha = 0.25f) else colors.outline.copy(alpha = 0.18f),
+                shape = CircleShape
+            )
+            .bounceClick(onClick = onToggle)
+            .padding(horizontal = 12.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.PowerSettingsNew,
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(15.dp)
+        )
+        Text(
+            text = if (enabled) "ON" else "OFF",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = contentColor
+        )
+    }
+}
+
+/**
+ * The row of channel strips. The 60 Hz `busLevels` meter flow is collected
+ * HERE rather than in [MixerScreen] so a new meter frame recomposes only the
+ * strips — the header, the DSP-canvas page, and the drag-transition gating all
+ * stay out of the per-frame path (mirrors the local `audioAmplitude` pattern).
+ */
+@Composable
+private fun ChannelStripRow(
+    viewModel: MixerViewModel,
+    buses: List<BusConfig>,
+    selectedBusIndex: Int,
+    accent: Color,
+    channelDynamicColor: Boolean,
+    onSelectBus: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val busLevels by viewModel.busLevels.collectAsState()
+    LazyRow(
+        modifier = modifier.fillMaxHeight(),
+        contentPadding = PaddingValues(horizontal = MonoDimens.spacingMd, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(MonoDimens.spacingSm),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        itemsIndexed(buses) { index, bus ->
+            tf.monochrome.android.devedit.DevEditable("channel_strip_$index", Modifier) {
+                FLChannelStrip(
+                    bus = bus,
+                    isSelected = index == selectedBusIndex,
+                    levels = busLevels.getOrNull(index) ?: BusLevels(),
+                    accentColor = if (bus.isMaster) accent else busAccent(channelDynamicColor, accent, bus.index),
+                    onSelect = { onSelectBus(index) },
+                    onGainChange = { viewModel.setBusGain(index, it) },
+                    onPanChange = { viewModel.setBusPan(index, it) },
+                    onToggleMute = { viewModel.toggleMute(index) },
+                    onToggleSolo = { viewModel.toggleSolo(index) }
                 )
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
@@ -19,6 +19,7 @@ import tf.monochrome.android.audio.dsp.model.BusConfig
 import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.audio.dsp.model.MixPreset
 import tf.monochrome.android.audio.dsp.model.MixPresetFile
+import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.data.repository.MixPresetRepository
 import tf.monochrome.android.ui.mixer.canvas.model.CanvasOffset
 import tf.monochrome.android.ui.mixer.canvas.model.CanvasState
@@ -30,12 +31,21 @@ import javax.inject.Inject
 @HiltViewModel
 class MixerViewModel @Inject constructor(
     private val dspManager: DspEngineManager,
-    private val presetRepository: MixPresetRepository
+    private val presetRepository: MixPresetRepository,
+    private val preferencesManager: PreferencesManager
 ) : ViewModel() {
 
     val enabled: StateFlow<Boolean> = dspManager.enabled
     val buses: StateFlow<List<BusConfig>> = dspManager.buses
     val busLevels: StateFlow<List<BusLevels>> = dspManager.busLevels
+
+    /** Channel coloring mode: false = curated palette, true = album/theme-derived. */
+    val channelDynamicColor: StateFlow<Boolean> = preferencesManager.mixerChannelDynamic
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    fun setChannelDynamicColor(enabled: Boolean) {
+        viewModelScope.launch { preferencesManager.setMixerChannelDynamic(enabled) }
+    }
 
     val presets: StateFlow<List<MixPreset>> = presetRepository.getAllPresets()
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/PanKnob.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/PanKnob.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -31,13 +33,16 @@ import kotlin.math.sin
  */
 @Composable
 fun PanKnob(
-    value: Float,               // -1 … +1
+    value: Float,               // -1 ... +1
     onValueChange: (Float) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary
 ) {
-    val trackColor  = MaterialTheme.colorScheme.surfaceContainerHigh
-    val activeColor = MaterialTheme.colorScheme.primary
-    val dotColor    = MaterialTheme.colorScheme.onPrimary
+    // A translucent-white ring reads as a recessed groove on the dark strip;
+    // the theme's surfaceContainer was too low-contrast to see the knob at all.
+    val trackColor  = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.16f)
+    val activeColor = accentColor
+    val dotColor    = if (accentColor.luminance() > 0.55f) Color.Black else Color.White
     val haptic      = LocalHapticFeedback.current
 
     // Remember whether we already fired a haptic for the centre detent

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -12,8 +11,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -21,19 +23,19 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.absoluteValue
 
 /**
- * Vertical gain fader with logarithmic-feel scale.
+ * Vertical gain fader with a logarithmic-feel scale.
  *
  * Bottom 60 % of travel covers  -60 … 0 dB (unity).
  * Top    40 % of travel covers    0 … +24 dB.
  *
- * Designed to overlay VU meters inside a Box — the background is
- * transparent so the glass surface and meters behind remain visible.
- * Colours come from MaterialTheme so the fader respects the current
- * app theme and liquid-glass look.
+ * Rendered as a recessed groove with a coloured value-fill rising up to a
+ * weighted fader cap, so the channel reads as a real console fader rather
+ * than a hairline. The fader fills the WIDTH it is given by its parent — keep
+ * it in a width-bounded slot (weight / fillMaxWidth / a fixed width).
  *
- * @param gainDb      current gain in dB (-60 … +24).
+ * @param gainDb       current gain in dB (-60 … +24).
  * @param onGainChange callback when the user moves the fader.
- * @param accentColor colour for the active-fill portion below the thumb.
+ * @param accentColor  colour for the value-fill below the cap and the cap's indicator.
  */
 @Composable
 fun VerticalFader(
@@ -42,16 +44,19 @@ fun VerticalFader(
     modifier: Modifier = Modifier,
     accentColor: Color = MaterialTheme.colorScheme.primary
 ) {
-    val trackColor  = MaterialTheme.colorScheme.surfaceContainerHigh
-    val thumbFill   = MaterialTheme.colorScheme.surfaceContainerHighest
-    val thumbBorder = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
-    val tickColor   = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+    val colors      = MaterialTheme.colorScheme
+    val grooveTop   = Color.Black.copy(alpha = 0.30f)
+    val grooveBot   = Color.Black.copy(alpha = 0.52f)
+    val capTop      = lerp(colors.surfaceContainerHighest, Color.White, 0.12f)
+    val capBottom   = lerp(colors.surfaceContainerHigh, Color.Black, 0.35f)
+    val capBorder   = Color.White.copy(alpha = 0.22f)
+    val tickColor   = colors.onSurfaceVariant.copy(alpha = 0.26f)
+    val unityColor  = accentColor.copy(alpha = 0.70f)
     val haptic      = LocalHapticFeedback.current
     val prevInDetent = remember { mutableSetOf<Boolean>() }
 
     Canvas(
         modifier = modifier
-            .width(44.dp)
             .fillMaxHeight()
             .pointerInput(Unit) {
                 detectDragGestures { change, _ ->
@@ -70,86 +75,87 @@ fun VerticalFader(
         val w = size.width
         val h = size.height
         val cx = w / 2f
-        val trackW = 2.dp.toPx()
-        val thumbW = 36.dp.toPx()
-        val thumbH = 10.dp.toPx()
-        val thumbR = 3.dp.toPx()
+        val grooveW = 8.dp.toPx()
+        val grooveR = grooveW / 2f
+        val capW = (w - 6.dp.toPx()).coerceIn(20.dp.toPx(), 34.dp.toPx())
+        val capH = 16.dp.toPx()
+        val capR = 5.dp.toPx()
+        val thumbY = dbToY(gainDb, h)
 
-        // ── Thin fader track ───────────────────────────────────────────
+        // ── Recessed groove ───────────────────────────────────────────────
         drawRoundRect(
-            color      = trackColor,
-            topLeft    = Offset(cx - trackW / 2f, 0f),
-            size       = Size(trackW, h),
-            cornerRadius = CornerRadius(trackW / 2f)
+            brush      = Brush.verticalGradient(listOf(grooveTop, grooveBot)),
+            topLeft    = Offset(cx - grooveR, 0f),
+            size       = Size(grooveW, h),
+            cornerRadius = CornerRadius(grooveR)
         )
 
-        // ── Unity mark (0 dB) at 40 % from top ────────────────────────
-        val unityY = h * 0.4f
+        // ── dB tick marks (both sides of the groove) ──────────────────────
+        val ticks = listOf(24f, 18f, 12f, 6f, 0f, -6f, -12f, -18f, -24f, -36f, -48f, -60f)
+        val tickGap = grooveR + 3.dp.toPx()
+        for (db in ticks) {
+            val y = dbToY(db, h)
+            val len = if (db == 0f) 5.dp.toPx() else 3.dp.toPx()
+            drawLine(tickColor, Offset(cx - tickGap - len, y), Offset(cx - tickGap, y), strokeWidth = 1.dp.toPx())
+            drawLine(tickColor, Offset(cx + tickGap, y), Offset(cx + tickGap + len, y), strokeWidth = 1.dp.toPx())
+        }
+
+        // ── Value fill below the cap ──────────────────────────────────────
+        if (thumbY < h) {
+            drawRoundRect(
+                brush = Brush.verticalGradient(
+                    colors = listOf(accentColor.copy(alpha = 0.95f), accentColor.copy(alpha = 0.42f)),
+                    startY = thumbY,
+                    endY   = h
+                ),
+                topLeft    = Offset(cx - grooveR, thumbY),
+                size       = Size(grooveW, h - thumbY),
+                cornerRadius = CornerRadius(grooveR)
+            )
+        }
+
+        // ── Unity (0 dB) reference line ───────────────────────────────────
+        val unityY = dbToY(0f, h)
         drawLine(
-            color       = accentColor.copy(alpha = 0.5f),
-            start       = Offset(cx - 12.dp.toPx(), unityY),
-            end         = Offset(cx + 12.dp.toPx(), unityY),
+            color       = unityColor,
+            start       = Offset(cx - capW / 2f, unityY),
+            end         = Offset(cx + capW / 2f, unityY),
             strokeWidth = 1.dp.toPx()
         )
 
-        // ── dB tick marks (small lines on left edge) ──────────────────
-        val ticks = listOf(24f, 18f, 12f, 6f, 0f, -6f, -12f, -18f, -24f, -36f, -48f, -60f)
-        for (db in ticks) {
-            val y = dbToY(db, h)
-            val len = if (db == 0f) 6.dp.toPx() else 3.dp.toPx()
-            drawLine(
-                color       = tickColor,
-                start       = Offset(0f, y),
-                end         = Offset(len, y),
-                strokeWidth = 0.5.dp.toPx()
-            )
-        }
-
-        // ── Filled portion below thumb ─────────────────────────────────
-        val thumbY = dbToY(gainDb, h)
+        // ── Fader cap ─────────────────────────────────────────────────────
+        val capLeft = cx - capW / 2f
+        val capTopY = thumbY - capH / 2f
+        // Drop shadow
         drawRoundRect(
-            color      = accentColor.copy(alpha = 0.3f),
-            topLeft    = Offset(cx - trackW / 2f, thumbY),
-            size       = Size(trackW, h - thumbY),
-            cornerRadius = CornerRadius(trackW / 2f)
+            color      = Color.Black.copy(alpha = 0.40f),
+            topLeft    = Offset(capLeft, capTopY + 3.dp.toPx()),
+            size       = Size(capW, capH),
+            cornerRadius = CornerRadius(capR)
         )
-
-        // ── Thumb bar ──────────────────────────────────────────────────
-        val thumbLeft = cx - thumbW / 2f
-        val thumbTop  = thumbY - thumbH / 2f
-
-        // Shadow
+        // Body
         drawRoundRect(
-            color      = Color.Black.copy(alpha = 0.18f),
-            topLeft    = Offset(thumbLeft, thumbTop + 2.dp.toPx()),
-            size       = Size(thumbW, thumbH),
-            cornerRadius = CornerRadius(thumbR)
-        )
-        // Fill
-        drawRoundRect(
-            color      = thumbFill,
-            topLeft    = Offset(thumbLeft, thumbTop),
-            size       = Size(thumbW, thumbH),
-            cornerRadius = CornerRadius(thumbR)
+            brush      = Brush.verticalGradient(listOf(capTop, capBottom)),
+            topLeft    = Offset(capLeft, capTopY),
+            size       = Size(capW, capH),
+            cornerRadius = CornerRadius(capR)
         )
         // Border
         drawRoundRect(
-            color      = thumbBorder,
-            topLeft    = Offset(thumbLeft, thumbTop),
-            size       = Size(thumbW, thumbH),
-            cornerRadius = CornerRadius(thumbR),
+            color      = capBorder,
+            topLeft    = Offset(capLeft, capTopY),
+            size       = Size(capW, capH),
+            cornerRadius = CornerRadius(capR),
             style      = Stroke(width = 1.dp.toPx())
         )
-        // Grip lines on thumb
-        for (i in -1..1) {
-            val ly = thumbTop + thumbH / 2f + i * 2.5.dp.toPx()
-            drawLine(
-                color       = thumbBorder,
-                start       = Offset(cx - 8.dp.toPx(), ly),
-                end         = Offset(cx + 8.dp.toPx(), ly),
-                strokeWidth = 0.5.dp.toPx()
-            )
-        }
+        // Centre indicator line in accent
+        drawLine(
+            color       = accentColor,
+            start       = Offset(capLeft + 4.dp.toPx(), thumbY),
+            end         = Offset(capLeft + capW - 4.dp.toPx(), thumbY),
+            strokeWidth = 2.dp.toPx(),
+            cap         = StrokeCap.Round
+        )
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/VuMeter.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/VuMeter.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -13,21 +15,21 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
 /**
- * FL Studio-style segmented vertical VU meter.
+ * Segmented vertical VU meter.
  *
- * Draws a column of thin horizontal bar segments that light up from
- * bottom to top based on the current level.  Colours transition from
- * green (low) through yellow (mid-high) to red (clip).
- *
- * Background is semi-transparent so it composites cleanly on top of
- * a liquidGlass surface.
+ * A recessed rounded track with thin horizontal segments that light up from
+ * the bottom based on the current level. Only active (and the held peak)
+ * segments are painted, so the inactive track stays clean instead of showing
+ * a column of faint dots. Colours run low → warning → clip near the top.
  *
  * @param levelDb current level in dB (typically -60 … +6).
  * @param muted   when true the bar drops to zero and dims.
@@ -36,11 +38,16 @@ import kotlinx.coroutines.delay
 fun VuMeter(
     levelDb: Float,
     muted: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary
 ) {
-    // Normalise dB → 0..1 fraction  (-60 dB → 0,  0 dB → 1,  +6 dB → clamp 1)
+    // Normalise dB -> 0..1 fraction  (-60 dB -> 0,  0 dB -> 1,  +6 dB -> clamp 1)
     val targetFraction = if (muted) 0f
     else ((levelDb + 60f) / 60f).coerceIn(0f, 1f)
+    val warningColor = lerp(accentColor, Color(0xFFFFD166), 0.55f)
+    val clipColor = lerp(accentColor, MaterialTheme.colorScheme.error, 0.80f)
+    val lowColor = accentColor.copy(alpha = 0.80f)
+    val trackColor = Color.Black.copy(alpha = 0.38f)
 
     val animatedLevel by animateFloatAsState(
         targetValue = targetFraction,
@@ -65,42 +72,38 @@ fun VuMeter(
 
     Canvas(
         modifier = modifier
-            .width(6.dp)
+            .width(7.dp)
             .fillMaxHeight()
+            .clip(RoundedCornerShape(3.5.dp))
     ) {
         val w = size.width
         val h = size.height
-        val segH = 2.5.dp.toPx()
-        val gapH = 0.8.dp.toPx()
+        val segH = 3.dp.toPx()
+        val gapH = 1.2.dp.toPx()
         val stepH = segH + gapH
-        val segCount = (h / stepH).toInt()
+        val segCount = (h / stepH).toInt().coerceAtLeast(1)
 
-        // Semi-transparent background (glass-compatible)
-        drawRect(color = Color.White.copy(alpha = 0.04f))
+        // Recessed track
+        drawRect(color = trackColor)
 
         val activeSegs = (segCount * animatedLevel).toInt()
         val peakSeg = (segCount * peak).toInt().coerceIn(0, segCount - 1)
 
         for (i in 0 until segCount) {
+            val isActive = i < activeSegs
+            val isPeak = i == peakSeg && peak > 0.01f
+            if (!isActive && !isPeak) continue   // keep the inactive track clean
+
             val segY = h - (i + 1) * stepH
             val fraction = i.toFloat() / segCount
-
-            // Colour depends on position in the meter
             val color = when {
-                fraction > 0.88f -> FLColors.meterRed
-                fraction > 0.72f -> FLColors.meterYellow
-                fraction > 0.35f -> FLColors.meterGreen
-                else             -> FLColors.meterGreenDark
+                fraction > 0.88f -> clipColor
+                fraction > 0.72f -> warningColor
+                fraction > 0.40f -> accentColor
+                else             -> lowColor
             }
-
-            val isActive = i < activeSegs
-            val isPeak   = i == peakSeg && peak > 0.01f
-
             drawRect(
-                color = when {
-                    isActive || isPeak -> color
-                    else               -> color.copy(alpha = 0.06f)
-                },
+                color   = if (isPeak && !isActive) color.copy(alpha = 0.85f) else color,
                 topLeft = Offset(0f, segY),
                 size    = Size(w, segH)
             )

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -1,14 +1,14 @@
 package tf.monochrome.android.ui.player
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,20 +41,27 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import tf.monochrome.android.domain.model.NowPlayingViewMode
 import tf.monochrome.android.domain.model.RepeatMode
 import tf.monochrome.android.devedit.DevEditable
@@ -93,10 +100,6 @@ data class MainPlayerUiState(
     val inflatorEnabled: Boolean,
 )
 
-// Vertical drag distance (px) that commits a swipe-up / swipe-down on the
-// audio-tools panel.
-private const val SwipeThresholdPx = 48f
-
 /**
  * Pure, stateless layout for the redesigned main player. The audio-tools grid
  * (output / sound / speed / sleep) is hidden by default and revealed as an
@@ -132,7 +135,62 @@ fun MainPlayerScreen(
     hero: @Composable (Modifier) -> Unit,
 ) {
     val accent = state.albumColors.vibrant
-    var statusExpanded by remember { mutableStateOf(false) }
+
+    // ── Audio-tools sheet drag-to-reveal (swipe up to pull it in) ───────
+    // reveal 0 = hidden, 1 = fully open. A swipe up on the bottom handle (or a
+    // swipe down on the panel) writes `reveal` synchronously (zero-lag), and on
+    // release it settles to 0/1 by fling velocity (else position). `reveal` is
+    // read ONLY inside graphicsLayer{} (draw phase) and derivedStateOf, so the
+    // slide never recomposes the player content.
+    val scope = rememberCoroutineScope()
+    var reveal by remember { mutableFloatStateOf(0f) }
+    var panelH by remember { mutableFloatStateOf(0f) }
+    var dragging by remember { mutableStateOf(false) }
+    var settleJob by remember { mutableStateOf<Job?>(null) }
+    val settleSpec = remember {
+        spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow)
+    }
+    val animateRevealTo: (Float, Float) -> Unit = { target, initialVel ->
+        settleJob?.cancel()
+        settleJob = scope.launch {
+            // Coerce: a fast fling into the critically-damped spring can overshoot
+            // past the endpoint, which would expose a gap above the sheet.
+            animate(reveal, target, initialVel, settleSpec) { value, _ -> reveal = value.coerceIn(0f, 1f) }
+        }
+    }
+    val dragState = rememberDraggableState { delta ->
+        // Up drag (negative delta) opens the sheet; down closes it.
+        if (panelH > 0f) reveal = (reveal - delta / panelH).coerceIn(0f, 1f)
+    }
+    val onDragStarted: suspend CoroutineScope.(Offset) -> Unit = {
+        settleJob?.cancel()
+        dragging = true
+    }
+    val onDragStopped: suspend CoroutineScope.(Float) -> Unit = { velocity ->
+        // reveal rises as the finger moves up, so reveal-velocity = -v / H.
+        val vReveal = if (panelH > 0f) -velocity / panelH else 0f
+        val target = when {
+            vReveal > 0.8f -> 1f          // fling up → open
+            vReveal < -0.8f -> 0f         // fling down → close
+            reveal > 0.5f -> 1f
+            else -> 0f
+        }
+        // Only carry velocity that agrees with the target (no reverse lurch).
+        val settleVel = if ((target == 1f) == (vReveal > 0f)) vReveal else 0f
+        dragging = false
+        animateRevealTo(target, settleVel)
+    }
+    // Boundary-only flags (derivedStateOf recomposes only when the bool flips).
+    val scrimVisible by remember { derivedStateOf { reveal > 0.001f || dragging } }
+    // `|| dragging` keeps the open-handle mounted for the WHOLE gesture: disposing
+    // the node that owns the active drag would cancel it (onDragStopped never
+    // fires), stranding `dragging` true and the scrim alive — locking the player.
+    val handleVisible by remember { derivedStateOf { reveal < 0.999f || dragging } }
+
+    // Back closes the open sheet (it's modal once the scrim is up). Gated on the
+    // boundary-only `scrimVisible` so Back falls through to normal navigation when
+    // closed, and so we never read `reveal` in composition.
+    BackHandler(enabled = scrimVisible) { animateRevealTo(0f, 0f) }
 
     Box(
         modifier = Modifier
@@ -250,58 +308,76 @@ fun MainPlayerScreen(
             Spacer(Modifier.weight(1f))
         }
 
-        // Thin bottom-edge pull strip — the only element that captures the
-        // audio-tools pull gesture. Everything above it stays interactive when
-        // the panel isn't pulled up. Hidden once the panel is open.
-        if (!statusExpanded) {
+        // Thin bottom-edge pull strip — captures the open gesture and fades out
+        // as the sheet rises. Removed once the sheet is fully open.
+        if (handleVisible) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .navigationBarsPadding()
                     .height(44.dp)
-                    .pointerInput(Unit) {
-                        var total = 0f
-                        detectVerticalDragGestures(
-                            onDragStart = { total = 0f },
-                            onVerticalDrag = { _, dy -> total += dy },
-                            onDragEnd = { if (total < -SwipeThresholdPx) statusExpanded = true },
-                        )
-                    },
+                    .graphicsLayer { alpha = 1f - reveal }
+                    .draggable(
+                        state = dragState,
+                        orientation = Orientation.Vertical,
+                        onDragStarted = onDragStarted,
+                        onDragStopped = onDragStopped,
+                    ),
                 contentAlignment = Alignment.Center,
             ) {
-                SwipeUpHandle(onClick = { statusExpanded = true })
+                SwipeUpHandle(onClick = { animateRevealTo(1f, 0f) })
             }
         }
 
-        // Scrim behind the overlay.
-        AnimatedVisibility(
-            visible = statusExpanded,
-            enter = fadeIn(),
-            exit = fadeOut(),
-            modifier = Modifier.fillMaxSize(),
-        ) {
+        // Scrim behind the sheet — opacity tracks the drag (draw-phase read).
+        if (scrimVisible) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .graphicsLayer { alpha = reveal }
                     .background(Color.Black.copy(alpha = 0.45f))
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
-                        onClick = { statusExpanded = false },
+                        onClick = { animateRevealTo(0f, 0f) },
                     ),
             )
         }
 
-        // Audio-tools overlay panel, sliding up over the player with a shadow.
-        AnimatedVisibility(
-            visible = statusExpanded,
-            enter = slideInVertically(animationSpec = tween(280)) { it } + fadeIn(tween(220)),
-            exit = slideOutVertically(animationSpec = tween(240)) { it } + fadeOut(tween(180)),
-            modifier = Modifier.align(Alignment.BottomCenter),
+        // Audio-tools sheet — ALWAYS composed so its height is known for the
+        // drag; translated to follow `reveal`; kept invisible until measured so
+        // it never flashes at its rest position on first layout.
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .onSizeChanged { panelH = it.height.toFloat() }
+                .graphicsLayer {
+                    // Travel an extra shadow-height when closing so the 32dp
+                    // elevation shadow (which draws above the panel's top edge)
+                    // is pushed fully off-screen too — no dark band at rest.
+                    translationY = (1f - reveal) * (panelH + 32.dp.toPx())
+                    alpha = if (panelH > 0f) 1f else 0f
+                }
+                .draggable(
+                    state = dragState,
+                    orientation = Orientation.Vertical,
+                    onDragStarted = onDragStarted,
+                    onDragStopped = onDragStopped,
+                ),
         ) {
+            // Granular, stable params (not the whole `state`) so this always-
+            // composed sheet is SKIPPED on every position tick during playback.
             StatusOverlayPanel(
-                state = state,
+                accent = accent,
+                outputLabel = state.outputLabel,
+                soundLabel = state.soundLabel,
+                speedLabel = state.speedLabel,
+                visualizerActive = state.visualizerActive,
+                waveformActive = state.waveformActive,
+                compressorEnabled = state.compressorEnabled,
+                inflatorEnabled = state.inflatorEnabled,
                 onOutput = onOutput,
                 onSound = onSound,
                 onSpeed = onSpeed,
@@ -310,7 +386,7 @@ fun MainPlayerScreen(
                 onWaveform = onWaveform,
                 onCompressorToggle = onCompressorToggle,
                 onInflatorToggle = onInflatorToggle,
-                onDismiss = { statusExpanded = false },
+                onDismiss = { animateRevealTo(0f, 0f) },
             )
         }
     }
@@ -353,7 +429,14 @@ private fun SwipeUpHandle(onClick: () -> Unit) {
 
 @Composable
 private fun StatusOverlayPanel(
-    state: MainPlayerUiState,
+    accent: Color,
+    outputLabel: String,
+    soundLabel: String,
+    speedLabel: String,
+    visualizerActive: Boolean,
+    waveformActive: Boolean,
+    compressorEnabled: Boolean,
+    inflatorEnabled: Boolean,
     onOutput: () -> Unit,
     onSound: () -> Unit,
     onSpeed: () -> Unit,
@@ -364,21 +447,12 @@ private fun StatusOverlayPanel(
     onInflatorToggle: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val accent = state.albumColors.vibrant
     val shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(elevation = 32.dp, shape = shape, clip = false)
-            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f)
-            .pointerInput(Unit) {
-                var total = 0f
-                detectVerticalDragGestures(
-                    onDragStart = { total = 0f },
-                    onVerticalDrag = { _, dy -> total += dy },
-                    onDragEnd = { if (total > SwipeThresholdPx) onDismiss() },
-                )
-            },
+            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f),
         shape = shape,
         color = PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
     ) {
@@ -391,17 +465,26 @@ private fun StatusOverlayPanel(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            // Tap the handle (or swipe the sheet down / tap the scrim) to close.
             Box(
                 modifier = Modifier
-                    .width(40.dp)
-                    .height(4.dp)
-                    .background(Color.White.copy(alpha = 0.35f), RoundedCornerShape(999.dp)),
-            )
+                    .clip(RoundedCornerShape(999.dp))
+                    .clickable(onClick = onDismiss)
+                    .padding(8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(40.dp)
+                        .height(4.dp)
+                        .background(Color.White.copy(alpha = 0.35f), RoundedCornerShape(999.dp)),
+                )
+            }
             PlayerStatusGrid(
                 accent = accent,
-                outputLabel = state.outputLabel,
-                soundLabel = state.soundLabel,
-                speedLabel = state.speedLabel,
+                outputLabel = outputLabel,
+                soundLabel = soundLabel,
+                speedLabel = speedLabel,
                 mixerLabel = "FX",
                 onOutput = onOutput,
                 onSound = onSound,
@@ -414,13 +497,13 @@ private fun StatusOverlayPanel(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                OverlayAction(Icons.Default.Animation, "Visualizer", accent, state.visualizerActive, onVisualizer)
-                OverlayAction(Icons.Default.GraphicEq, "Waveform", accent, state.waveformActive, onWaveform)
+                OverlayAction(Icons.Default.Animation, "Visualizer", accent, visualizerActive, onVisualizer)
+                OverlayAction(Icons.Default.GraphicEq, "Waveform", accent, waveformActive, onWaveform)
             }
 
             // Effects toggles
-            ToggleRow("Compressor", "Oxford dynamics", state.compressorEnabled, accent, onCompressorToggle)
-            ToggleRow("Inflator", "Oxford loudness", state.inflatorEnabled, accent, onInflatorToggle)
+            ToggleRow("Compressor", "Oxford dynamics", compressorEnabled, accent, onCompressorToggle)
+            ToggleRow("Inflator", "Oxford loudness", inflatorEnabled, accent, onInflatorToggle)
         }
     }
 }


### PR DESCRIPTION
## Summary
Visual + interaction polish for the live mixer and the main player's audio-tools panel.

### Mixer page
- Solid channel strips (meter│fader│meter layout), wider faders, badge ring, value pill — fixes the washed-out/amateur look caused by low-alpha panels over the album glow.
- Channel color modes: curated `BusAccentPalette` **and** a dynamic HSV hue-rotation mode, toggleable (persisted via DataStore).
- Polished top nav: glass `NavIconButton`s, a `DspPowerToggle` pill (replacing the bare Switch), and a palette-mode toggle.
- **Swipe-down filmstrip** revealing the DSP canvas — finger-tracked and velocity-settled, not a page skip.
- Per-row `busLevels` collection so 60 Hz meter updates no longer recompose the whole screen.

### Main player
- Audio-tools panel converted to a **finger-tracking bottom-sheet** (smooth swipe-up, scrim tracks the drag, velocity/halfway settle) — replaces the instant `AnimatedVisibility` pop.
- `BackHandler` closes the open sheet; granular stable params let Compose skip the blur-heavy panel during playback.

### Prefs
- Persist the mixer channel dynamic-color preference.

## Notes
- Scope is UI only; unrelated in-progress USB driver changes are intentionally **not** included.
- Both `compileDebugKotlin` and `assembleDebug` pass; APK deployed and verified on-device.
- Adversarial 3-lens review run on the player diff caught a tap-lockout blocker (handle disposed mid-drag stranding an invisible hit-testing scrim) — fixed before merge.

