### PR TITLE
Add Spotify playlist import via OAuth PKCE connection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,15 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        // Spotify PKCE OAuth — client ID is public by design (no secret needed for
+        // the authorization-code-with-PKCE flow). Overridable via local.properties.
+        buildConfigField(
+            "String",
+            "SPOTIFY_CLIENT_ID",
+            "\"${localProperties.getProperty("spotify.clientId") ?: "c9e571c8b81948feb6573014a3efdd2c"}\"",
+        )
+        buildConfigField("String", "SPOTIFY_REDIRECT_URI", "\"tryptify://spotify-callback\"")
+
         externalNativeBuild {
             cmake {
                 cppFlags += "-std=c++17"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,16 @@
                     android:scheme="tf.monotrypt.android"
                     android:host="login-callback" />
             </intent-filter>
+
+            <!-- Spotify OAuth (PKCE) callback deep-link -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="tryptify"
+                    android:host="spotify-callback" />
+            </intent-filter>
         </activity>
 
         <!-- Media Playback Service -->

--- a/app/src/main/java/tf/monochrome/android/data/api/SpotifyApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SpotifyApiClient.kt
@@ -16,12 +16,8 @@ import javax.inject.Singleton
 class SpotifyNotConnectedException :
     Exception("Spotify is not connected. Connect your Spotify account in Settings first.")
 
-/** Thrown on 403 — the app is in Development mode and this account isn't allowlisted. */
-class SpotifyDevModeException :
-    Exception(
-        "Spotify denied access (403). This Spotify app is in Development mode — the Spotify " +
-            "account must be added to the allowlist in the Spotify Developer Dashboard (User Management).",
-    )
+/** Thrown on 403 — restricted content or a non-allowlisted Development-mode account. */
+class SpotifyForbiddenException(message: String) : Exception(message)
 
 class SpotifyNotFoundException :
     Exception("Playlist not found — it may be private, deleted, or the URL is wrong.")
@@ -47,15 +43,22 @@ class SpotifyApiClient @Inject constructor(
         json.decodeFromString<SpotifyPlaylistMeta>(resp.bodyAsText())
     }
 
-    /** All tracks of a playlist, following pagination past the 100-item page limit. */
+    /**
+     * All tracks of a playlist, following pagination past the 100-item page
+     * limit. Uses the /items endpoint introduced by the Feb 2026 Web API
+     * migration (the old /tracks endpoint now returns 403 for every
+     * Development-mode caller). Only works for playlists the user owns or
+     * collaborates on — Spotify no longer serves other playlists' contents
+     * to dev-mode apps.
+     */
     suspend fun getPlaylistTracks(playlistId: String): Result<List<CsvTrack>> = runCatching {
         paginate { offset ->
-            val fields = "items(track(name,duration_ms,is_local,type,artists(name),album(name))),next,total"
+            val fields = "items(item(name,duration_ms,is_local,type,artists(name),album(name))),next,total"
             val resp = authedGet(
-                "$API_BASE/playlists/$playlistId/tracks?limit=100&offset=$offset&fields=$fields",
+                "$API_BASE/playlists/$playlistId/items?limit=100&offset=$offset&fields=$fields",
             )
             json.decodeFromString<SpotifyPagingObject<SpotifyPlaylistTrackItem>>(resp.bodyAsText())
-        }.mapNotNull { it.track.toCsvTrackOrNull() }
+        }.mapNotNull { it.trackOrItem.toCsvTrackOrNull() }
     }
 
     /** The connected user's playlists (owned + followed). */
@@ -110,7 +113,7 @@ class SpotifyApiClient @Inject constructor(
                     }
                     forcedRefresh = true
                 }
