### PR TITLE
Fix memory leaks in album-art color extraction

### DIFF
--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
@@ -85,7 +85,7 @@ fun rememberAlbumColors(imageUrl: String?): AlbumColors {
                 .allowHardware(false)
                 .size(256, 256)
                 .build()
-            val result = ImageLoader(context).execute(request)
+            val result = SingletonImageLoader.get(context).execute(request)
             (result as? SuccessResult)?.image?.toBitmap()
         } catch (_: Exception) {
             null

--- a/app/src/main/java/tf/monochrome/android/ui/theme/DynamicColorExtractor.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/theme/DynamicColorExtractor.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.palette.graphics.Palette
-import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
@@ -35,18 +35,19 @@ data class DynamicPalette(
 /**
  * Extracts a [DynamicPalette] from a cover image URL off the main thread.
  *
- * Results are memoized in a small in-memory map so repeated renders of the
- * same track don't re-run Palette. The cache is intentionally unbounded but
- * process-scoped; the dataset is small (one entry per distinct cover in a
- * session) and the app restart clears it.
+ * Results are memoized in a bounded LruCache so repeated renders of the same
+ * track don't re-run Palette, while a long listening session cycling through
+ * hundreds of covers can't grow the map without limit. LruCache is internally
+ * synchronized, which also covers concurrent extract() calls from multiple
+ * composables.
  */
 object DynamicColorExtractor {
 
-    private val cache = mutableMapOf<String, DynamicPalette>()
+    private val cache = android.util.LruCache<String, DynamicPalette>(128)
 
     suspend fun extract(context: Context, coverUrl: String?): DynamicPalette? {
         if (coverUrl.isNullOrBlank()) return null
-        cache[coverUrl]?.let { return it }
+        cache.get(coverUrl)?.let { return it }
 
         val bitmap = loadBitmap(context, coverUrl) ?: return null
         val palette = withContext(Dispatchers.Default) {
@@ -73,13 +74,18 @@ object DynamicColorExtractor {
             secondary = Color(secondarySwatch.rgb),
             onSecondary = Color(secondarySwatch.bodyTextColor)
         )
-        cache[coverUrl] = dp
+        cache.put(coverUrl, dp)
         return dp
     }
 
     private suspend fun loadBitmap(context: Context, url: String): Bitmap? {
         return try {
-            val loader = ImageLoader(context)
+            // Reuse the app-wide singleton loader (MonochromeApp tunes its
+            // memory/disk caches per device tier). Building a fresh
+            // ImageLoader here would allocate a new memory cache per track
+            // change that is never shut down, and re-fetch covers Coil has
+            // already cached.
+            val loader = SingletonImageLoader.get(context)
             val request = ImageRequest.Builder(context)
                 .data(url)
                 // Palette needs pixel-readable (software) bitmaps.


### PR DESCRIPTION
Both DynamicColorExtractor and rememberAlbumColors built a fresh Coil ImageLoader on every track change. Each loader allocates its own memory cache that is never shut down, so decoded full-size software bitmaps piled up until GC, and every extraction bypassed the app's tuned singleton caches (re-downloading and re-decoding covers Coil already had). Both paths now reuse the app-wide loader via SingletonImageLoader.get().

Also bound DynamicColorExtractor's palette memo cache with an LruCache: the previous plain mutableMapOf grew without limit over a long session and was written concurrently from multiple composables without synchronization.