### PR TITLE
Speed up library scanning with parallel tag reads and batched DB writes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -290,4 +290,7 @@ dependencies {
     // Bundles app/src/main/baseline-prof.txt into the APK so ProfileInstaller
     // AOT-compiles hot Compose code paths on first launch.
     implementation(libs.profileinstaller)
+
+    // Testing
+    testImplementation(libs.junit)
 }

--- a/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
@@ -62,14 +62,14 @@ interface LocalMediaDao {
     @Query("DELETE FROM local_tracks WHERE filePath = :path")
     suspend fun deleteTrackByPath(path: String)
 
-    @Query("DELETE FROM local_tracks WHERE filePath NOT IN (:existingPaths)")
-    suspend fun deleteTracksNotIn(existingPaths: Set<String>)
+    @Query("DELETE FROM local_tracks WHERE filePath IN (:paths)")
+    suspend fun deleteTracksByPaths(paths: List<String>)
 
     @Query("SELECT filePath FROM local_tracks")
     suspend fun getAllTrackPaths(): List<String>
 
-    @Query("SELECT filePath, lastModified FROM local_tracks")
-    suspend fun getAllTrackPathsWithModified(): List<TrackPathModified>
+    @Query("SELECT filePath, lastModified, artworkCacheKey, hasEmbeddedArt, artist, title FROM local_tracks")
+    suspend fun getAllTrackScanInfo(): List<TrackScanInfo>
 
     // ── Albums ──────────────────────────────────────────────────────
 
@@ -133,6 +133,9 @@ interface LocalMediaDao {
     @Upsert
     suspend fun upsertFolder(folder: LocalFolderEntity)
 
+    @Upsert
+    suspend fun upsertFolders(folders: List<LocalFolderEntity>)
+
     @Query("DELETE FROM local_folders")
     suspend fun clearFolders()
 
@@ -168,7 +171,16 @@ interface LocalMediaDao {
     }
 }
 
-data class TrackPathModified(
+/**
+ * Lightweight projection of the columns the scanner's re-read heuristics
+ * need, so a full scan can prefetch the whole table in one query instead
+ * of issuing a per-file SELECT.
+ */
+data class TrackScanInfo(
     val filePath: String,
-    val lastModified: Long
+    val lastModified: Long,
+    val artworkCacheKey: String?,
+    val hasEmbeddedArt: Boolean,
+    val artist: String?,
+    val title: String?
 )

--- a/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/scanner/MediaScanner.kt
@@ -1,8 +1,13 @@
 package tf.monochrome.android.data.local.scanner
 
 import androidx.room.withTransaction
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import tf.monochrome.android.data.local.db.LocalAlbumEntity
@@ -12,9 +17,11 @@ import tf.monochrome.android.data.local.db.LocalGenreEntity
 import tf.monochrome.android.data.local.db.LocalMediaDao
 import tf.monochrome.android.data.local.db.LocalTrackEntity
 import tf.monochrome.android.data.local.db.ScanStateEntity
+import tf.monochrome.android.data.local.db.TrackScanInfo
 import tf.monochrome.android.data.local.tags.TagReader
 import java.io.File
 import java.text.Normalizer
+import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -42,68 +49,19 @@ class MediaScanner @Inject constructor(
             val mediaStoreFiles = mediaStoreSource.queryAllAudio(minDurationMs, excludedPaths)
             emit(ScanProgress.Started(totalFiles = mediaStoreFiles.size))
 
-            var addedCount = 0
-            // Memoize sidecar cover art lookups by parent directory so we don't
-            // listFiles() once per track. A 500-track album → 1 directory scan.
-            val folderArtCache = HashMap<String, String?>()
+            // One projection query up front instead of a findByPath() SELECT
+            // per file — the re-read decision then runs entirely in memory.
+            val scanInfoByPath = localMediaDao.getAllTrackScanInfo().associateBy { it.filePath }
 
-            mediaStoreFiles.forEachIndexed { index, audioFile ->
-                try {
-                    val existing = localMediaDao.findByPath(audioFile.absolutePath)
-                    // Android reaps the app cache/ directory under storage
-                    // pressure, leaving Room rows pointing at vanished
-                    // artwork files. mtime hasn't changed, so without this
-                    // extra check the refresh button would never repopulate
-                    // them and the user is stuck with empty cards.
-                    val artworkMissing = existing != null &&
-                        existing.artworkCacheKey != null &&
-                        !File(existing.artworkCacheKey).exists()
-                    // Re-tag tracks whose previous scan came up artwork-less.
-                    // The TagReader sidecar matcher has been extended over
-                    // time (per-track stem match was added later), so a
-                    // null cache key on an existing row may just mean "the
-                    // older scan logic missed it" — re-read so freshly-
-                    // installed cover detection logic gets a chance.
-                    val maybeMissedArt = existing != null &&
-                        !existing.hasEmbeddedArt &&
-                        existing.artworkCacheKey == null
-                    // Re-read rows that were indexed before artist-from-title
-                    // recovery existed: no artist tag, but a "Artist - Title"
-                    // shaped title we can now split. Self-heals (artist gets
-                    // populated, so the next scan skips them) and stays cheap
-                    // by only targeting files that can actually benefit.
-                    val derivableArtist = existing != null &&
-                        existing.artist == null &&
-                        existing.title?.contains(" - ") == true
-                    if (existing == null ||
-                        existing.lastModified < audioFile.dateModified ||
-                        artworkMissing ||
-                        maybeMissedArt ||
-                        derivableArtist
-                    ) {
-                        val tags = tagReader.readTags(audioFile.absolutePath, folderArtCache)
-                        val trackEntity = buildTrackEntity(audioFile, tags)
-                        localMediaDao.insertTrack(trackEntity)
-                        addedCount++
-                    }
-                } catch (_: Exception) {
-                    // Skip individual file errors
-                }
-
-                if (index % 50 == 0 || index == mediaStoreFiles.size - 1) {
-                    emit(ScanProgress.Processing(
-                        current = index + 1,
-                        total = mediaStoreFiles.size,
-                        currentFile = audioFile.displayName
-                    ))
-                }
-            }
+            val addedCount = processFiles(
+                files = mediaStoreFiles,
+                shouldRead = { needsReRead(scanInfoByPath[it.absolutePath], it.dateModified) },
+                progressChunkSize = 50
+            )
 
             // Prune deleted files
             emit(ScanProgress.Grouping("Removing deleted tracks..."))
-            val existingPaths = mediaStoreFiles.map { it.absolutePath }.toSet()
-            localMediaDao.deleteTracksNotIn(existingPaths)
-            val removedCount = localMediaDao.getAllTrackPaths().size.let { mediaStoreFiles.size - it }
+            val removedCount = pruneDeleted(mediaStoreFiles.mapTo(HashSet()) { it.absolutePath })
 
             // Rebuild groupings
             emit(ScanProgress.Grouping("Building album & artist library..."))
@@ -147,26 +105,19 @@ class MediaScanner @Inject constructor(
             }
 
             emit(ScanProgress.Started(totalFiles = modifiedFiles.size))
-            var addedCount = 0
-            val folderArtCache = HashMap<String, String?>()
 
-            modifiedFiles.forEachIndexed { index, audioFile ->
-                try {
-                    val tags = tagReader.readTags(audioFile.absolutePath, folderArtCache)
-                    val trackEntity = buildTrackEntity(audioFile, tags)
-                    localMediaDao.insertTrack(trackEntity)
-                    addedCount++
-                } catch (_: Exception) {}
-
-                if (index % 20 == 0 || index == modifiedFiles.size - 1) {
-                    emit(ScanProgress.Processing(index + 1, modifiedFiles.size, audioFile.displayName))
-                }
-            }
+            // MediaStore already filtered to files modified since the last
+            // scan, so every one of them needs a fresh tag read.
+            val addedCount = processFiles(
+                files = modifiedFiles,
+                shouldRead = { true },
+                progressChunkSize = 20
+            )
 
             // Check for deleted files
             val allMediaStorePaths = mediaStoreSource.queryAllAudio(minDurationMs)
-                .map { it.absolutePath }.toSet()
-            localMediaDao.deleteTracksNotIn(allMediaStorePaths)
+                .mapTo(HashSet()) { it.absolutePath }
+            pruneDeleted(allMediaStorePaths)
 
             rebuildGroupings()
             rebuildFolders()
@@ -178,7 +129,101 @@ class MediaScanner @Inject constructor(
         }
     }.flowOn(Dispatchers.IO)
 
-    private suspend fun buildTrackEntity(audioFile: AudioFileInfo, tags: tf.monochrome.android.data.local.tags.AudioTags): LocalTrackEntity {
+    /**
+     * Read tags for [files] with bounded parallelism and batch the resulting
+     * rows into the database, emitting [ScanProgress.Processing] once per
+     * [progressChunkSize] files (matching the old per-file loop's cadence).
+     *
+     * Tag extraction dominates scan time — each file costs a native
+     * MediaMetadataRetriever.setDataSource + metadata + artwork read — and
+     * the files are independent, so fan the reads out across cores. DB
+     * writes stay on the collector coroutine: one insertTracks() per
+     * [INSERT_BATCH_SIZE] rows instead of one transaction per file.
+     *
+     * Written as a FlowCollector extension so it can emit() from inside the
+     * callers' flow {} builders; emissions happen only between chunks, on
+     * the collector's own coroutine, because flow {} emit is not
+     * thread-safe from concurrent children.
+     *
+     * @return the number of tracks actually (re-)read and written.
+     */
+    private suspend fun FlowCollector<ScanProgress>.processFiles(
+        files: List<AudioFileInfo>,
+        shouldRead: (AudioFileInfo) -> Boolean,
+        progressChunkSize: Int
+    ): Int {
+        val parallelism = Runtime.getRuntime().availableProcessors().coerceIn(2, 8)
+        val tagDispatcher = Dispatchers.IO.limitedParallelism(parallelism)
+        // Memoize sidecar cover art lookups by parent directory so we don't
+        // listFiles() once per track. A 500-track album → 1 directory scan.
+        // synchronizedMap (not ConcurrentHashMap) because "no art in this
+        // folder" is cached as a null value; a lost race just re-lists the
+        // same folder once with an identical result.
+        val folderArtCache = Collections.synchronizedMap(HashMap<String, String?>())
+
+        val pending = ArrayList<LocalTrackEntity>(INSERT_BATCH_SIZE)
+        var added = 0
+        var processed = 0
+
+        for (chunk in files.chunked(progressChunkSize)) {
+            val entities = coroutineScope {
+                chunk.map { audioFile ->
+                    async(tagDispatcher) {
+                        try {
+                            if (!shouldRead(audioFile)) return@async null
+                            val tags = tagReader.readTags(audioFile.absolutePath, folderArtCache)
+                            buildTrackEntity(audioFile, tags)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                            // Skip individual file errors
+                            null
+                        }
+                    }
+                }.awaitAll().filterNotNull()
+            }
+
+            pending += entities
+            added += entities.size
+            if (pending.size >= INSERT_BATCH_SIZE) {
+                localMediaDao.insertTracks(pending.toList())
+                pending.clear()
+            }
+
+            processed += chunk.size
+            emit(ScanProgress.Processing(
+                current = processed,
+                total = files.size,
+                currentFile = chunk.last().displayName
+            ))
+        }
+        if (pending.isNotEmpty()) {
+            localMediaDao.insertTracks(pending)
+        }
+        return added
+    }
+
+    /**
+     * Delete DB rows whose files no longer exist in MediaStore. The diff is
+     * computed in memory and deleted with positive IN-lists chunked under
+     * SQLite's 999 bound-variable limit (the old NOT IN variant bound the
+     * entire MediaStore path set into a single statement).
+     *
+     * @return the number of rows removed.
+     */
+    private suspend fun pruneDeleted(mediaStorePaths: Set<String>): Int {
+        val toDelete = localMediaDao.getAllTrackPaths().filterNot { it in mediaStorePaths }
+        if (toDelete.isNotEmpty()) {
+            musicDatabase.withTransaction {
+                toDelete.chunked(DELETE_CHUNK_SIZE).forEach {
+                    localMediaDao.deleteTracksByPaths(it)
+                }
+            }
+        }
+        return toDelete.size
+    }
+
+    private fun buildTrackEntity(audioFile: AudioFileInfo, tags: tf.monochrome.android.data.local.tags.AudioTags): LocalTrackEntity {
         return LocalTrackEntity(
             filePath = audioFile.absolutePath,
             fileSizeBytes = audioFile.sizeBytes,
@@ -333,8 +378,6 @@ class MediaScanner @Inject constructor(
     }
 
     private suspend fun rebuildFolders() {
-        localMediaDao.clearFolders()
-
         val allPaths = localMediaDao.getAllTrackPaths()
         val folderMap = mutableMapOf<String, MutableList<String>>()
 
@@ -343,17 +386,24 @@ class MediaScanner @Inject constructor(
             folderMap.getOrPut(folder) { mutableListOf() }.add(path)
         }
 
-        for ((folderPath, filePaths) in folderMap) {
+        val folders = folderMap.map { (folderPath, filePaths) ->
             val parentPath = folderPath.substringBeforeLast('/').takeIf { it != folderPath }
-            localMediaDao.upsertFolder(
-                LocalFolderEntity(
-                    path = folderPath,
-                    parentPath = parentPath,
-                    displayName = folderPath.substringAfterLast('/'),
-                    trackCount = filePaths.size,
-                    totalDuration = 0 // Could compute from track durations
-                )
+            LocalFolderEntity(
+                path = folderPath,
+                parentPath = parentPath,
+                displayName = folderPath.substringAfterLast('/'),
+                trackCount = filePaths.size,
+                totalDuration = 0 // Could compute from track durations
             )
+        }
+
+        // Clear + repopulate atomically so folder-tab observers never see an
+        // empty list mid-scan, and the whole rebuild is one Room flush.
+        musicDatabase.withTransaction {
+            localMediaDao.clearFolders()
+            if (folders.isNotEmpty()) {
+                localMediaDao.upsertFolders(folders)
+            }
         }
     }
 
@@ -392,6 +442,48 @@ class MediaScanner @Inject constructor(
     }
 
     companion object {
+        /** Rows per insertTracks() call — one Room transaction per batch. */
+        private const val INSERT_BATCH_SIZE = 500
+
+        /** Paths per DELETE ... IN (...) — under SQLite's 999-variable limit. */
+        private const val DELETE_CHUNK_SIZE = 500
+
+        /**
+         * Decide whether a MediaStore file needs its tags (re-)read or the
+         * existing DB row can be kept as-is. Pure function so it's unit
+         * testable; [artworkFileExists] is injectable for the same reason.
+         */
+        fun needsReRead(
+            existing: TrackScanInfo?,
+            mediaStoreDateModified: Long,
+            artworkFileExists: (String) -> Boolean = { File(it).exists() }
+        ): Boolean {
+            if (existing == null) return true
+            if (existing.lastModified < mediaStoreDateModified) return true
+            // Android reaps the app cache/ directory under storage
+            // pressure, leaving Room rows pointing at vanished
+            // artwork files. mtime hasn't changed, so without this
+            // extra check the refresh button would never repopulate
+            // them and the user is stuck with empty cards.
+            if (existing.artworkCacheKey != null &&
+                !artworkFileExists(existing.artworkCacheKey)
+            ) return true
+            // Re-tag tracks whose previous scan came up artwork-less.
+            // The TagReader sidecar matcher has been extended over
+            // time (per-track stem match was added later), so a
+            // null cache key on an existing row may just mean "the
+            // older scan logic missed it" — re-read so freshly-
+            // installed cover detection logic gets a chance.
+            if (!existing.hasEmbeddedArt && existing.artworkCacheKey == null) return true
+            // Re-read rows that were indexed before artist-from-title
+            // recovery existed: no artist tag, but a "Artist - Title"
+            // shaped title we can now split. Self-heals (artist gets
+            // populated, so the next scan skips them) and stays cheap
+            // by only targeting files that can actually benefit.
+            if (existing.artist == null && existing.title?.contains(" - ") == true) return true
+            return false
+        }
+
         fun normalizeText(text: String): String {
             return Normalizer.normalize(text.trim().lowercase(), Normalizer.Form.NFC)
         }

--- a/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
@@ -288,7 +288,10 @@ class TagReader @Inject constructor(
      * folder has no recognisable image.
      *
      * Pass a [cache] keyed by parent directory to avoid re-listing the same folder
-     * for every track in an album.
+     * for every track in an album. The scanner shares one (synchronized) cache
+     * across parallel tag-read workers; the containsKey/put sequence here is not
+     * atomic across calls, but a lost race just re-lists the same folder once
+     * with an identical result.
      */
     private fun findFolderCoverArt(
         filePath: String,

--- a/app/src/test/java/tf/monochrome/android/data/local/scanner/ReReadHeuristicsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/local/scanner/ReReadHeuristicsTest.kt
@@ -1,0 +1,65 @@
+package tf.monochrome.android.data.local.scanner
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tf.monochrome.android.data.local.db.TrackScanInfo
+
+class ReReadHeuristicsTest {
+
+    private fun scanInfo(
+        lastModified: Long = 1_000L,
+        artworkCacheKey: String? = "/cache/artwork/abc.jpg",
+        hasEmbeddedArt: Boolean = true,
+        artist: String? = "Some Artist",
+        title: String? = "Some Title"
+    ) = TrackScanInfo(
+        filePath = "/storage/emulated/0/Music/song.flac",
+        lastModified = lastModified,
+        artworkCacheKey = artworkCacheKey,
+        hasEmbeddedArt = hasEmbeddedArt,
+        artist = artist,
+        title = title
+    )
+
+    private val artExists: (String) -> Boolean = { true }
+    private val artMissing: (String) -> Boolean = { false }
+
+    @Test
+    fun `unknown file needs read`() {
+        assertTrue(MediaScanner.needsReRead(null, 1_000L, artExists))
+    }
+
+    @Test
+    fun `stale mtime needs read`() {
+        assertTrue(MediaScanner.needsReRead(scanInfo(lastModified = 500L), 1_000L, artExists))
+    }
+
+    @Test
+    fun `fresh row with intact artwork is skipped`() {
+        assertFalse(MediaScanner.needsReRead(scanInfo(lastModified = 1_000L), 1_000L, artExists))
+    }
+
+    @Test
+    fun `reaped artwork cache file forces re-read`() {
+        assertTrue(MediaScanner.needsReRead(scanInfo(), 1_000L, artMissing))
+    }
+
+    @Test
+    fun `artwork-less row is re-read so newer sidecar detection gets a chance`() {
+        val info = scanInfo(hasEmbeddedArt = false, artworkCacheKey = null)
+        assertTrue(MediaScanner.needsReRead(info, 1_000L, artExists))
+    }
+
+    @Test
+    fun `missing artist with derivable title forces re-read`() {
+        val info = scanInfo(artist = null, title = "Artist - Title")
+        assertTrue(MediaScanner.needsReRead(info, 1_000L, artExists))
+    }
+
+    @Test
+    fun `missing artist with plain title is skipped`() {
+        val info = scanInfo(artist = null, title = "Just A Title")
+        assertFalse(MediaScanner.needsReRead(info, 1_000L, artExists))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ accompanist = "0.36.0"
 haze = "1.7.1"
 nextlibMedia3ext = "0.8.4"
 profileinstaller = "1.4.1"
+junit = "4.13.2"
 
 [libraries]
 # Compose
@@ -136,6 +137,9 @@ haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", versi
 # NowPlayingScreen / MixerScreen / FLChannelStrip the first time the user
 # opens those screens.
 profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+
+# Testing
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
The scan pipeline processed files strictly sequentially on one IO
thread with two DB round-trips per file: a findByPath() SELECT to
decide whether re-tagging was needed, and an insertTrack() that
committed its own transaction. Tag extraction itself (native
MediaMetadataRetriever work, the dominant cost) never used more than
one core.

- Prefetch the re-read decision inputs for the whole library in one
  projection query (TrackScanInfo) and evaluate the heuristics in
  memory via a new pure needsReRead() function.
- Fan tag reads out across cores with a bounded
  Dispatchers.IO.limitedParallelism dispatcher (2-8 workers), shared
  by fullScan and incrementalScan through a common processFiles()
  helper. Progress emission stays on the collector coroutine with the
  same 50/20-file cadence as before.
- Batch inserts through the previously unused insertTracks() DAO
  method, 500 rows per transaction instead of one transaction per
  file.
- Replace the NOT IN (...) prune, which bound the entire MediaStore
  path set into a single statement (over SQLite's 999-variable limit
  on large libraries), with an in-memory diff deleted in chunked
  positive IN-lists inside one transaction.
- Make rebuildFolders() atomic: build entities in memory, then clear +
  bulk-upsert inside a single transaction so folder observers never
  see an empty list mid-scan.
- Share the sidecar folder-art cache across workers via a
  synchronized map (values are nullable, so ConcurrentHashMap doesn't
  fit); races only re-list a folder once with an identical result.

Adds the project's first unit-test setup (junit) with coverage for the
extracted needsReRead() heuristics.