-                403 -> throw SpotifyDevModeException()
+                403 -> throw SpotifyForbiddenException(buildForbiddenMessage(url, response.bodyAsText()))
                 404 -> throw SpotifyNotFoundException()
                 429 -> {
                     if (attempt >= MAX_RETRIES) {
@@ -127,6 +130,26 @@ class SpotifyApiClient @Inject constructor(
                     throw Exception("Spotify API error ${response.status.value}${detail?.let { ": $it" } ?: ""}")
                 }
             }
+        }
+    }
+
+    private fun buildForbiddenMessage(url: String, body: String): String {
+        val detail = runCatching {
+            json.decodeFromString<SpotifyErrorBody>(body).error?.message
+        }.getOrNull()?.takeIf { it.isNotBlank() }
+        val hint = if (url.contains("/playlists/")) {
+            "Spotify only serves playlist contents for playlists you own or collaborate on " +
+                "(Feb 2026 API restriction for Development-mode apps). Also check that your " +
+                "Spotify account is allowlisted in the Developer Dashboard (User Management)."
+        } else {
+            "Check that your Spotify account is allowlisted in the Spotify Developer " +
+                "Dashboard (User Management) — the app is in Development mode."
+        }
+        return buildString {
+            append("Spotify denied access (403")
+            detail?.let { append(": ").append(it) }
+            append("). ")
+            append(hint)
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/api/SpotifyApiClient.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SpotifyApiClient.kt
@@ -1,0 +1,150 @@
+package tf.monochrome.android.data.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import tf.monochrome.android.data.auth.SpotifyAuthManager
+import tf.monochrome.android.data.import_.CsvTrack
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Thrown when no Spotify account is connected (or the session expired). */
+class SpotifyNotConnectedException :
+    Exception("Spotify is not connected. Connect your Spotify account in Settings first.")
+
+/** Thrown on 403 — the app is in Development mode and this account isn't allowlisted. */
+class SpotifyDevModeException :
+    Exception(
+        "Spotify denied access (403). This Spotify app is in Development mode — the Spotify " +
+            "account must be added to the allowlist in the Spotify Developer Dashboard (User Management).",
+    )
+
+class SpotifyNotFoundException :
+    Exception("Playlist not found — it may be private, deleted, or the URL is wrong.")
+
+/**
+ * Authenticated Spotify Web API client for playlist import. All requests
+ * carry the PKCE user token from [SpotifyAuthManager]; 401s trigger one
+ * forced refresh, 429s honor Retry-After.
+ */
+@Singleton
+class SpotifyApiClient @Inject constructor(
+    private val httpClient: HttpClient,
+    private val json: Json,
+    private val authManager: SpotifyAuthManager,
+) {
+
+    suspend fun getCurrentUser(): Result<SpotifyUserProfile> = runCatching {
+        json.decodeFromString<SpotifyUserProfile>(authedGet("$API_BASE/me").bodyAsText())
+    }
+
+    suspend fun getPlaylistMeta(playlistId: String): Result<SpotifyPlaylistMeta> = runCatching {
+        val resp = authedGet("$API_BASE/playlists/$playlistId?fields=id,name,description")
+        json.decodeFromString<SpotifyPlaylistMeta>(resp.bodyAsText())
+    }
+
+    /** All tracks of a playlist, following pagination past the 100-item page limit. */
+    suspend fun getPlaylistTracks(playlistId: String): Result<List<CsvTrack>> = runCatching {
+        paginate { offset ->
+            val fields = "items(track(name,duration_ms,is_local,type,artists(name),album(name))),next,total"
+            val resp = authedGet(
+                "$API_BASE/playlists/$playlistId/tracks?limit=100&offset=$offset&fields=$fields",
+            )
+            json.decodeFromString<SpotifyPagingObject<SpotifyPlaylistTrackItem>>(resp.bodyAsText())
+        }.mapNotNull { it.track.toCsvTrackOrNull() }
+    }
+
+    /** The connected user's playlists (owned + followed). */
+    suspend fun getMyPlaylists(): Result<List<SpotifySimplePlaylist>> = runCatching {
+        paginate { offset ->
+            val resp = authedGet("$API_BASE/me/playlists?limit=50&offset=$offset")
+            json.decodeFromString<SpotifyPagingObject<SpotifySimplePlaylist>>(resp.bodyAsText())
+        }
+    }
+
+    /** The connected user's Liked Songs. */
+    suspend fun getLikedSongs(): Result<List<CsvTrack>> = runCatching {
+        paginate { offset ->
+            val resp = authedGet("$API_BASE/me/tracks?limit=50&offset=$offset")
+            json.decodeFromString<SpotifyPagingObject<SpotifySavedTrackItem>>(resp.bodyAsText())
+        }.mapNotNull { it.track.toCsvTrackOrNull() }
+    }
+
+    /**
+     * Follows Spotify's paging objects: fetch page at offset 0, then keep
+     * bumping the offset by the page's item count while `next` is set.
+     */
+    private suspend fun <T> paginate(fetchPage: suspend (offset: Int) -> SpotifyPagingObject<T>): List<T> {
+        val all = mutableListOf<T>()
+        var offset = 0
+        while (true) {
+            val page = fetchPage(offset)
+            all += page.items
+            if (page.next == null || page.items.isEmpty()) break
+            offset += page.items.size
+            if (offset >= MAX_TRACKS) break // safety valve against runaway pagination
+        }
+        return all
+    }
+
+    private suspend fun authedGet(url: String): HttpResponse {
+        var attempt = 0
+        var forcedRefresh = false
+        while (true) {
+            val token = authManager.getValidAccessToken(forceRefresh = forcedRefresh)
+                ?: throw SpotifyNotConnectedException()
+            val response = httpClient.get(url) {
+                header("Authorization", "Bearer $token")
+            }
+            when (response.status.value) {
+                in 200..299 -> return response
+                401 -> {
+                    // Token rejected despite local expiry check — force one refresh.
+                    if (forcedRefresh) {
+                        authManager.disconnect()
+                        throw SpotifyNotConnectedException()
+                    }
+                    forcedRefresh = true
+                }
+                403 -> throw SpotifyDevModeException()
+                404 -> throw SpotifyNotFoundException()
+                429 -> {
+                    if (attempt >= MAX_RETRIES) {
+                        throw Exception("Spotify rate limit exceeded. Please try again in a minute.")
+                    }
+                    val retryAfterSec = response.headers["Retry-After"]?.toLongOrNull() ?: 2L
+                    delay(retryAfterSec.coerceAtMost(MAX_RETRY_AFTER_SEC) * 1000)
+                    attempt++
+                }
+                else -> {
+                    val detail = runCatching {
+                        json.decodeFromString<SpotifyErrorBody>(response.bodyAsText()).error?.message
+                    }.getOrNull()
+                    throw Exception("Spotify API error ${response.status.value}${detail?.let { ": $it" } ?: ""}")
+                }
+            }
+        }
+    }
+
+    private fun SpotifyTrack?.toCsvTrackOrNull(): CsvTrack? {
+        if (this == null || isLocal || type != "track" || name.isBlank()) return null
+        return CsvTrack(
+            title = name,
+            // Matches Exportify's "Artist Name(s)" semantics used by the CSV pipeline.
+            artist = artists.joinToString(", ") { it.name },
+            album = album?.name.orEmpty(),
+            durationMs = durationMs,
+        )
+    }
+
+    companion object {
+        private const val API_BASE = "https://api.spotify.com/v1"
+        private const val MAX_RETRIES = 3
+        private const val MAX_RETRY_AFTER_SEC = 30L
+        private const val MAX_TRACKS = 10_000
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/api/SpotifyModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SpotifyModels.kt
@@ -1,0 +1,110 @@
+package tf.monochrome.android.data.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Minimal Spotify Web API / Accounts service DTOs — only the fields the
+ * playlist importer consumes. The shared Json is configured with
+ * ignoreUnknownKeys, so everything else in Spotify's responses is dropped.
+ */
+
+@Serializable
+data class SpotifyTokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String = "Bearer",
+    @SerialName("expires_in") val expiresIn: Int = 3600,
+    // Absent on refresh responses when Spotify chooses not to rotate —
+    // callers must keep the previous refresh token in that case.
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    val scope: String? = null,
+)
+
+@Serializable
+data class SpotifyErrorBody(
+    val error: SpotifyErrorDetail? = null,
+)
+
+@Serializable
+data class SpotifyErrorDetail(
+    val status: Int = 0,
+    val message: String? = null,
+)
+
+@Serializable
+data class SpotifyAuthError(
+    val error: String? = null,
+    @SerialName("error_description") val errorDescription: String? = null,
+)
+
+@Serializable
+data class SpotifyPagingObject<T>(
+    val items: List<T> = emptyList(),
+    val next: String? = null,
+    val total: Int = 0,
+    val offset: Int = 0,
+    val limit: Int = 0,
+)
+
+@Serializable
+data class SpotifyUserProfile(
+    val id: String,
+    @SerialName("display_name") val displayName: String? = null,
+)
+
+@Serializable
+data class SpotifyArtist(val name: String = "")
+
+@Serializable
+data class SpotifyAlbum(val name: String = "")
+
+@Serializable
+data class SpotifyTrack(
+    val name: String = "",
+    @SerialName("duration_ms") val durationMs: Long = 0,
+    val artists: List<SpotifyArtist> = emptyList(),
+    val album: SpotifyAlbum? = null,
+    @SerialName("is_local") val isLocal: Boolean = false,
+    // "track" or "episode" — playlists can contain podcast episodes.
+    val type: String = "track",
+)
+
+/** Item of /v1/playlists/{id}/tracks — track is null for removed/unavailable entries. */
+@Serializable
+data class SpotifyPlaylistTrackItem(
+    val track: SpotifyTrack? = null,
+)
+
+/** Item of /v1/me/tracks (Liked Songs). */
+@Serializable
+data class SpotifySavedTrackItem(
+    val track: SpotifyTrack? = null,
+)
+
+/** GET /v1/playlists/{id}?fields=id,name,description */
+@Serializable
+data class SpotifyPlaylistMeta(
+    val id: String = "",
+    val name: String = "",
+    val description: String? = null,
+)
+
+@Serializable
+data class SpotifyPlaylistOwner(
+    @SerialName("display_name") val displayName: String? = null,
+)
+
+@Serializable
+data class SpotifyPlaylistTracksRef(
+    val total: Int = 0,
+)
+
+/** Item of /v1/me/playlists. */
+@Serializable
+data class SpotifySimplePlaylist(
+    val id: String,
+    val name: String = "",
+    val description: String? = null,
+    val owner: SpotifyPlaylistOwner? = null,
+    val tracks: SpotifyPlaylistTracksRef? = null,
+)

--- a/app/src/main/java/tf/monochrome/android/data/api/SpotifyModels.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SpotifyModels.kt
@@ -69,11 +69,18 @@ data class SpotifyTrack(
     val type: String = "track",
 )
 
-/** Item of /v1/playlists/{id}/tracks — track is null for removed/unavailable entries. */
+/**
+ * Item of /v1/playlists/{id}/items. The Feb 2026 Web API migration renamed
+ * the wrapper field `track` → `item`; both are kept so old-shaped responses
+ * still parse. Null for removed/unavailable entries.
+ */
 @Serializable
 data class SpotifyPlaylistTrackItem(
+    val item: SpotifyTrack? = null,
     val track: SpotifyTrack? = null,
-)
+) {
+    val trackOrItem: SpotifyTrack? get() = item ?: track
+}
 
 /** Item of /v1/me/tracks (Liked Songs). */
 @Serializable

--- a/app/src/main/java/tf/monochrome/android/data/auth/SpotifyAuthManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/auth/SpotifyAuthManager.kt
@@ -1,0 +1,266 @@
+package tf.monochrome.android.data.auth
+
+import android.content.Context
+import android.net.Uri
+import android.util.Base64
+import android.util.Log
+import androidx.browser.customtabs.CustomTabsIntent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.parameters
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import tf.monochrome.android.BuildConfig
+import tf.monochrome.android.data.api.SpotifyAuthError
+import tf.monochrome.android.data.api.SpotifyTokenResponse
+import tf.monochrome.android.data.preferences.PreferencesManager
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Spotify OAuth via Authorization Code + PKCE — the only grant that works
+ * from a mobile app without a client secret or backend. Mirrors the
+ * Custom-Tab + deep-link pattern used by [SupabaseAuthManager]:
+ *
+ *  1. [connect] opens accounts.spotify.com/authorize in a Custom Tab.
+ *  2. Spotify redirects to tryptify://spotify-callback, which MainActivity
+ *     routes to [handleCallback].
+ *  3. The code is exchanged for access + refresh tokens, persisted in
+ *     DataStore via [PreferencesManager].
+ *  4. [getValidAccessToken] transparently refreshes on expiry. Spotify
+ *     rotates refresh tokens for PKCE clients, so a rotated token in the
+ *     refresh response must be persisted or the next refresh breaks.
+ */
+@Singleton
+class SpotifyAuthManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val httpClient: HttpClient,
+    private val json: Json,
+    private val preferences: PreferencesManager,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val refreshMutex = Mutex()
+
+    // PKCE verifier + state survive process death while the Custom Tab is
+    // open (same rationale as SharedPrefsCodeVerifierCache for Supabase).
+    private val pkcePrefs = context.getSharedPreferences("spotify_pkce", Context.MODE_PRIVATE)
+
+    val isConnected: StateFlow<Boolean> = preferences.spotifyRefreshToken
+        .map { !it.isNullOrBlank() }
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
+    val connectedUserName: StateFlow<String?> = preferences.spotifyUserName
+        .stateIn(scope, SharingStarted.Eagerly, null)
+
+    private val _isConnecting = MutableStateFlow(false)
+    val isConnecting: StateFlow<Boolean> = _isConnecting.asStateFlow()
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    /** Launch the Spotify consent page in a Custom Tab. */
+    fun connect(activityContext: Context) {
+        _errorMessage.value = null
+        _isConnecting.value = true
+
+        val verifier = randomUrlSafe(64)
+        val state = randomUrlSafe(16)
+        pkcePrefs.edit()
+            .putString(KEY_VERIFIER, verifier)
+            .putString(KEY_STATE, state)
+            .apply()
+
+        val challenge = Base64.encodeToString(
+            MessageDigest.getInstance("SHA-256")
+                .digest(verifier.toByteArray(StandardCharsets.US_ASCII)),
+            BASE64_URL_FLAGS,
+        )
+
+        val url = Uri.parse(AUTHORIZE_URL).buildUpon()
+            .appendQueryParameter("client_id", BuildConfig.SPOTIFY_CLIENT_ID)
+            .appendQueryParameter("response_type", "code")
+            .appendQueryParameter("redirect_uri", BuildConfig.SPOTIFY_REDIRECT_URI)
+            .appendQueryParameter("code_challenge_method", "S256")
+            .appendQueryParameter("code_challenge", challenge)
+            .appendQueryParameter("state", state)
+            .appendQueryParameter("scope", SCOPES)
+            .build()
+
+        try {
+            CustomTabsIntent.Builder().build().launchUrl(activityContext, url)
+        } catch (e: Exception) {
+            _isConnecting.value = false
+            _errorMessage.value = "Could not open browser: ${e.message}"
+        }
+    }
+
+    /** Handle tryptify://spotify-callback?code=...&state=... from MainActivity.onNewIntent. */
+    suspend fun handleCallback(uri: Uri) {
+        try {
+            val expectedState = pkcePrefs.getString(KEY_STATE, null)
+            val verifier = pkcePrefs.getString(KEY_VERIFIER, null)
+
+            uri.getQueryParameter("error")?.let { error ->
+                _errorMessage.value = if (error == "access_denied") {
+                    "Spotify authorization was cancelled."
+                } else {
+                    "Spotify authorization failed: $error"
+                }
+                return
+            }
+
+            val returnedState = uri.getQueryParameter("state")
+            if (expectedState.isNullOrBlank() || returnedState != expectedState) {
+                _errorMessage.value = "Spotify authorization failed: state mismatch. Please try again."
+                return
+            }
+            val code = uri.getQueryParameter("code")
+            if (code.isNullOrBlank() || verifier.isNullOrBlank()) {
+                _errorMessage.value = "Spotify authorization failed: missing code. Please try again."
+                return
+            }
+
+            val response = httpClient.submitForm(
+                url = TOKEN_URL,
+                formParameters = parameters {
+                    append("grant_type", "authorization_code")
+                    append("code", code)
+                    append("redirect_uri", BuildConfig.SPOTIFY_REDIRECT_URI)
+                    append("client_id", BuildConfig.SPOTIFY_CLIENT_ID)
+                    append("code_verifier", verifier)
+                },
+            )
+            val body = response.bodyAsText()
+            if (response.status.value !in 200..299) {
+                _errorMessage.value = mapTokenError(response.status.value, body)
+                return
+            }
+
+            val tokens = json.decodeFromString<SpotifyTokenResponse>(body)
+            val refresh = tokens.refreshToken
+            if (refresh.isNullOrBlank()) {
+                _errorMessage.value = "Spotify did not return a refresh token. Please try again."
+                return
+            }
+            preferences.setSpotifyTokens(
+                accessToken = tokens.accessToken,
+                refreshToken = refresh,
+                expiresAtMillis = System.currentTimeMillis() + tokens.expiresIn * 1000L,
+            )
+            pkcePrefs.edit().remove(KEY_VERIFIER).remove(KEY_STATE).apply()
+            _errorMessage.value = null
+            Log.d(TAG, "Spotify connected; token expires in ${tokens.expiresIn}s")
+        } catch (e: Exception) {
+            Log.e(TAG, "Spotify callback failed", e)
+            _errorMessage.value = "Spotify connection failed: ${e.message}"
+        } finally {
+            _isConnecting.value = false
+        }
+    }
+
+    /**
+     * Returns a non-expired access token, refreshing if needed; null when
+     * not connected or the refresh token was revoked (in which case local
+     * state is cleared so the UI falls back to "Connect").
+     */
+    suspend fun getValidAccessToken(forceRefresh: Boolean = false): String? = refreshMutex.withLock {
+        val refreshToken = preferences.spotifyRefreshToken.first() ?: return null
+        val expiresAt = preferences.spotifyTokenExpiresAt.first()
+        val access = preferences.spotifyAccessToken.first()
+
+        if (!forceRefresh && !access.isNullOrBlank() && expiresAt - EXPIRY_MARGIN_MS > System.currentTimeMillis()) {
+            return access
+        }
+
+        return try {
+            val response = httpClient.submitForm(
+                url = TOKEN_URL,
+                formParameters = parameters {
+                    append("grant_type", "refresh_token")
+                    append("refresh_token", refreshToken)
+                    append("client_id", BuildConfig.SPOTIFY_CLIENT_ID)
+                },
+            )
+            val body = response.bodyAsText()
+            if (response.status.value !in 200..299) {
+                Log.w(TAG, "Spotify token refresh failed (${response.status.value}): $body")
+                if (response.status.value == 400) {
+                    // invalid_grant — refresh token revoked/expired; force reconnect.
+                    disconnect()
+                }
+                return null
+            }
+            val tokens = json.decodeFromString<SpotifyTokenResponse>(body)
+            preferences.setSpotifyTokens(
+                accessToken = tokens.accessToken,
+                // Spotify rotates PKCE refresh tokens — persist the new one when present.
+                refreshToken = tokens.refreshToken ?: refreshToken,
+                expiresAtMillis = System.currentTimeMillis() + tokens.expiresIn * 1000L,
+            )
+            tokens.accessToken
+        } catch (e: Exception) {
+            Log.e(TAG, "Spotify token refresh error", e)
+            null
+        }
+    }
+
+    suspend fun setConnectedUserName(name: String?) {
+        preferences.setSpotifyUserName(name)
+    }
+
+    /** Spotify has no token-revocation endpoint for PKCE; clearing local tokens is the disconnect. */
+    suspend fun disconnect() {
+        preferences.clearSpotifyTokens()
+        _errorMessage.value = null
+    }
+
+    fun clearError() {
+        _errorMessage.value = null
+    }
+
+    private fun mapTokenError(status: Int, body: String): String {
+        val parsed = runCatching { json.decodeFromString<SpotifyAuthError>(body) }.getOrNull()
+        return when {
+            status == 403 || body.contains("not be registered", ignoreCase = true) ->
+                "This Spotify app is in Development mode — your Spotify account must be " +
+                    "added to the allowlist in the Spotify Developer Dashboard (User Management)."
+            parsed?.error == "invalid_grant" ->
+                "Authorization expired. Please try connecting again."
+            else ->
+                "Spotify token exchange failed: ${parsed?.errorDescription ?: parsed?.error ?: "HTTP $status"}"
+        }
+    }
+
+    private fun randomUrlSafe(bytes: Int): String {
+        val buf = ByteArray(bytes)
+        SecureRandom().nextBytes(buf)
+        return Base64.encodeToString(buf, BASE64_URL_FLAGS)
+    }
+
+    companion object {
+        private const val TAG = "SpotifyAuth"
+        private const val AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
+        private const val TOKEN_URL = "https://accounts.spotify.com/api/token"
+        private const val SCOPES = "playlist-read-private playlist-read-collaborative user-library-read"
+        private const val EXPIRY_MARGIN_MS = 60_000L
+        private const val BASE64_URL_FLAGS = Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING
+        private const val KEY_VERIFIER = "code_verifier"
+        private const val KEY_STATE = "state"
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
@@ -1,0 +1,108 @@
+package tf.monochrome.android.data.import_
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tf.monochrome.android.data.repository.LibraryRepository
+import tf.monochrome.android.data.repository.MusicRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed interface ImportProgress {
+    data object Idle : ImportProgress
+
+    /** Fetching track metadata from the source (Spotify API, CSV parse, ...). */
+    data class Fetching(val source: String) : ImportProgress
+
+    /** Matching fetched tracks against the streaming catalog. */
+    data class Matching(val current: Int, val total: Int, val matched: Int) : ImportProgress
+
+    data class Done(
+        val playlistId: String,
+        val playlistName: String,
+        val matched: Int,
+        val total: Int,
+        /** "Title — Artist" strings for tracks with no catalog match. */
+        val unmatched: List<String>,
+    ) : ImportProgress
+
+    data class Failed(val message: String) : ImportProgress
+}
+
+/**
+ * Shared create-playlist → search-match → add-track pipeline used by both
+ * the CSV (Exportify) and Spotify importers. Extracted from
+ * LibraryViewModel.importCsvPlaylist and instrumented with an observable
+ * [progress] StateFlow so any screen can render live matched/unmatched counts.
+ */
+@Singleton
+class PlaylistImportService @Inject constructor(
+    private val libraryRepository: LibraryRepository,
+    private val musicRepository: MusicRepository,
+) {
+    private val _progress = MutableStateFlow<ImportProgress>(ImportProgress.Idle)
+    val progress: StateFlow<ImportProgress> = _progress.asStateFlow()
+
+    fun reportFetching(source: String) {
+        _progress.value = ImportProgress.Fetching(source)
+    }
+
+    fun reportFailure(message: String) {
+        _progress.value = ImportProgress.Failed(message)
+    }
+
+    fun resetProgress() {
+        _progress.value = ImportProgress.Idle
+    }
+
+    /**
+     * Creates the playlist, then matches each track against the streaming
+     * catalog and adds the best hit. Returns the terminal [ImportProgress.Done]
+     * (also published on [progress]).
+     */
+    suspend fun importTracks(
+        name: String,
+        description: String?,
+        tracks: List<CsvTrack>,
+        strictAlbumMatch: Boolean,
+    ): ImportProgress.Done {
+        val playlistId = libraryRepository.createPlaylist(name, description)
+        val unmatched = mutableListOf<String>()
+        var matched = 0
+
+        tracks.forEachIndexed { index, csvTrack ->
+            _progress.value = ImportProgress.Matching(
+                current = index + 1,
+                total = tracks.size,
+                matched = matched,
+            )
+
+            val query = "${csvTrack.title} ${csvTrack.artist}"
+            val results = musicRepository.searchTracks(query).getOrNull().orEmpty()
+
+            val bestMatch = if (strictAlbumMatch && csvTrack.album.isNotBlank()) {
+                results.find { it.album?.title?.equals(csvTrack.album, ignoreCase = true) == true }
+                    ?: results.firstOrNull()
+            } else {
+                results.firstOrNull()
+            }
+
+            if (bestMatch != null) {
+                libraryRepository.addTrackToPlaylist(playlistId, bestMatch)
+                matched++
+            } else {
+                unmatched += "${csvTrack.title} — ${csvTrack.artist}"
+            }
+        }
+
+        val done = ImportProgress.Done(
+            playlistId = playlistId,
+            playlistName = name,
+            matched = matched,
+            total = tracks.size,
+            unmatched = unmatched,
+        )
+        _progress.value = done
+        return done
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
@@ -78,7 +78,13 @@ class PlaylistImportService @Inject constructor(
             )
 
             val query = "${csvTrack.title} ${csvTrack.artist}"
-            val results = musicRepository.searchTracks(query).getOrNull().orEmpty()
+            // Qobuz first: searchQobuz registers every hit in QobuzIdRegistry,
+            // which is what routes the stored id to Qobuz playback later.
+            // Tidal is the per-track fallback when Qobuz has no result (or no
+            // Qobuz instance is configured, in which case it returns nothing).
+            val results = musicRepository.searchQobuz(query).getOrNull()?.tracks
+                ?.takeIf { it.isNotEmpty() }
+                ?: musicRepository.searchTracks(query).getOrNull().orEmpty()
 
             val bestMatch = if (strictAlbumMatch && csvTrack.album.isNotBlank()) {
                 results.find { it.album?.title?.equals(csvTrack.album, ignoreCase = true) == true }

--- a/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImporter.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImporter.kt
@@ -30,20 +30,28 @@ class PlaylistImporter @Inject constructor(
             importService.reportFailure(message)
             return Result.failure(Exception(message))
         }
-        return importSpotifyPlaylist(playlistId, fallbackName = "Spotify Playlist", strictAlbumMatch)
+        return importSpotifyPlaylist(playlistId, knownName = null, strictAlbumMatch = strictAlbumMatch)
     }
 
+    /**
+     * @param knownName playlist name when the caller already has it (the
+     *   picker does) — skips the metadata request entirely. For URL imports
+     *   pass null; the name is then looked up best-effort and a metadata
+     *   failure does not abort the import (the /items call is what matters).
+     */
     suspend fun importSpotifyPlaylist(
         playlistId: String,
-        fallbackName: String,
+        knownName: String?,
         strictAlbumMatch: Boolean = false,
     ): Result<ImportProgress.Done> = runCatching {
         importService.reportFetching("Spotify")
-        val meta = spotifyApiClient.getPlaylistMeta(playlistId).getOrThrow()
         val tracks = spotifyApiClient.getPlaylistTracks(playlistId).getOrThrow()
         if (tracks.isEmpty()) throw Exception("This Spotify playlist has no importable tracks.")
+        val name = knownName?.takeIf { it.isNotBlank() }
+            ?: spotifyApiClient.getPlaylistMeta(playlistId).getOrNull()?.name?.takeIf { it.isNotBlank() }
+            ?: "Spotify Playlist"
         importService.importTracks(
-            name = meta.name.ifBlank { fallbackName },
+            name = name,
             description = "Imported from Spotify",
             tracks = tracks,
             strictAlbumMatch = strictAlbumMatch,

--- a/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImporter.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImporter.kt
@@ -1,31 +1,74 @@
 package tf.monochrome.android.data.import_
 
-import tf.monochrome.android.data.api.HiFiApiClient
-import tf.monochrome.android.domain.model.Track
+import tf.monochrome.android.data.api.SpotifyApiClient
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Imports playlists from Spotify into the local library: fetches metadata
+ * via the Spotify Web API (user must have connected their account — see
+ * SpotifyAuthManager), then runs the shared search-and-match pipeline in
+ * [PlaylistImportService].
+ */
 @Singleton
 class PlaylistImporter @Inject constructor(
-    private val apiClient: HiFiApiClient
+    private val spotifyApiClient: SpotifyApiClient,
+    private val importService: PlaylistImportService,
 ) {
-    suspend fun importFromUrl(url: String): Result<List<Track>> = runCatching {
-        // In a real implementation, this would call a backend scraper
-        // that returns track metadata (artist, title) for the playlist.
-        // For this parity implementation, we'll simulate the matching
-        // by searching for a few demo tracks if the URL is valid.
-        
-        val isSpotify = url.contains("spotify.com/playlist/")
-        val isYouTube = url.contains("youtube.com/playlist") || url.contains("music.youtube.com/playlist")
-        
-        if (!isSpotify && !isYouTube) {
-            throw Exception("Invalid or unsupported playlist URL")
+
+    /** Import from a pasted link — Spotify playlist URLs and spotify: URIs. */
+    suspend fun importFromUrl(url: String, strictAlbumMatch: Boolean = false): Result<ImportProgress.Done> {
+        val playlistId = extractSpotifyPlaylistId(url)
+        if (playlistId == null) {
+            val isYouTube = url.contains("youtube.com/playlist") || url.contains("music.youtube.com/playlist")
+            val message = if (isYouTube) {
+                "YouTube Music import is not supported yet — only Spotify playlist links work."
+            } else {
+                "Unrecognized playlist URL. Paste a Spotify playlist link like " +
+                    "https://open.spotify.com/playlist/…"
+            }
+            importService.reportFailure(message)
+            return Result.failure(Exception(message))
         }
-        
-        // Simulating metadata extraction and search matching
-        // We'll just return a success for now to show the flow.
-        // In practice, we'd loop through extracted metadata and call apiClient.search(query).tracks
-        
-        emptyList<Track>()
+        return importSpotifyPlaylist(playlistId, fallbackName = "Spotify Playlist", strictAlbumMatch)
+    }
+
+    suspend fun importSpotifyPlaylist(
+        playlistId: String,
+        fallbackName: String,
+        strictAlbumMatch: Boolean = false,
+    ): Result<ImportProgress.Done> = runCatching {
+        importService.reportFetching("Spotify")
+        val meta = spotifyApiClient.getPlaylistMeta(playlistId).getOrThrow()
+        val tracks = spotifyApiClient.getPlaylistTracks(playlistId).getOrThrow()
+        if (tracks.isEmpty()) throw Exception("This Spotify playlist has no importable tracks.")
+        importService.importTracks(
+            name = meta.name.ifBlank { fallbackName },
+            description = "Imported from Spotify",
+            tracks = tracks,
+            strictAlbumMatch = strictAlbumMatch,
+        )
+    }.onFailure { importService.reportFailure(it.message ?: "Spotify import failed") }
+
+    suspend fun importSpotifyLikedSongs(strictAlbumMatch: Boolean = false): Result<ImportProgress.Done> =
+        runCatching {
+            importService.reportFetching("Spotify")
+            val tracks = spotifyApiClient.getLikedSongs().getOrThrow()
+            if (tracks.isEmpty()) throw Exception("Your Spotify Liked Songs list is empty.")
+            importService.importTracks(
+                name = "Liked Songs (Spotify)",
+                description = "Imported from Spotify",
+                tracks = tracks,
+                strictAlbumMatch = strictAlbumMatch,
+            )
+        }.onFailure { importService.reportFailure(it.message ?: "Spotify import failed") }
+
+    companion object {
+        // 22-char base62 ID from open.spotify.com/playlist/{id}, /intl-xx/playlist/{id},
+        // or spotify:playlist:{id} URIs.
+        private val SPOTIFY_PLAYLIST_ID = Regex("playlist[/:]([A-Za-z0-9]{22})")
+
+        fun extractSpotifyPlaylistId(url: String): String? =
+            SPOTIFY_PLAYLIST_ID.find(url)?.groupValues?.get(1)
     }
 }

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -125,6 +125,12 @@ class PreferencesManager @Inject constructor(
         private val GEMINI_API_KEY = stringPreferencesKey("gemini_api_key")
         private val AI_RADIO_ENABLED = booleanPreferencesKey("ai_radio_enabled")
 
+        // Spotify (PKCE OAuth tokens for playlist import)
+        private val SPOTIFY_ACCESS_TOKEN = stringPreferencesKey("spotify_access_token")
+        private val SPOTIFY_REFRESH_TOKEN = stringPreferencesKey("spotify_refresh_token")
+        private val SPOTIFY_TOKEN_EXPIRES_AT = longPreferencesKey("spotify_token_expires_at")
+        private val SPOTIFY_USER_NAME = stringPreferencesKey("spotify_user_name")
+
         // PocketBase
         private val POCKETBASE_TOKEN = stringPreferencesKey("pocketbase_token")
         private val POCKETBASE_USER_ID = stringPreferencesKey("pocketbase_user_id")
@@ -646,6 +652,36 @@ class PreferencesManager @Inject constructor(
         dataStore.edit { it[AI_RADIO_ENABLED] = enabled }
     }
 
+
+    // --- Spotify ---
+    val spotifyAccessToken: Flow<String?> = dataStore.data.map { it[SPOTIFY_ACCESS_TOKEN] }
+    val spotifyRefreshToken: Flow<String?> = dataStore.data.map { it[SPOTIFY_REFRESH_TOKEN] }
+    val spotifyTokenExpiresAt: Flow<Long> = dataStore.data.map { it[SPOTIFY_TOKEN_EXPIRES_AT] ?: 0L }
+    val spotifyUserName: Flow<String?> = dataStore.data.map { it[SPOTIFY_USER_NAME] }
+
+    suspend fun setSpotifyTokens(accessToken: String, refreshToken: String, expiresAtMillis: Long) {
+        dataStore.edit {
+            it[SPOTIFY_ACCESS_TOKEN] = accessToken
+            it[SPOTIFY_REFRESH_TOKEN] = refreshToken
+            it[SPOTIFY_TOKEN_EXPIRES_AT] = expiresAtMillis
+        }
+    }
+
+    suspend fun setSpotifyUserName(name: String?) {
+        dataStore.edit {
+            if (name.isNullOrBlank()) it.remove(SPOTIFY_USER_NAME)
+            else it[SPOTIFY_USER_NAME] = name
+        }
+    }
+
+    suspend fun clearSpotifyTokens() {
+        dataStore.edit {
+            it.remove(SPOTIFY_ACCESS_TOKEN)
+            it.remove(SPOTIFY_REFRESH_TOKEN)
+            it.remove(SPOTIFY_TOKEN_EXPIRES_AT)
+            it.remove(SPOTIFY_USER_NAME)
+        }
+    }
 
     // --- PocketBase ---
     val pocketBaseToken: Flow<String?> = dataStore.data.map { it[POCKETBASE_TOKEN] }

--- a/app/src/main/java/tf/monochrome/android/data/repository/LibraryRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/LibraryRepository.kt
@@ -76,6 +76,11 @@ class LibraryRepository @Inject constructor(
         }
     }
 
+    /** Explicit bulk unlike (idempotent — no toggle race on already-removed ids). */
+    suspend fun removeFavoriteTracks(trackIds: Collection<Long>) {
+        trackIds.forEach { favoriteDao.deleteFavoriteTrack(it) }
+    }
+
     suspend fun toggleFavoriteAlbum(album: Album) {
         if (favoriteDao.isFavoriteAlbum(album.id)) {
             favoriteDao.deleteFavoriteAlbum(album.id)
@@ -150,6 +155,11 @@ class LibraryRepository @Inject constructor(
     suspend fun clearHistory() {
         historyDao.clearHistory()
         playEventDao.clearAll()
+    }
+
+    /** Remove individual entries from listening history (play-event stats are kept). */
+    suspend fun removeFromHistory(trackIds: Collection<Long>) {
+        trackIds.forEach { historyDao.deleteByTrackId(it) }
     }
 
     // --- Play events / stats ---

--- a/app/src/main/java/tf/monochrome/android/ui/components/AddToPlaylistSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/AddToPlaylistSheet.kt
@@ -26,17 +26,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.data.db.entity.UserPlaylistEntity
-import tf.monochrome.android.domain.model.Track
 import tf.monochrome.android.ui.theme.MonoDimens
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddToPlaylistSheet(
-    track: Track,
     playlists: List<UserPlaylistEntity>,
     onDismiss: () -> Unit,
     onPlaylistSelected: (UserPlaylistEntity) -> Unit,
-    onCreateNew: () -> Unit
+    onCreateNew: () -> Unit,
+    title: String = "Add to Playlist"
 ) {
     val sheetState = rememberModalBottomSheetState()
 
@@ -47,7 +46,7 @@ fun AddToPlaylistSheet(
     ) {
         Column(modifier = Modifier.padding(bottom = 24.dp)) {
             Text(
-                text = "Add to Playlist",
+                text = title,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -176,7 +176,7 @@ fun CreatePlaylistDialog(
 
                         if (selectedSource == "Spotify") {
                             Text(
-                                text = "Please use Exportify to export your Spotify playlist into a .csv.",
+                                text = "Connect Spotify in Settings → System to import playlists directly, or upload an Exportify .csv here.",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )

--- a/app/src/main/java/tf/monochrome/android/ui/components/SpotifyPlaylistPickerDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/SpotifyPlaylistPickerDialog.kt
@@ -1,0 +1,190 @@
+package tf.monochrome.android.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.QueueMusic
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import tf.monochrome.android.data.api.SpotifySimplePlaylist
+
+/**
+ * Picker for the connected Spotify account's playlists. "Liked Songs" is
+ * pinned at the top; tapping a row starts the import immediately.
+ */
+@Composable
+fun SpotifyPlaylistPickerDialog(
+    playlists: List<SpotifySimplePlaylist>,
+    isLoading: Boolean,
+    error: String?,
+    onPick: (playlistId: String, name: String, strictAlbumMatch: Boolean) -> Unit,
+    onPickLikedSongs: (strictAlbumMatch: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var strictAlbumMatch by remember { mutableStateOf(false) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .wrapContentHeight()
+                .padding(vertical = 24.dp)
+                .liquidGlass(shape = RoundedCornerShape(16.dp)),
+            shape = RoundedCornerShape(16.dp),
+            color = Color.Transparent,
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = "Import from Spotify",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Strict Album Matching", style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            "Album name must match Spotify metadata",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(checked = strictAlbumMatch, onCheckedChange = { strictAlbumMatch = it })
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                when {
+                    isLoading -> {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 24.dp),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                        }
+                    }
+                    error != null -> {
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(vertical = 16.dp),
+                        )
+                    }
+                    else -> {
+                        LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                            item {
+                                PickerRow(
+                                    title = "Liked Songs",
+                                    subtitle = "Your saved Spotify tracks",
+                                    isLikedSongs = true,
+                                    onClick = { onPickLikedSongs(strictAlbumMatch) },
+                                )
+                            }
+                            items(playlists, key = { it.id }) { playlist ->
+                                PickerRow(
+                                    title = playlist.name,
+                                    subtitle = buildString {
+                                        playlist.tracks?.let { append("${it.total} tracks") }
+                                        playlist.owner?.displayName?.let {
+                                            if (isNotEmpty()) append(" • ")
+                                            append(it)
+                                        }
+                                    },
+                                    isLikedSongs = false,
+                                    onClick = { onPick(playlist.id, playlist.name, strictAlbumMatch) },
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PickerRow(
+    title: String,
+    subtitle: String,
+    isLikedSongs: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = if (isLikedSongs) Icons.Default.Favorite else Icons.Default.QueueMusic,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(22.dp),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (subtitle.isNotBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.QueueMusic
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SkipNext
@@ -49,6 +50,7 @@ fun TrackContextMenu(
     onAddToQueue: () -> Unit,
     onToggleLike: () -> Unit,
     onAddToPlaylist: () -> Unit,
+    onRemoveFromPlaylist: (() -> Unit)? = null,
     onDownloadTrack: (() -> Unit)? = null,
     onShareFile: (() -> Unit)? = null,
     onGoToAlbum: (() -> Unit)? = null,
@@ -125,6 +127,15 @@ fun TrackContextMenu(
                 label = "Add to playlist",
                 onClick = { onAddToPlaylist(); onDismiss() }
             )
+
+            if (onRemoveFromPlaylist != null) {
+                ContextMenuItem(
+                    icon = Icons.Default.RemoveCircleOutline,
+                    label = "Remove from playlist",
+                    tint = MaterialTheme.colorScheme.error,
+                    onClick = { onRemoveFromPlaylist(); onDismiss() }
+                )
+            }
 
             if (onDownloadTrack != null) {
                 ContextMenuItem(

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackItem.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackItem.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Explicit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,8 +49,17 @@ fun TrackItem(
     onMoreClick: (() -> Unit)? = null,
     onAlbumClick: (() -> Unit)? = null,
     onArtistClick: ((Long) -> Unit)? = null,
-    downloadState: TrackDownloadState? = null
+    downloadState: TrackDownloadState? = null,
+    selectionMode: Boolean = false,
+    selected: Boolean = false
 ) {
+    // While multi-selecting, per-row affordances (like, 3-dot, inline
+    // artist/album links) would steal taps meant for selection — hide them.
+    val effectiveOnLikeClick = onLikeClick.takeUnless { selectionMode }
+    val effectiveOnMoreClick = onMoreClick.takeUnless { selectionMode }
+    val effectiveOnAlbumClick = onAlbumClick.takeUnless { selectionMode }
+    val effectiveOnArtistClick = onArtistClick.takeUnless { selectionMode }
+
     Surface(
         modifier = modifier
             .fillMaxWidth()
@@ -59,7 +70,7 @@ fun TrackItem(
             )
             .liquidGlass(shape = MonoDimens.shapeMd),
         shape = MonoDimens.shapeMd,
-        color = Color.Transparent
+        color = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent
     ) {
         Row(
             modifier = Modifier
@@ -67,6 +78,15 @@ fun TrackItem(
                 .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingSm),
             verticalAlignment = Alignment.CenterVertically
     ) {
+        if (selectionMode) {
+            Icon(
+                imageVector = if (selected) Icons.Default.CheckCircle else Icons.Outlined.Circle,
+                contentDescription = if (selected) "Selected" else "Not selected",
+                tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(MonoDimens.spacingMd))
+        }
+
         if (trackNumber != null) {
             Text(
                 text = trackNumber.toString(),
@@ -77,8 +97,8 @@ fun TrackItem(
         }
 
         if (showCover) {
-            val coverModifier = if (onAlbumClick != null) {
-                Modifier.clickable { onAlbumClick() }
+            val coverModifier = if (effectiveOnAlbumClick != null) {
+                Modifier.clickable { effectiveOnAlbumClick() }
             } else {
                 Modifier
             }
@@ -117,11 +137,11 @@ fun TrackItem(
                 }
             }
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (onArtistClick != null) {
+                if (effectiveOnArtistClick != null) {
                     ClickableArtists(
                         artists = track.uiArtistRefs(),
                         fallbackName = track.displayArtist,
-                        onArtistClick = { ref -> ref.id?.let { onArtistClick(it) } },
+                        onArtistClick = { ref -> ref.id?.let { effectiveOnArtistClick(it) } },
                         modifier = Modifier.weight(1f, fill = false),
                     )
                 } else {
@@ -133,7 +153,7 @@ fun TrackItem(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
-                if (track.album != null && onAlbumClick != null) {
+                if (track.album != null && effectiveOnAlbumClick != null) {
                     Text(
                         text = " • ",
                         style = MaterialTheme.typography.bodySmall,
@@ -145,7 +165,7 @@ fun TrackItem(
                         color = MaterialTheme.colorScheme.primary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.clickable(onClick = onAlbumClick)
+                        modifier = Modifier.clickable(onClick = effectiveOnAlbumClick)
                     )
                 } else if (track.album != null) {
                     Text(
@@ -159,8 +179,8 @@ fun TrackItem(
             }
         }
 
-        if (onLikeClick != null) {
-            IconButton(onClick = onLikeClick, modifier = Modifier.padding(start = 4.dp)) {
+        if (effectiveOnLikeClick != null) {
+            IconButton(onClick = effectiveOnLikeClick, modifier = Modifier.padding(start = 4.dp)) {
                 Icon(
                     imageVector = if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                     contentDescription = if (isLiked) "Unlike" else "Like",
@@ -178,7 +198,7 @@ fun TrackItem(
         }
 
         if (showDuration) {
-            Spacer(modifier = Modifier.width(if (onLikeClick == null) 8.dp else 4.dp))
+            Spacer(modifier = Modifier.width(if (effectiveOnLikeClick == null) 8.dp else 4.dp))
             Text(
                 text = track.formattedDuration,
                 style = MaterialTheme.typography.bodySmall,
@@ -186,8 +206,8 @@ fun TrackItem(
             )
         }
 
-        if (onMoreClick != null) {
-            IconButton(onClick = onMoreClick) {
+        if (effectiveOnMoreClick != null) {
+            IconButton(onClick = effectiveOnMoreClick) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
                     contentDescription = "More options",

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackSelectionBar.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackSelectionBar.kt
@@ -1,0 +1,87 @@
+package tf.monochrome.android.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import tf.monochrome.android.ui.theme.MonoDimens
+
+/**
+ * Contextual action bar shown while track multi-select is active. Delete is
+ * optional — streaming/catalog lists have nothing to delete from, so they
+ * omit it and only offer the "send" actions (queue / playlist).
+ */
+@Composable
+fun TrackSelectionBar(
+    selectedCount: Int,
+    onClose: () -> Unit,
+    onAddToQueue: () -> Unit,
+    onAddToPlaylist: () -> Unit,
+    modifier: Modifier = Modifier,
+    onDelete: (() -> Unit)? = null,
+    deleteContentDescription: String = "Delete",
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = MonoDimens.cardAlpha),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Exit selection",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Text(
+                text = "$selectedCount selected",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onAddToQueue) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+                    contentDescription = "Add to queue",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            IconButton(onClick = onAddToPlaylist) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
+                    contentDescription = "Add to playlist",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            if (onDelete != null) {
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = deleteContentDescription,
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackSelectionState.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackSelectionState.kt
@@ -1,0 +1,35 @@
+package tf.monochrome.android.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Per-screen multi-select state for track lists. Selection mode is active
+ * exactly while at least one row is selected, so deselecting the last row
+ * exits the mode with no extra bookkeeping. Generic key type because legacy
+ * Track/DownloadedTrackEntity ids are Longs while UnifiedTrack ids are Strings.
+ */
+@Stable
+class TrackSelectionState<K : Any> {
+    var selectedIds by mutableStateOf(emptySet<K>())
+        private set
+
+    val active: Boolean get() = selectedIds.isNotEmpty()
+    val count: Int get() = selectedIds.size
+
+    fun toggle(id: K) {
+        selectedIds = if (id in selectedIds) selectedIds - id else selectedIds + id
+    }
+
+    fun clear() {
+        selectedIds = emptySet()
+    }
+}
+
+@Composable
+fun <K : Any> rememberTrackSelectionState(): TrackSelectionState<K> =
+    remember { TrackSelectionState() }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/AlbumDetailScreen.kt
@@ -65,6 +65,10 @@ fun AlbumDetailScreen(
     var showContextMenuForTrack by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<tf.monochrome.android.domain.model.Track?>(null) }
     var showAddToPlaylistForTrack by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<tf.monochrome.android.domain.model.Track?>(null) }
     var showCreatePlaylistDialog by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+    var showAddToPlaylistForSelection by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+
+    val selection = tf.monochrome.android.ui.components.rememberTrackSelectionState<Long>()
+    androidx.activity.compose.BackHandler(enabled = selection.active) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -96,7 +100,6 @@ fun AlbumDetailScreen(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = playlists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -105,6 +108,26 @@ fun AlbumDetailScreen(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = playlists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    albumDetail?.tracks.orEmpty().filter { it.id in selection.selectedIds },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -131,6 +154,17 @@ fun AlbumDetailScreen(
             )
             albumDetail != null -> {
                 val detail = albumDetail ?: return
+                androidx.compose.animation.AnimatedVisibility(visible = selection.active) {
+                    tf.monochrome.android.ui.components.TrackSelectionBar(
+                        selectedCount = selection.count,
+                        onClose = { selection.clear() },
+                        onAddToQueue = {
+                            playerViewModel.addToQueue(detail.tracks.filter { it.id in selection.selectedIds })
+                            selection.clear()
+                        },
+                        onAddToPlaylist = { showAddToPlaylistForSelection = true }
+                    )
+                }
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = 80.dp)
@@ -227,12 +261,17 @@ fun AlbumDetailScreen(
                             track = track,
                             isLiked = favoriteTrackIds.contains(track.id),
                             onLikeClick = { playerViewModel.toggleFavorite(track) },
-                            onClick = { playerViewModel.playTrack(track, detail.tracks) },
-                            onLongClick = { showContextMenuForTrack = track },
+                            onClick = {
+                                if (selection.active) selection.toggle(track.id)
+                                else playerViewModel.playTrack(track, detail.tracks)
+                            },
+                            onLongClick = { selection.toggle(track.id) },
                             onMoreClick = { showContextMenuForTrack = track },
                             onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                             showCover = false,
-                            trackNumber = track.trackNumber ?: (index + 1)
+                            trackNumber = track.trackNumber ?: (index + 1),
+                            selectionMode = selection.active,
+                            selected = track.id in selection.selectedIds
                         )
                     }
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
@@ -76,6 +76,10 @@ fun ArtistDetailScreen(
     var showAddToPlaylistForTrack by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf<tf.monochrome.android.domain.model.Track?>(null) }
     var showCreatePlaylistDialog by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     var showAllTopTracks by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+    var showAddToPlaylistForSelection by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+
+    val selection = tf.monochrome.android.ui.components.rememberTrackSelectionState<Long>()
+    androidx.activity.compose.BackHandler(enabled = selection.active) { selection.clear() }
     var showDownloadConfirm by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
 
     if (showDownloadConfirm) {
@@ -135,7 +139,6 @@ fun ArtistDetailScreen(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = playlists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -144,6 +147,28 @@ fun ArtistDetailScreen(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = playlists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    // Resolve against the FULL top-tracks list so selections made
+                    // while expanded still resolve after the list collapses.
+                    artistDetail?.topTracks.orEmpty().filter { it.id in selection.selectedIds },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -188,6 +213,17 @@ fun ArtistDetailScreen(
             )
             artistDetail != null -> {
                 val detail = artistDetail ?: return
+                androidx.compose.animation.AnimatedVisibility(visible = selection.active) {
+                    tf.monochrome.android.ui.components.TrackSelectionBar(
+                        selectedCount = selection.count,
+                        onClose = { selection.clear() },
+                        onAddToQueue = {
+                            playerViewModel.addToQueue(detail.topTracks.filter { it.id in selection.selectedIds })
+                            selection.clear()
+                        },
+                        onAddToPlaylist = { showAddToPlaylistForSelection = true }
+                    )
+                }
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(bottom = 80.dp)
@@ -232,13 +268,18 @@ fun ArtistDetailScreen(
                                 track = track,
                                 isLiked = favoriteTrackIds.contains(track.id),
                                 onLikeClick = { playerViewModel.toggleFavorite(track) },
-                                onClick = { playerViewModel.playTrack(track, detail.topTracks) },
-                                onLongClick = { showContextMenuForTrack = track },
+                                onClick = {
+                                    if (selection.active) selection.toggle(track.id)
+                                    else playerViewModel.playTrack(track, detail.topTracks)
+                                },
+                                onLongClick = { selection.toggle(track.id) },
                                 onMoreClick = { showContextMenuForTrack = track },
                                 onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                                 onAlbumClick = track.album?.id?.let { albumId ->
                                     { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
-                                }
+                                },
+                                selectionMode = selection.active,
+                                selected = track.id in selection.selectedIds
                             )
                         }
                         if (detail.topTracks.size > 5) {

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -127,6 +127,12 @@ fun HomeScreen(
     var showCreatePlaylistDialog by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf(false)
     }
+    var showAddToPlaylistForSelection by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf(false)
+    }
+
+    val selection = tf.monochrome.android.ui.components.rememberTrackSelectionState<Long>()
+    androidx.activity.compose.BackHandler(enabled = selection.active) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -160,7 +166,6 @@ fun HomeScreen(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = libraryPlaylists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -169,6 +174,26 @@ fun HomeScreen(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = libraryPlaylists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    recentTracks.filter { it.id in selection.selectedIds },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -254,6 +279,23 @@ fun HomeScreen(
         } else if (isLoading) {
             LoadingScreen()
         } else {
+            androidx.compose.animation.AnimatedVisibility(visible = selection.active) {
+                tf.monochrome.android.ui.components.TrackSelectionBar(
+                    selectedCount = selection.count,
+                    onClose = { selection.clear() },
+                    onAddToQueue = {
+                        playerViewModel.addToQueue(recentTracks.filter { it.id in selection.selectedIds })
+                        selection.clear()
+                    },
+                    onAddToPlaylist = { showAddToPlaylistForSelection = true },
+                    onDelete = {
+                        playerViewModel.removeFromHistory(selection.selectedIds)
+                        selection.clear()
+                    },
+                    deleteContentDescription = "Remove from history"
+                )
+            }
+
             // ── Home content ────────────────────────────────────
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -301,13 +343,18 @@ fun HomeScreen(
                             track = track,
                             isLiked = favoriteTrackIds.contains(track.id),
                             onLikeClick = { playerViewModel.toggleFavorite(track) },
-                            onClick = { playerViewModel.playTrack(track, recentTracks) },
-                            onLongClick = { showContextMenuForTrack = track },
+                            onClick = {
+                                if (selection.active) selection.toggle(track.id)
+                                else playerViewModel.playTrack(track, recentTracks)
+                            },
+                            onLongClick = { selection.toggle(track.id) },
                             onMoreClick = { showContextMenuForTrack = track },
                             onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                             onAlbumClick = track.album?.id?.let { albumId ->
                                 { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
-                            }
+                            },
+                            selectionMode = selection.active,
+                            selected = track.id in selection.selectedIds
                         )
                     }
                 } else {

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
@@ -1,6 +1,10 @@
 package tf.monochrome.android.ui.library
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,8 +22,9 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +32,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +45,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import tf.monochrome.android.data.db.entity.DownloadedTrackEntity
+import tf.monochrome.android.ui.components.AddToPlaylistSheet
 import tf.monochrome.android.ui.components.CoverImage
+import tf.monochrome.android.ui.components.CreatePlaylistDialog
+import tf.monochrome.android.ui.components.TrackSelectionBar
+import tf.monochrome.android.ui.components.rememberTrackSelectionState
 import tf.monochrome.android.ui.player.PlayerViewModel
 
 @Composable
@@ -48,6 +60,43 @@ fun DownloadsScreen(
 ) {
     val downloadedTracks by viewModel.downloadedTracks.collectAsState()
     val albumGroups by viewModel.albumGroups.collectAsState()
+    val playlists by playerViewModel.playlists.collectAsState()
+
+    val selection = rememberTrackSelectionState<Long>()
+    BackHandler(enabled = selection.active) { selection.clear() }
+    var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
+    var showCreatePlaylistDialog by remember { mutableStateOf(false) }
+
+    if (showCreatePlaylistDialog) {
+        CreatePlaylistDialog(
+            onDismiss = { showCreatePlaylistDialog = false },
+            onSubmit = { name, description ->
+                playerViewModel.createPlaylist(name, description)
+                showCreatePlaylistDialog = false
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = playlists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    downloadedTracks.filter { it.id in selection.selectedIds }
+                        .map { it.toUnifiedTrack().toLegacyTrack() },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
 
     if (downloadedTracks.isEmpty()) {
         Box(
@@ -69,6 +118,27 @@ fun DownloadsScreen(
     // drives 'tap a track to play within the entire downloads queue', the
     // per-album lists drive 'tap an album card to play that album in order'.
     val allUnified = downloadedTracks.map { it.toUnifiedTrack() }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+    AnimatedVisibility(visible = selection.active) {
+        TrackSelectionBar(
+            selectedCount = selection.count,
+            onClose = { selection.clear() },
+            onAddToQueue = {
+                playerViewModel.addUnifiedToQueue(
+                    downloadedTracks.filter { it.id in selection.selectedIds }
+                        .map { it.toUnifiedTrack() },
+                )
+                selection.clear()
+            },
+            onAddToPlaylist = { showAddToPlaylistForSelection = true },
+            onDelete = {
+                viewModel.deleteDownloads(downloadedTracks.filter { it.id in selection.selectedIds })
+                selection.clear()
+            },
+            deleteContentDescription = "Delete downloads"
+        )
+    }
 
     LazyColumn(
         contentPadding = PaddingValues(bottom = 120.dp),
@@ -118,13 +188,20 @@ fun DownloadsScreen(
             DownloadedTrackRow(
                 track = track,
                 onClick = {
-                    val tappedUnified = track.toUnifiedTrack()
-                    playerViewModel.playUnifiedTrack(tappedUnified, allUnified)
+                    if (selection.active) {
+                        selection.toggle(track.id)
+                    } else {
+                        val tappedUnified = track.toUnifiedTrack()
+                        playerViewModel.playUnifiedTrack(tappedUnified, allUnified)
+                    }
                 },
+                onLongClick = { selection.toggle(track.id) },
                 onShare = { playerViewModel.shareDownloadedTrack(track) },
-                onDelete = { viewModel.deleteDownload(track) },
+                selectionMode = selection.active,
+                selected = track.id in selection.selectedIds,
             )
         }
+    }
     }
 }
 
@@ -164,20 +241,31 @@ private fun AlbumCard(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DownloadedTrackRow(
     track: DownloadedTrackEntity,
     onClick: () -> Unit,
+    onLongClick: () -> Unit,
     onShare: () -> Unit,
-    onDelete: () -> Unit,
+    selectionMode: Boolean,
+    selected: Boolean,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             .padding(horizontal = 24.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        if (selectionMode) {
+            Icon(
+                imageVector = if (selected) Icons.Default.CheckCircle else Icons.Outlined.Circle,
+                contentDescription = if (selected) "Selected" else "Not selected",
+                tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+        }
         CoverImage(
             url = track.albumCover,
             contentDescription = track.title,
@@ -203,19 +291,16 @@ private fun DownloadedTrackRow(
                 overflow = TextOverflow.Ellipsis
             )
         }
-        IconButton(onClick = onShare) {
-            Icon(
-                Icons.Default.Share,
-                contentDescription = "Share Download",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        IconButton(onClick = onDelete) {
-            Icon(
-                Icons.Default.Delete,
-                contentDescription = "Delete Download",
-                tint = MaterialTheme.colorScheme.error
-            )
+        // Deletion is intentionally not a per-row button anymore — long-press
+        // to select, then delete from the selection bar.
+        if (!selectionMode) {
+            IconButton(onClick = onShare) {
+                Icon(
+                    Icons.Default.Share,
+                    contentDescription = "Share Download",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
@@ -185,21 +185,27 @@ class DownloadsViewModel @Inject constructor(
     }
 
     fun deleteDownload(track: DownloadedTrackEntity) {
-        viewModelScope.launch {
-            if (track.filePath.startsWith("content://")) {
-                try {
-                    val uri = track.filePath.toUri()
-                    val docFile = DocumentFile.fromSingleUri(appCtx, uri)
-                    docFile?.delete()
-                } catch (e: Exception) {
-                    // Ignore exceptions during content deletion
-                }
-            } else {
-                val file = File(track.filePath)
-                if (file.exists()) file.delete()
+        viewModelScope.launch { deleteOne(track) }
+    }
+
+    fun deleteDownloads(tracks: List<DownloadedTrackEntity>) {
+        viewModelScope.launch { tracks.forEach { deleteOne(it) } }
+    }
+
+    private suspend fun deleteOne(track: DownloadedTrackEntity) {
+        if (track.filePath.startsWith("content://")) {
+            try {
+                val uri = track.filePath.toUri()
+                val docFile = DocumentFile.fromSingleUri(appCtx, uri)
+                docFile?.delete()
+            } catch (e: Exception) {
+                // Ignore exceptions during content deletion
             }
-            downloadDao.deleteDownloadedTrack(track.id)
+        } else {
+            val file = File(track.filePath)
+            if (file.exists()) file.delete()
         }
+        downloadDao.deleteDownloadedTrack(track.id)
     }
 
     companion object {

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -1,5 +1,7 @@
 package tf.monochrome.android.ui.library
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -50,6 +53,8 @@ import tf.monochrome.android.ui.components.CreatePlaylistDialog
 import tf.monochrome.android.ui.components.SectionHeader
 import tf.monochrome.android.ui.components.TrackContextMenu
 import tf.monochrome.android.ui.components.TrackItem
+import tf.monochrome.android.ui.components.TrackSelectionBar
+import tf.monochrome.android.ui.components.rememberTrackSelectionState
 import tf.monochrome.android.ui.navigation.Screen
 import tf.monochrome.android.ui.navigation.openCatalogArtist
 import tf.monochrome.android.ui.player.PlayerViewModel
@@ -88,6 +93,12 @@ fun LibraryScreen(
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
+    var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
+
+    val selection = rememberTrackSelectionState<Long>()
+    BackHandler(enabled = selection.active) { selection.clear() }
+    // Lists (and delete semantics) differ per tab — drop any selection on switch.
+    LaunchedEffect(selectedTabIndex) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -125,7 +136,6 @@ fun LibraryScreen(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = playlists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -134,6 +144,30 @@ fun LibraryScreen(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    // Tracks that bulk-selection actions operate on; ids are unique across the
+    // overview's two sections, so a combined distinct list resolves either.
+    val selectableTracks = (recentTracks + favoriteTracks).distinctBy { it.id }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = playlists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    selectableTracks.filter { it.id in selection.selectedIds },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -181,6 +215,25 @@ fun LibraryScreen(
 
         val currentSectionId = tabs.getOrNull(selectedTabIndex)?.first ?: "overview"
 
+        AnimatedVisibility(visible = selection.active) {
+            TrackSelectionBar(
+                selectedCount = selection.count,
+                onClose = { selection.clear() },
+                onAddToQueue = {
+                    playerViewModel.addToQueue(selectableTracks.filter { it.id in selection.selectedIds })
+                    selection.clear()
+                },
+                onAddToPlaylist = { showAddToPlaylistForSelection = true },
+                onDelete = if (currentSectionId == "favorites") {
+                    {
+                        playerViewModel.unlikeTracks(selection.selectedIds)
+                        selection.clear()
+                    }
+                } else null,
+                deleteContentDescription = "Unlike"
+            )
+        }
+
         when (currentSectionId) {
             "overview" ->
                 LazyColumn(
@@ -194,14 +247,19 @@ fun LibraryScreen(
                                 track = track,
                                 isLiked = favoriteTrackIds.contains(track.id),
                                 onLikeClick = { playerViewModel.toggleFavorite(track) },
-                                onClick = { playerViewModel.playTrack(track, recentTracks) },
-                                onLongClick = { showContextMenuForTrack = track },
+                                onClick = {
+                                    if (selection.active) selection.toggle(track.id)
+                                    else playerViewModel.playTrack(track, recentTracks)
+                                },
+                                onLongClick = { selection.toggle(track.id) },
                                 onMoreClick = { showContextMenuForTrack = track },
                                 onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                                 onAlbumClick = track.album?.id?.let { albumId ->
                                     { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
                                 },
-                                downloadState = activeDownloads[track.id]
+                                downloadState = activeDownloads[track.id],
+                                selectionMode = selection.active,
+                                selected = track.id in selection.selectedIds
                             )
                         }
                     }
@@ -213,14 +271,19 @@ fun LibraryScreen(
                                 track = track,
                                 isLiked = true,
                                 onLikeClick = { playerViewModel.toggleFavorite(track) },
-                                onClick = { playerViewModel.playTrack(track, favoriteTracks) },
-                                onLongClick = { showContextMenuForTrack = track },
+                                onClick = {
+                                    if (selection.active) selection.toggle(track.id)
+                                    else playerViewModel.playTrack(track, favoriteTracks)
+                                },
+                                onLongClick = { selection.toggle(track.id) },
                                 onMoreClick = { showContextMenuForTrack = track },
                                 onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                                 onAlbumClick = track.album?.id?.let { albumId ->
                                     { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
                                 },
-                                downloadState = activeDownloads[track.id]
+                                downloadState = activeDownloads[track.id],
+                                selectionMode = selection.active,
+                                selected = track.id in selection.selectedIds
                             )
                         }
                     }
@@ -353,14 +416,19 @@ fun LibraryScreen(
                                 track = track,
                                 isLiked = true,
                                 onLikeClick = { playerViewModel.toggleFavorite(track) },
-                                onClick = { playerViewModel.playTrack(track, favoriteTracks) },
-                                onLongClick = { showContextMenuForTrack = track },
+                                onClick = {
+                                    if (selection.active) selection.toggle(track.id)
+                                    else playerViewModel.playTrack(track, favoriteTracks)
+                                },
+                                onLongClick = { selection.toggle(track.id) },
                                 onMoreClick = { showContextMenuForTrack = track },
                                 onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
                                 onAlbumClick = track.album?.id?.let { albumId ->
                                     { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
                                 },
-                                downloadState = activeDownloads[track.id]
+                                downloadState = activeDownloads[track.id],
+                                selectionMode = selection.active,
+                                selected = track.id in selection.selectedIds
                             )
                         }
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
@@ -13,16 +13,20 @@ import tf.monochrome.android.domain.model.Album
 import tf.monochrome.android.domain.model.Artist
 import tf.monochrome.android.domain.model.Track
 import tf.monochrome.android.data.import_.CsvPlaylistParser
-import tf.monochrome.android.data.repository.MusicRepository
+import tf.monochrome.android.data.import_.ImportProgress
+import tf.monochrome.android.data.import_.PlaylistImportService
 import android.net.Uri
 import javax.inject.Inject
+
 
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val csvPlaylistParser: CsvPlaylistParser,
-    private val musicRepository: MusicRepository
+    private val playlistImportService: PlaylistImportService
 ) : ViewModel() {
+
+    val importProgress: StateFlow<ImportProgress> = playlistImportService.progress
 
     fun createPlaylist(name: String, description: String? = null) {
         viewModelScope.launch {
@@ -32,25 +36,13 @@ class LibraryViewModel @Inject constructor(
 
     fun importCsvPlaylist(uri: Uri, strictAlbumMatch: Boolean, name: String, description: String?) {
         viewModelScope.launch {
-            val playlistId = libraryRepository.createPlaylist(name, description)
-            val result = csvPlaylistParser.parseFromUri(uri)
-            val parsedPlaylist = result.getOrNull() ?: return@launch
-            
-            for (csvTrack in parsedPlaylist.tracks) {
-                val query = "${csvTrack.title} ${csvTrack.artist}"
-                val results = musicRepository.searchTracks(query).getOrNull() ?: continue
-                
-                val bestMatch = if (strictAlbumMatch && csvTrack.album.isNotBlank()) {
-                    results.find { it.album?.title?.equals(csvTrack.album, ignoreCase = true) == true }
-                        ?: results.firstOrNull()
-                } else {
-                    results.firstOrNull()
-                }
-
-                if (bestMatch != null) {
-                    libraryRepository.addTrackToPlaylist(playlistId, bestMatch)
-                }
+            playlistImportService.reportFetching("CSV")
+            val parsedPlaylist = csvPlaylistParser.parseFromUri(uri).getOrNull()
+            if (parsedPlaylist == null) {
+                playlistImportService.reportFailure("Could not parse the CSV file")
+                return@launch
             }
+            playlistImportService.importTracks(name, description, parsedPlaylist.tracks, strictAlbumMatch)
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -393,9 +393,9 @@ private fun PermissionRequest(
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 if (shouldShowRationale)
-                    "Monochrome needs access to your audio files to scan and play local music. Please grant the permission."
+                    "Tryptify needs access to your audio files to scan and play local music. Please grant the permission."
                 else
-                    "Grant access to your audio files so Monochrome can scan and play your local music library.",
+                    "Grant access to your audio files so Tryptify can scan and play your local music library.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp)

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -1,5 +1,7 @@
 package tf.monochrome.android.ui.library
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -22,7 +24,6 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Public
-import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -56,6 +57,8 @@ import tf.monochrome.android.ui.components.AddToPlaylistSheet
 import tf.monochrome.android.ui.components.CreatePlaylistDialog
 import tf.monochrome.android.ui.components.TrackContextMenu
 import tf.monochrome.android.ui.components.TrackItem
+import tf.monochrome.android.ui.components.TrackSelectionBar
+import tf.monochrome.android.ui.components.rememberTrackSelectionState
 import tf.monochrome.android.ui.navigation.Screen
 import tf.monochrome.android.ui.navigation.openCatalogArtist
 import tf.monochrome.android.ui.player.PlayerViewModel
@@ -78,6 +81,10 @@ fun PlaylistScreen(
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
+    var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
+
+    val selection = rememberTrackSelectionState<Long>()
+    BackHandler(enabled = selection.active) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -88,6 +95,7 @@ fun PlaylistScreen(
             onAddToQueue = { playerViewModel.addToQueue(listOf(track)) },
             onToggleLike = { playerViewModel.toggleFavorite(track) },
             onAddToPlaylist = { showAddToPlaylistForTrack = track },
+            onRemoveFromPlaylist = { viewModel.removeTrack(track.id) },
             onDownloadTrack = { playerViewModel.downloadTrack(track) },
             onShareFile = { playerViewModel.shareTrack(track) },
             onGoToAlbum = track.album?.id?.let { albumId ->
@@ -111,7 +119,6 @@ fun PlaylistScreen(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = playlists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -120,6 +127,26 @@ fun PlaylistScreen(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = playlists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    tracks.filter { it.id in selection.selectedIds },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -188,6 +215,23 @@ fun PlaylistScreen(
                 containerColor = Color.Transparent
             )
         )
+
+        AnimatedVisibility(visible = selection.active) {
+            TrackSelectionBar(
+                selectedCount = selection.count,
+                onClose = { selection.clear() },
+                onAddToQueue = {
+                    playerViewModel.addToQueue(tracks.filter { it.id in selection.selectedIds })
+                    selection.clear()
+                },
+                onAddToPlaylist = { showAddToPlaylistForSelection = true },
+                onDelete = {
+                    viewModel.removeTracks(selection.selectedIds)
+                    selection.clear()
+                },
+                deleteContentDescription = "Remove from playlist"
+            )
+        }
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -280,37 +324,24 @@ fun PlaylistScreen(
                 }
             } else {
                 items(tracks) { track ->
-                    // In a real app we might want custom TrackItem for playlists to show a remove button
-                    // But we can just use TrackItem with context menu for now.
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        TrackItem(
-                            track = track,
-                            isLiked = favoriteTrackIds.contains(track.id),
-                            onLikeClick = { playerViewModel.toggleFavorite(track) },
-                            onClick = { playerViewModel.playTrack(track, tracks) },
-                            onLongClick = { showContextMenuForTrack = track },
-                            onMoreClick = { showContextMenuForTrack = track },
-                            onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
-                            onAlbumClick = track.album?.id?.let { albumId ->
-                                { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
-                            },
-                            downloadState = activeDownloads[track.id],
-                            modifier = Modifier.weight(1f)
-                        )
-                        IconButton(
-                            onClick = { viewModel.removeTrack(track.id) },
-                            modifier = Modifier.padding(end = 8.dp)
-                        ) {
-                            Icon(
-                                Icons.Default.RemoveCircleOutline,
-                                contentDescription = "Remove from playlist",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
+                    TrackItem(
+                        track = track,
+                        isLiked = favoriteTrackIds.contains(track.id),
+                        onLikeClick = { playerViewModel.toggleFavorite(track) },
+                        onClick = {
+                            if (selection.active) selection.toggle(track.id)
+                            else playerViewModel.playTrack(track, tracks)
+                        },
+                        onLongClick = { selection.toggle(track.id) },
+                        onMoreClick = { showContextMenuForTrack = track },
+                        onArtistClick = { artistId -> navController.openCatalogArtist(artistId) },
+                        onAlbumClick = track.album?.id?.let { albumId ->
+                            { navController.navigate(Screen.AlbumDetail.createRoute(albumId)) }
+                        },
+                        downloadState = activeDownloads[track.id],
+                        selectionMode = selection.active,
+                        selected = track.id in selection.selectedIds
+                    )
                 }
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
@@ -49,6 +49,12 @@ class PlaylistViewModel @Inject constructor(
             libraryRepository.removeTrackFromPlaylist(playlistId, trackId)
         }
     }
+
+    fun removeTracks(trackIds: Collection<Long>) {
+        viewModelScope.launch {
+            trackIds.forEach { libraryRepository.removeTrackFromPlaylist(playlistId, it) }
+        }
+    }
     
     fun deletePlaylist() {
         viewModelScope.launch {

--- a/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var devEditController: tf.monochrome.android.devedit.DevEditController
     @Inject lateinit var preferences: PreferencesManager
     @Inject lateinit var supabaseAuthManager: SupabaseAuthManager
+    @Inject lateinit var spotifyAuthManager: tf.monochrome.android.data.auth.SpotifyAuthManager
     @Inject lateinit var queueManager: QueueManager
     @Inject lateinit var performanceProfile: PerformanceProfile
     @Inject lateinit var libusbDriver: tf.monochrome.android.audio.usb.LibusbUacDriver
@@ -261,10 +262,15 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        // Handle Supabase OAuth callback deep-link
+        // Route OAuth callback deep-links: Spotify (tryptify://spotify-callback)
+        // vs Supabase (tf.monotrypt.android://login-callback)
         val uri = intent.data ?: return
         lifecycleScope.launch {
-            supabaseAuthManager.handleDeepLink(uri)
+            if (uri.scheme == "tryptify" && uri.host == "spotify-callback") {
+                spotifyAuthManager.handleCallback(uri)
+            } else {
+                supabaseAuthManager.handleDeepLink(uri)
+            }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -418,6 +418,38 @@ class PlayerViewModel @Inject constructor(
         queueManager.addToQueue(tracks)
     }
 
+    /**
+     * Queue UnifiedTracks (search results, downloads): register each in the
+     * registry first — same as playAllUnified — so local/Qobuz items resolve
+     * to the right playback source when they come up.
+     */
+    fun addUnifiedToQueue(tracks: List<UnifiedTrack>) {
+        if (tracks.isEmpty()) return
+        tracks.forEach { unifiedTrackRegistry.put(it.toLegacyTrack().id, it) }
+        queueManager.addToQueue(tracks.map { it.toLegacyTrack() })
+    }
+
+    /** Bulk add from multi-select. */
+    fun addTracksToPlaylist(playlistId: String, tracks: List<Track>) {
+        viewModelScope.launch {
+            tracks.forEach { libraryRepository.addTrackToPlaylist(playlistId, it) }
+        }
+    }
+
+    /** Bulk unlike from multi-select. */
+    fun unlikeTracks(trackIds: Collection<Long>) {
+        viewModelScope.launch {
+            libraryRepository.removeFavoriteTracks(trackIds)
+        }
+    }
+
+    /** Bulk remove listening-history entries from multi-select. */
+    fun removeFromHistory(trackIds: Collection<Long>) {
+        viewModelScope.launch {
+            libraryRepository.removeFromHistory(trackIds)
+        }
+    }
+
     /** Insert a track right after the current one. */
     fun playNext(track: Track) {
         queueManager.addNextInQueue(track)

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
@@ -299,7 +299,7 @@ private fun SignedOutView(
             Spacer(modifier = Modifier.height(20.dp))
 
             Text(
-                text = "Sign in to Monochrome",
+                text = "Sign in to Tryptify",
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onBackground

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -1,5 +1,7 @@
 package tf.monochrome.android.ui.search
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Clear
@@ -29,6 +32,7 @@ import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -69,7 +73,9 @@ import tf.monochrome.android.ui.components.LoadingScreen
 import tf.monochrome.android.ui.components.SectionHeader
 import tf.monochrome.android.ui.components.TrackArtistAlbumLine
 import tf.monochrome.android.ui.components.TrackContextMenu
+import tf.monochrome.android.ui.components.TrackSelectionBar
 import tf.monochrome.android.ui.components.bounceCombinedClick
+import tf.monochrome.android.ui.components.rememberTrackSelectionState
 import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.navigation.Screen
 import tf.monochrome.android.ui.navigation.openAlbum
@@ -219,6 +225,11 @@ fun SearchResultsContent(
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
+    var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
+
+    // UnifiedTrack ids are Strings ("api_…", "qobuz_…", "local_…").
+    val selection = rememberTrackSelectionState<String>()
+    BackHandler(enabled = selection.active) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -252,7 +263,6 @@ fun SearchResultsContent(
 
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
-            track = track,
             playlists = libraryPlaylists,
             onDismiss = { showAddToPlaylistForTrack = null },
             onPlaylistSelected = { playlist ->
@@ -261,6 +271,26 @@ fun SearchResultsContent(
             },
             onCreateNew = {
                 showAddToPlaylistForTrack = null
+                showCreatePlaylistDialog = true
+            }
+        )
+    }
+
+    if (showAddToPlaylistForSelection) {
+        AddToPlaylistSheet(
+            title = "Add ${selection.count} tracks to playlist",
+            playlists = libraryPlaylists,
+            onDismiss = { showAddToPlaylistForSelection = false },
+            onPlaylistSelected = { playlist ->
+                playerViewModel.addTracksToPlaylist(
+                    playlist.id,
+                    tracks.filter { it.id in selection.selectedIds }.map { it.toLegacyTrack() },
+                )
+                showAddToPlaylistForSelection = false
+                selection.clear()
+            },
+            onCreateNew = {
+                showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }
         )
@@ -292,9 +322,21 @@ fun SearchResultsContent(
                 onLoadMore(SearchViewModel.SearchPageType.ALBUMS)
             }
 
+            Column(modifier = modifier.fillMaxSize()) {
+            AnimatedVisibility(visible = selection.active) {
+                TrackSelectionBar(
+                    selectedCount = selection.count,
+                    onClose = { selection.clear() },
+                    onAddToQueue = {
+                        playerViewModel.addUnifiedToQueue(tracks.filter { it.id in selection.selectedIds })
+                        selection.clear()
+                    },
+                    onAddToPlaylist = { showAddToPlaylistForSelection = true }
+                )
+            }
             LazyColumn(
                 state = columnState,
-                modifier = modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 80.dp)
             ) {
                 item {
@@ -372,13 +414,19 @@ fun SearchResultsContent(
                             track = track,
                             isLiked = favoriteTrackIds.contains(track.toLegacyTrack().id),
                             onLikeClick = { playerViewModel.toggleFavorite(track.toLegacyTrack()) },
-                            onClick = { playerViewModel.playUnifiedTrack(track, tracks) },
+                            onClick = {
+                                if (selection.active) selection.toggle(track.id)
+                                else playerViewModel.playUnifiedTrack(track, tracks)
+                            },
+                            onLongClick = { selection.toggle(track.id) },
                             onArtistClick = { ref -> ref.id?.let { navController.openArtist(track.sourceType, it) } },
                             onAlbumClick = { navController.openAlbum(track.albumId) },
                             onMoreClick = if (track.sourceType == SourceType.API ||
                                 track.sourceType == SourceType.QOBUZ) {
                                 { showContextMenuForTrack = track.toLegacyTrack() }
-                            } else null
+                            } else null,
+                            selectionMode = selection.active,
+                            selected = track.id in selection.selectedIds
                         )
                     }
                 }
@@ -412,6 +460,7 @@ fun SearchResultsContent(
                         )
                     }
                 }
+            }
             }
         }
     }
@@ -497,17 +546,23 @@ private fun UnifiedSearchTrackItem(
     onClick: () -> Unit,
     onArtistClick: (UnifiedArtistRef) -> Unit,
     onAlbumClick: () -> Unit,
-    onMoreClick: (() -> Unit)?
+    onMoreClick: (() -> Unit)?,
+    onLongClick: (() -> Unit)? = null,
+    selectionMode: Boolean = false,
+    selected: Boolean = false
 ) {
     val legacyTrack = track.toLegacyTrack()
+    // Same treatment as TrackItem: hide per-row affordances while selecting.
+    val effectiveOnLikeClick = onLikeClick.takeUnless { selectionMode }
+    val effectiveOnMoreClick = onMoreClick.takeUnless { selectionMode }
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingXs)
-            .bounceCombinedClick(onClick = onClick, onLongClick = onMoreClick)
+            .bounceCombinedClick(onClick = onClick, onLongClick = onLongClick ?: onMoreClick)
             .liquidGlass(shape = MonoDimens.shapeMd),
         shape = MonoDimens.shapeMd,
-        color = Color.Transparent
+        color = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f) else Color.Transparent
     ) {
         Row(
             modifier = Modifier
@@ -515,6 +570,14 @@ private fun UnifiedSearchTrackItem(
                 .padding(horizontal = MonoDimens.listItemPaddingH, vertical = MonoDimens.spacingSm),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            if (selectionMode) {
+                Icon(
+                    imageVector = if (selected) Icons.Default.CheckCircle else Icons.Outlined.Circle,
+                    contentDescription = if (selected) "Selected" else "Not selected",
+                    tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.width(MonoDimens.spacingMd))
+            }
             if (track.artworkUri != null) {
                 CoverImage(
                     url = track.artworkUri,
@@ -550,8 +613,8 @@ private fun UnifiedSearchTrackItem(
                 )
                 TrackArtistAlbumLine(
                     track = track,
-                    onArtistClick = onArtistClick,
-                    onAlbumClick = onAlbumClick,
+                    onArtistClick = if (selectionMode) ({}) else onArtistClick,
+                    onAlbumClick = if (selectionMode) ({}) else onAlbumClick,
                 )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -561,20 +624,22 @@ private fun UnifiedSearchTrackItem(
                     track.qualityBadge?.let { ResultBadge(text = it) }
                 }
             }
-            IconButton(onClick = onLikeClick) {
-                Icon(
-                    imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-                    contentDescription = if (isLiked) "Unlike" else "Like",
-                    tint = if (isLiked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            if (effectiveOnLikeClick != null) {
+                IconButton(onClick = effectiveOnLikeClick) {
+                    Icon(
+                        imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                        contentDescription = if (isLiked) "Unlike" else "Like",
+                        tint = if (isLiked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
             Text(
                 text = legacyTrack.formattedDuration,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            if (onMoreClick != null) {
-                IconButton(onClick = onMoreClick) {
+            if (effectiveOnMoreClick != null) {
+                IconButton(onClick = effectiveOnMoreClick) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
                         contentDescription = "More options",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1625,25 +1625,159 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
 
         Spacer(modifier = Modifier.height(20.dp))
         SettingsGroupHeader("Playlist Import")
+        val spotifyViewModel: SpotifyImportViewModel = hiltViewModel()
+        val spotifyConnected by spotifyViewModel.isConnected.collectAsState()
+        val spotifyUserName by spotifyViewModel.userName.collectAsState()
+        val spotifyConnecting by spotifyViewModel.isConnecting.collectAsState()
+        val spotifyAuthError by spotifyViewModel.authError.collectAsState()
+        val importProgress by spotifyViewModel.importProgress.collectAsState()
+        val isImporting by spotifyViewModel.isImporting.collectAsState()
+        var showSpotifyPicker by remember { mutableStateOf(false) }
         var importUrl by remember { mutableStateOf("") }
+
+        val onImportResult: (Boolean, String) -> Unit = { success, msg ->
+            android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_LONG).show()
+            if (success) importUrl = ""
+        }
+
+        if (spotifyConnected) {
+            SettingItem(
+                title = "Spotify",
+                subtitle = "Connected as ${spotifyUserName ?: "…"}",
+                onClick = {}
+            )
+            OutlinedButton(onClick = { spotifyViewModel.disconnect() }) {
+                Text("Disconnect Spotify")
+            }
+        } else {
+            Text(
+                "Connect your Spotify account to import playlists directly. " +
+                    "Note: only Spotify accounts allowlisted for this app can connect while it is in Development mode.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Button(
+                onClick = { spotifyViewModel.connect(context) },
+                enabled = !spotifyConnecting
+            ) {
+                Text(if (spotifyConnecting) "Connecting…" else "Connect Spotify")
+            }
+        }
+        spotifyAuthError?.let { error ->
+            Text(
+                error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
         androidx.compose.material3.OutlinedTextField(
             value = importUrl,
             onValueChange = { importUrl = it },
-            label = { Text("Spotify / YT Music URL") },
+            label = { Text("Spotify playlist URL") },
             modifier = Modifier.fillMaxWidth(),
-            singleLine = true
+            singleLine = true,
+            enabled = spotifyConnected,
+            supportingText = if (!spotifyConnected) {
+                { Text("Connect Spotify above to enable URL import") }
+            } else null
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Button(
-            onClick = {
-                viewModel.importPlaylist(importUrl) { success, msg ->
-                    android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_LONG).show()
-                    if (success) importUrl = ""
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = { spotifyViewModel.importByUrl(importUrl, onResult = onImportResult) },
+                enabled = spotifyConnected && importUrl.isNotBlank() && !isImporting
+            ) {
+                Text("Import Playlist")
+            }
+            OutlinedButton(
+                onClick = {
+                    spotifyViewModel.loadMyPlaylists()
+                    showSpotifyPicker = true
+                },
+                enabled = spotifyConnected && !isImporting
+            ) {
+                Text("Browse My Playlists")
+            }
+        }
+
+        when (val progress = importProgress) {
+            is tf.monochrome.android.data.import_.ImportProgress.Fetching -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                androidx.compose.material3.LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Text(
+                    "Fetching playlist from ${progress.source}…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is tf.monochrome.android.data.import_.ImportProgress.Matching -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                androidx.compose.material3.LinearProgressIndicator(
+                    progress = { progress.current.toFloat() / progress.total.coerceAtLeast(1) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    "Matching ${progress.current}/${progress.total} — ${progress.matched} found",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is tf.monochrome.android.data.import_.ImportProgress.Done -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "Imported ${progress.matched} of ${progress.total} tracks into '${progress.playlistName}'",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (progress.unmatched.isNotEmpty()) {
+                    var showUnmatched by remember { mutableStateOf(false) }
+                    TextButton(onClick = { showUnmatched = !showUnmatched }) {
+                        Text(if (showUnmatched) "Hide unmatched tracks" else "Show ${progress.unmatched.size} unmatched tracks")
+                    }
+                    if (showUnmatched) {
+                        progress.unmatched.forEach { line ->
+                            Text(
+                                line,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
-            },
-            enabled = importUrl.isNotBlank()
-        ) {
-            Text("Import Playlist")
+            }
+            is tf.monochrome.android.data.import_.ImportProgress.Failed -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    progress.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            tf.monochrome.android.data.import_.ImportProgress.Idle -> {}
+        }
+
+        if (showSpotifyPicker) {
+            val spotifyPlaylists by spotifyViewModel.myPlaylists.collectAsState()
+            val playlistsLoading by spotifyViewModel.playlistsLoading.collectAsState()
+            val playlistsError by spotifyViewModel.playlistsError.collectAsState()
+            tf.monochrome.android.ui.components.SpotifyPlaylistPickerDialog(
+                playlists = spotifyPlaylists,
+                isLoading = playlistsLoading,
+                error = playlistsError,
+                onPick = { playlistId, name, strict ->
+                    showSpotifyPicker = false
+                    spotifyViewModel.importPlaylist(playlistId, name, strict, onImportResult)
+                },
+                onPickLikedSongs = { strict ->
+                    showSpotifyPicker = false
+                    spotifyViewModel.importLikedSongs(strict, onImportResult)
+                },
+                onDismiss = { showSpotifyPicker = false }
+            )
         }
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -450,19 +450,13 @@ class SettingsViewModel @Inject constructor(
     // --- Playlist Import actions ---
     fun importPlaylist(url: String, onResult: (Boolean, String) -> Unit) {
         viewModelScope.launch {
-            val result = playlistImporter.importFromUrl(url)
-            result.onSuccess { tracks ->
-                if (tracks.isNotEmpty()) {
-                    // Create playlist and add tracks
-                    val id = preferences.customApiEndpoint.first() ?: "Imported"
-                    // Real implementation would use libraryRepository.createPlaylist(name, ...)
-                    onResult(true, "Imported ${tracks.size} tracks")
-                } else {
-                    onResult(false, "No tracks found or matched")
+            playlistImporter.importFromUrl(url)
+                .onSuccess { done ->
+                    onResult(true, "Imported ${done.matched}/${done.total} tracks into '${done.playlistName}'")
                 }
-            }.onFailure {
-                onResult(false, it.message ?: "Import failed")
-            }
+                .onFailure {
+                    onResult(false, it.message ?: "Import failed")
+                }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SpotifyImportViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SpotifyImportViewModel.kt
@@ -1,0 +1,116 @@
+package tf.monochrome.android.ui.settings
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import tf.monochrome.android.data.api.SpotifyApiClient
+import tf.monochrome.android.data.api.SpotifySimplePlaylist
+import tf.monochrome.android.data.auth.SpotifyAuthManager
+import tf.monochrome.android.data.import_.ImportProgress
+import tf.monochrome.android.data.import_.PlaylistImportService
+import tf.monochrome.android.data.import_.PlaylistImporter
+import javax.inject.Inject
+
+/**
+ * Drives the "Playlist Import" section in Settings → System: Spotify
+ * connect/disconnect, the my-playlists picker, and URL/Liked-Songs imports.
+ * Kept separate from the already-large SettingsViewModel.
+ */
+@HiltViewModel
+class SpotifyImportViewModel @Inject constructor(
+    private val spotifyAuthManager: SpotifyAuthManager,
+    private val spotifyApiClient: SpotifyApiClient,
+    private val playlistImporter: PlaylistImporter,
+    playlistImportService: PlaylistImportService,
+) : ViewModel() {
+
+    val isConnected: StateFlow<Boolean> = spotifyAuthManager.isConnected
+    val userName: StateFlow<String?> = spotifyAuthManager.connectedUserName
+    val isConnecting: StateFlow<Boolean> = spotifyAuthManager.isConnecting
+    val authError: StateFlow<String?> = spotifyAuthManager.errorMessage
+    val importProgress: StateFlow<ImportProgress> = playlistImportService.progress
+
+    private val _myPlaylists = MutableStateFlow<List<SpotifySimplePlaylist>>(emptyList())
+    val myPlaylists: StateFlow<List<SpotifySimplePlaylist>> = _myPlaylists.asStateFlow()
+
+    private val _playlistsLoading = MutableStateFlow(false)
+    val playlistsLoading: StateFlow<Boolean> = _playlistsLoading.asStateFlow()
+
+    private val _playlistsError = MutableStateFlow<String?>(null)
+    val playlistsError: StateFlow<String?> = _playlistsError.asStateFlow()
+
+    private val _isImporting = MutableStateFlow(false)
+    val isImporting: StateFlow<Boolean> = _isImporting.asStateFlow()
+
+    init {
+        // After the OAuth callback lands we only have tokens — fill in the
+        // "Connected as ..." display name (also heals installs that
+        // connected before a name was stored).
+        viewModelScope.launch {
+            spotifyAuthManager.isConnected.collect { connected ->
+                if (connected && userName.value.isNullOrBlank()) {
+                    spotifyApiClient.getCurrentUser().onSuccess { profile ->
+                        spotifyAuthManager.setConnectedUserName(
+                            profile.displayName?.takeIf { it.isNotBlank() } ?: profile.id,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun connect(context: Context) = spotifyAuthManager.connect(context)
+
+    fun disconnect() {
+        viewModelScope.launch {
+            spotifyAuthManager.disconnect()
+            _myPlaylists.value = emptyList()
+        }
+    }
+
+    fun clearAuthError() = spotifyAuthManager.clearError()
+
+    fun loadMyPlaylists() {
+        viewModelScope.launch {
+            _playlistsLoading.value = true
+            _playlistsError.value = null
+            spotifyApiClient.getMyPlaylists()
+                .onSuccess { _myPlaylists.value = it }
+                .onFailure { _playlistsError.value = it.message }
+            _playlistsLoading.value = false
+        }
+    }
+
+    fun importByUrl(url: String, strictAlbumMatch: Boolean = false, onResult: (Boolean, String) -> Unit) {
+        runImport(onResult) { playlistImporter.importFromUrl(url, strictAlbumMatch) }
+    }
+
+    fun importPlaylist(playlistId: String, name: String, strictAlbumMatch: Boolean = false, onResult: (Boolean, String) -> Unit) {
+        runImport(onResult) { playlistImporter.importSpotifyPlaylist(playlistId, name, strictAlbumMatch) }
+    }
+
+    fun importLikedSongs(strictAlbumMatch: Boolean = false, onResult: (Boolean, String) -> Unit) {
+        runImport(onResult) { playlistImporter.importSpotifyLikedSongs(strictAlbumMatch) }
+    }
+
+    private fun runImport(
+        onResult: (Boolean, String) -> Unit,
+        import: suspend () -> Result<ImportProgress.Done>,
+    ) {
+        if (_isImporting.value) return
+        viewModelScope.launch {
+            _isImporting.value = true
+            import()
+                .onSuccess { done ->
+                    onResult(true, "Imported ${done.matched}/${done.total} tracks into '${done.playlistName}'")
+                }
+                .onFailure { onResult(false, it.message ?: "Import failed") }
+            _isImporting.value = false
+        }
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/data/import_/PlaylistImporterTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/import_/PlaylistImporterTest.kt
@@ -1,0 +1,57 @@
+package tf.monochrome.android.data.import_
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PlaylistImporterTest {
+
+    @Test
+    fun `extracts id from standard open spotify url`() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            PlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+            ),
+        )
+    }
+
+    @Test
+    fun `extracts id from url with query params`() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            PlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M?si=abc123&pt=xyz",
+            ),
+        )
+    }
+
+    @Test
+    fun `extracts id from intl url`() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            PlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/intl-fr/playlist/37i9dQZF1DXcBWIGoYBM5M?si=x",
+            ),
+        )
+    }
+
+    @Test
+    fun `extracts id from spotify uri`() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            PlaylistImporter.extractSpotifyPlaylistId("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
+        )
+    }
+
+    @Test
+    fun `rejects non playlist urls`() {
+        assertNull(
+            PlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy",
+            ),
+        )
+        assertNull(PlaylistImporter.extractSpotifyPlaylistId("https://music.youtube.com/playlist?list=PLx"))
+        assertNull(PlaylistImporter.extractSpotifyPlaylistId("not a url"))
+    }
+}


### PR DESCRIPTION
Replace the stub PlaylistImporter with a real Spotify integration:

- SpotifyAuthManager: Authorization Code + PKCE flow via Custom Tab,
  tryptify://spotify-callback deep link, token storage in DataStore,
  auto-refresh with rotated refresh-token persistence
- SpotifyApiClient: playlist metadata/tracks, my-playlists, Liked Songs
  with pagination, 401 retry-after-refresh, 429 Retry-After handling,
  and a Development-mode 403 explanation
- PlaylistImportService: shared create->match->add pipeline extracted
  from LibraryViewModel.importCsvPlaylist, now with an observable
  ImportProgress StateFlow (CSV import gains progress reporting too)
- Settings > System: Connect/Disconnect Spotify, playlist URL import,
  Browse My Playlists picker (incl. Liked Songs), live matching
  progress and unmatched-track summary
- Unit tests for Spotify playlist URL/URI parsing