### PR TITLE
Lyrics FX + liquid-glass player overhaul, and Supabase settings sync

### DIFF
--- a/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
+++ b/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
@@ -84,6 +84,9 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
     @Inject
     lateinit var usbExclusiveController: tf.monochrome.android.audio.usb.UsbExclusiveController
 
+    @Inject
+    lateinit var settingsSyncCoordinator: tf.monochrome.android.data.sync.SettingsSyncCoordinator
+
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override val workManagerConfiguration: Configuration
@@ -168,6 +171,9 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
                     else deviceRegistry.clearOnSignOut()
                 }
         }
+        // Auto-save app settings to the user's Supabase row: pull on sign-in,
+        // then push (debounced) whenever an allow-listed setting changes.
+        settingsSyncCoordinator.start(appScope)
     }
 
     private fun registerPlaybackNotificationChannel() {

--- a/app/src/main/java/tf/monochrome/android/data/db/dao/PlayEventDao.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/dao/PlayEventDao.kt
@@ -32,6 +32,10 @@ interface PlayEventDao {
     @Query("SELECT * FROM play_events ORDER BY playedAt DESC LIMIT :limit")
     suspend fun getRecent(limit: Int = 1000): List<PlayEventEntity>
 
+    /** Events not yet pushed to the cloud (cloudRowId IS NULL) — for pushAll. */
+    @Query("SELECT * FROM play_events WHERE cloudRowId IS NULL ORDER BY playedAt DESC LIMIT :limit")
+    suspend fun getUnsynced(limit: Int = 1000): List<PlayEventEntity>
+
     @Query("DELETE FROM play_events WHERE playedAt < :cutoff")
     suspend fun deleteOlderThan(cutoff: Long)
 

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -247,6 +248,48 @@ class PreferencesManager @Inject constructor(
 
         // Onboarding
         private val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
+
+        // ── Settings cloud-sync allow-list ───────────────────────────────────
+        // ONLY these preferences are exported to the user's Supabase settings
+        // row. It is an allow-list on purpose: anything NOT here (auth tokens &
+        // OAuth secrets, device ids, per-device GPU/fps tuning, device-local
+        // file/SAF paths, caches, transient player state, one-shot flags, and
+        // the legacy lyrics keys superseded by LYRICS_FX_JSON) never leaves the
+        // device — and a newly added key defaults to "not synced" until it's
+        // deliberately added here.
+        val SETTINGS_SYNC_KEYS: Set<Preferences.Key<*>> = setOf(
+            WIFI_QUALITY, CELLULAR_QUALITY, REPLAY_GAIN_MODE, REPLAY_GAIN_PREAMP,
+            THEME, DYNAMIC_COLORS, FONT_SCALE,
+            GAPLESS_PLAYBACK, SHOW_EXPLICIT_BADGES, CONFIRM_CLEAR_QUEUE,
+            NORMALIZATION_ENABLED, CROSSFADE_DURATION, MULTICHANNEL_DOWNMIX_ENABLED,
+            PLAYBACK_SPEED, PRESERVE_PITCH,
+            DOWNLOAD_QUALITY, DOWNLOAD_LYRICS,
+            LASTFM_ENABLED, LASTFM_USERNAME, LISTENBRAINZ_ENABLED,
+            CUSTOM_API_ENDPOINT, QOBUZ_INSTANCE_URL, SOURCE_MODE, DEV_MODE_ENABLED,
+            NOW_PLAYING_VIEW_MODE, PLAYER_DYNAMIC_COLOR, PLAYER_BLURRED_BACKGROUND,
+            ROMAJI_LYRICS, LYRICS_WORD_PROVIDER,
+            LYRICS_FX_JSON, LYRICS_FX_CUSTOM_PRESETS_JSON,
+            VISUALIZER_SENSITIVITY, VISUALIZER_BRIGHTNESS,
+            VISUALIZER_ENGINE_ENABLED, VISUALIZER_AUTO_SHUFFLE, VISUALIZER_PRESET_ID,
+            VISUALIZER_ROTATION_SECONDS, VISUALIZER_SHOW_FPS, VISUALIZER_FULLSCREEN,
+            VISUALIZER_TOUCH_WAVEFORM, VISUALIZER_FAVORITE_PRESETS,
+            SPECTRUM_ANALYZER_ENABLED, SPECTRUM_SHOW_ON_NOW_PLAYING, SPECTRUM_FFT_SIZE,
+            EQ_ENABLED, EQ_ACTIVE_PRESET_ID, EQ_TARGET_ID, EQ_PREAMP, EQ_BANDS_JSON,
+            EQ_CUSTOM_TARGETS_JSON, EQ_SELECTED_HEADPHONE_ID, EQ_SELECTED_HEADPHONE_NAME,
+            EQ_UPLOADED_HEADPHONES_JSON,
+            PARAM_EQ_ENABLED, PARAM_EQ_ACTIVE_PRESET_ID, PARAM_EQ_PREAMP, PARAM_EQ_BANDS_JSON,
+            DSP_ENABLED, DSP_STATE_JSON, MIXER_CHANNEL_DYNAMIC,
+            SCAN_ON_APP_OPEN, MIN_TRACK_DURATION_MS, BACKGROUND_SCAN_INTERVAL,
+            LIBRARY_TAB_ORDER, CAR_MODE_BAND_COUNT,
+            AI_RADIO_ENABLED, RADIO_PLANNER_ENABLED, RADIO_PLANNER_URL,
+            RADIO_WEIGHT_LOCAL_LIBRARY, RADIO_WEIGHT_QOBUZ, RADIO_WEIGHT_SPOTIFY_DISCOVERY,
+            RADIO_WEIGHT_METABRAINZ_METADATA, RADIO_WEIGHT_LISTENBRAINZ_GRAPH,
+            RADIO_WEIGHT_CANONICAL_VERSION_BIAS, RADIO_WEIGHT_NOVELTY, RADIO_WEIGHT_FAMILIARITY,
+            RADIO_WEIGHT_ARTIST_SIMILARITY, RADIO_WEIGHT_GENRE_TAG_SIMILARITY,
+            RADIO_WEIGHT_MOOD_CONTINUITY, RADIO_WEIGHT_ERA_CONSISTENCY,
+            RADIO_WEIGHT_AVOID_RECENTLY_PLAYED, RADIO_WEIGHT_DISCOVERY_DISTANCE,
+        )
+        private val SETTINGS_SYNC_KEY_NAMES: Set<String> = SETTINGS_SYNC_KEYS.map { it.name }.toSet()
     }
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -1197,6 +1240,51 @@ class PreferencesManager @Inject constructor(
 
     suspend fun setCustomLyricsFxPresets(presets: List<tf.monochrome.android.domain.model.LyricsFxPreset>) {
         dataStore.edit { it[LYRICS_FX_CUSTOM_PRESETS_JSON] = json.encodeToString(presets) }
+    }
+
+    // ── Settings cloud-sync (export / import the allow-listed prefs) ─────────
+
+    /** A tagged-JSON snapshot of only the [SETTINGS_SYNC_KEYS] prefs. */
+    suspend fun exportSettingsJson(): String =
+        SettingsSyncCodec.encode(syncSnapshotOf(dataStore.data.first()))
+
+    /** The allow-listed subset of a Preferences snapshot, keyed by name. */
+    private fun syncSnapshotOf(prefs: Preferences): Map<String, Any> =
+        prefs.asMap()
+            .filterKeys { it in SETTINGS_SYNC_KEYS }
+            .mapKeys { it.key.name }
+
+    /**
+     * Apply a settings snapshot pulled from the cloud, in a single atomic edit.
+     * Only keys on the allow-list are written (a hostile/stale blob can't set
+     * excluded or unknown keys), and each is stored under a freshly reconstructed
+     * key of the decoded value's type.
+     */
+    suspend fun importSettingsJson(payload: String) {
+        val decoded = SettingsSyncCodec.decode(payload)
+        if (decoded.isEmpty()) return
+        dataStore.edit { prefs ->
+            decoded.forEach { (name, value) ->
+                if (name !in SETTINGS_SYNC_KEY_NAMES) return@forEach
+                when (value) {
+                    is Boolean -> prefs[booleanPreferencesKey(name)] = value
+                    is Int -> prefs[intPreferencesKey(name)] = value
+                    is Long -> prefs[longPreferencesKey(name)] = value
+                    is Float -> prefs[floatPreferencesKey(name)] = value
+                    is Double -> prefs[doublePreferencesKey(name)] = value
+                    is String -> prefs[stringPreferencesKey(name)] = value
+                    is Set<*> -> prefs[stringSetPreferencesKey(name)] = value.map { it.toString() }.toSet()
+                }
+            }
+        }
+    }
+
+    /**
+     * Emits the allow-listed settings snapshot whenever any synced pref changes.
+     * The [SettingsSyncCoordinator] debounces this to push changes to the cloud.
+     */
+    val settingsSyncSnapshot: Flow<String> = dataStore.data.map { prefs ->
+        SettingsSyncCodec.encode(syncSnapshotOf(prefs))
     }
 
     // --- Player appearance ---

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -96,6 +96,8 @@ class PreferencesManager @Inject constructor(
         private val LYRICS_FX_JSON = stringPreferencesKey("lyrics_fx_json")
         // User-saved Lyrics FX presets (a JSON array of {name, settings}).
         private val LYRICS_FX_CUSTOM_PRESETS_JSON = stringPreferencesKey("lyrics_fx_custom_presets_json")
+        // Player-chrome (transport button) liquid-glass settings, one JSON blob.
+        private val PLAYER_GLASS_JSON = stringPreferencesKey("player_glass_json")
 
         // Player / display
         private val PLAYER_DYNAMIC_COLOR = booleanPreferencesKey("player_dynamic_color")
@@ -268,7 +270,7 @@ class PreferencesManager @Inject constructor(
             CUSTOM_API_ENDPOINT, QOBUZ_INSTANCE_URL, SOURCE_MODE, DEV_MODE_ENABLED,
             NOW_PLAYING_VIEW_MODE, PLAYER_DYNAMIC_COLOR, PLAYER_BLURRED_BACKGROUND,
             ROMAJI_LYRICS, LYRICS_WORD_PROVIDER,
-            LYRICS_FX_JSON, LYRICS_FX_CUSTOM_PRESETS_JSON,
+            LYRICS_FX_JSON, LYRICS_FX_CUSTOM_PRESETS_JSON, PLAYER_GLASS_JSON,
             VISUALIZER_SENSITIVITY, VISUALIZER_BRIGHTNESS,
             VISUALIZER_ENGINE_ENABLED, VISUALIZER_AUTO_SHUFFLE, VISUALIZER_PRESET_ID,
             VISUALIZER_ROTATION_SECONDS, VISUALIZER_SHOW_FPS, VISUALIZER_FULLSCREEN,
@@ -1240,6 +1242,18 @@ class PreferencesManager @Inject constructor(
 
     suspend fun setCustomLyricsFxPresets(presets: List<tf.monochrome.android.domain.model.LyricsFxPreset>) {
         dataStore.edit { it[LYRICS_FX_CUSTOM_PRESETS_JSON] = json.encodeToString(presets) }
+    }
+
+    /** Player-chrome (transport button) liquid-glass settings. */
+    val playerGlass: Flow<tf.monochrome.android.domain.model.PlayerGlassSettings> = dataStore.data.map { prefs ->
+        prefs[PLAYER_GLASS_JSON]
+            ?.let { raw -> runCatching { json.decodeFromString<tf.monochrome.android.domain.model.PlayerGlassSettings>(raw) }.getOrNull() }
+            ?.clamped()
+            ?: tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT
+    }
+
+    suspend fun setPlayerGlass(settings: tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        dataStore.edit { it[PLAYER_GLASS_JSON] = json.encodeToString(settings.clamped()) }
     }
 
     // ── Settings cloud-sync (export / import the allow-listed prefs) ─────────

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -100,6 +100,9 @@ class PreferencesManager @Inject constructor(
         private val PLAYER_GLASS_JSON = stringPreferencesKey("player_glass_json")
         // User-saved Player Glass themes (a JSON array of {name, settings}).
         private val PLAYER_GLASS_CUSTOM_PRESETS_JSON = stringPreferencesKey("player_glass_custom_presets_json")
+        // Mini-player liquid-glass settings — same shape as PLAYER_GLASS_JSON but
+        // tuned independently (Lyrics FX Studio › "Mini Player" tab).
+        private val MINI_PLAYER_GLASS_JSON = stringPreferencesKey("mini_player_glass_json")
 
         // Player / display
         private val PLAYER_DYNAMIC_COLOR = booleanPreferencesKey("player_dynamic_color")
@@ -273,7 +276,7 @@ class PreferencesManager @Inject constructor(
             NOW_PLAYING_VIEW_MODE, PLAYER_DYNAMIC_COLOR, PLAYER_BLURRED_BACKGROUND,
             ROMAJI_LYRICS, LYRICS_WORD_PROVIDER,
             LYRICS_FX_JSON, LYRICS_FX_CUSTOM_PRESETS_JSON, PLAYER_GLASS_JSON,
-            PLAYER_GLASS_CUSTOM_PRESETS_JSON,
+            PLAYER_GLASS_CUSTOM_PRESETS_JSON, MINI_PLAYER_GLASS_JSON,
             VISUALIZER_SENSITIVITY, VISUALIZER_BRIGHTNESS,
             VISUALIZER_ENGINE_ENABLED, VISUALIZER_AUTO_SHUFFLE, VISUALIZER_PRESET_ID,
             VISUALIZER_ROTATION_SECONDS, VISUALIZER_SHOW_FPS, VISUALIZER_FULLSCREEN,
@@ -1257,6 +1260,18 @@ class PreferencesManager @Inject constructor(
 
     suspend fun setPlayerGlass(settings: tf.monochrome.android.domain.model.PlayerGlassSettings) {
         dataStore.edit { it[PLAYER_GLASS_JSON] = json.encodeToString(settings.clamped()) }
+    }
+
+    /** Mini-player glass settings (its own blob, same shape as [playerGlass]). */
+    val miniPlayerGlass: Flow<tf.monochrome.android.domain.model.PlayerGlassSettings> = dataStore.data.map { prefs ->
+        prefs[MINI_PLAYER_GLASS_JSON]
+            ?.let { raw -> runCatching { json.decodeFromString<tf.monochrome.android.domain.model.PlayerGlassSettings>(raw) }.getOrNull() }
+            ?.clamped()
+            ?: tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT
+    }
+
+    suspend fun setMiniPlayerGlass(settings: tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        dataStore.edit { it[MINI_PLAYER_GLASS_JSON] = json.encodeToString(settings.clamped()) }
     }
 
     /** User-saved Player Glass themes (empty until the user saves one). */

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -98,6 +98,8 @@ class PreferencesManager @Inject constructor(
         private val LYRICS_FX_CUSTOM_PRESETS_JSON = stringPreferencesKey("lyrics_fx_custom_presets_json")
         // Player-chrome (transport button) liquid-glass settings, one JSON blob.
         private val PLAYER_GLASS_JSON = stringPreferencesKey("player_glass_json")
+        // User-saved Player Glass themes (a JSON array of {name, settings}).
+        private val PLAYER_GLASS_CUSTOM_PRESETS_JSON = stringPreferencesKey("player_glass_custom_presets_json")
 
         // Player / display
         private val PLAYER_DYNAMIC_COLOR = booleanPreferencesKey("player_dynamic_color")
@@ -271,6 +273,7 @@ class PreferencesManager @Inject constructor(
             NOW_PLAYING_VIEW_MODE, PLAYER_DYNAMIC_COLOR, PLAYER_BLURRED_BACKGROUND,
             ROMAJI_LYRICS, LYRICS_WORD_PROVIDER,
             LYRICS_FX_JSON, LYRICS_FX_CUSTOM_PRESETS_JSON, PLAYER_GLASS_JSON,
+            PLAYER_GLASS_CUSTOM_PRESETS_JSON,
             VISUALIZER_SENSITIVITY, VISUALIZER_BRIGHTNESS,
             VISUALIZER_ENGINE_ENABLED, VISUALIZER_AUTO_SHUFFLE, VISUALIZER_PRESET_ID,
             VISUALIZER_ROTATION_SECONDS, VISUALIZER_SHOW_FPS, VISUALIZER_FULLSCREEN,
@@ -1254,6 +1257,23 @@ class PreferencesManager @Inject constructor(
 
     suspend fun setPlayerGlass(settings: tf.monochrome.android.domain.model.PlayerGlassSettings) {
         dataStore.edit { it[PLAYER_GLASS_JSON] = json.encodeToString(settings.clamped()) }
+    }
+
+    /** User-saved Player Glass themes (empty until the user saves one). */
+    val customPlayerGlassPresets: Flow<List<tf.monochrome.android.domain.model.PlayerGlassPreset>> =
+        dataStore.data.map { prefs ->
+            prefs[PLAYER_GLASS_CUSTOM_PRESETS_JSON]
+                ?.let { raw ->
+                    runCatching {
+                        json.decodeFromString<List<tf.monochrome.android.domain.model.PlayerGlassPreset>>(raw)
+                    }.getOrNull()
+                }
+                ?.map { it.copy(settings = it.settings.clamped()) }
+                ?: emptyList()
+        }
+
+    suspend fun setCustomPlayerGlassPresets(presets: List<tf.monochrome.android.domain.model.PlayerGlassPreset>) {
+        dataStore.edit { it[PLAYER_GLASS_CUSTOM_PRESETS_JSON] = json.encodeToString(presets) }
     }
 
     // ── Settings cloud-sync (export / import the allow-listed prefs) ─────────

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -96,6 +96,7 @@ class PreferencesManager @Inject constructor(
 
         // Player / display
         private val PLAYER_DYNAMIC_COLOR = booleanPreferencesKey("player_dynamic_color")
+        private val PLAYER_BLURRED_BACKGROUND = booleanPreferencesKey("player_blurred_background")
         private val APP_TARGET_FPS = intPreferencesKey("app_target_fps")
         private val APP_RENDER_RESOLUTION = intPreferencesKey("app_render_resolution")
 
@@ -1183,6 +1184,13 @@ class PreferencesManager @Inject constructor(
     val playerDynamicColor: Flow<Boolean> = dataStore.data.map { it[PLAYER_DYNAMIC_COLOR] ?: true }
     suspend fun setPlayerDynamicColor(enabled: Boolean) {
         dataStore.edit { it[PLAYER_DYNAMIC_COLOR] = enabled }
+    }
+
+    // Full-screen blurred, stretched album-art background behind the player
+    // (Apple-Music / Spotify style). Off by default (keeps the flat gradient).
+    val playerBlurredBackground: Flow<Boolean> = dataStore.data.map { it[PLAYER_BLURRED_BACKGROUND] ?: false }
+    suspend fun setPlayerBlurredBackground(enabled: Boolean) {
+        dataStore.edit { it[PLAYER_BLURRED_BACKGROUND] = enabled }
     }
 
     // --- Display: app-wide frame rate & panel resolution ---

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -93,6 +93,8 @@ class PreferencesManager @Inject constructor(
         private val LYRICS_BASS_REACT = floatPreferencesKey("lyrics_bass_react")
         // Full Lyrics FX Studio settings as one JSON blob (takes precedence).
         private val LYRICS_FX_JSON = stringPreferencesKey("lyrics_fx_json")
+        // User-saved Lyrics FX presets (a JSON array of {name, settings}).
+        private val LYRICS_FX_CUSTOM_PRESETS_JSON = stringPreferencesKey("lyrics_fx_custom_presets_json")
 
         // Player / display
         private val PLAYER_DYNAMIC_COLOR = booleanPreferencesKey("player_dynamic_color")
@@ -1178,6 +1180,23 @@ class PreferencesManager @Inject constructor(
     suspend fun setLyricsFx(settings: LyricsFxSettings) {
         val clamped = settings.clamped()
         dataStore.edit { it[LYRICS_FX_JSON] = json.encodeToString(clamped) }
+    }
+
+    /** User-saved Lyrics FX presets (empty until the user saves one). */
+    val customLyricsFxPresets: Flow<List<tf.monochrome.android.domain.model.LyricsFxPreset>> =
+        dataStore.data.map { prefs ->
+            prefs[LYRICS_FX_CUSTOM_PRESETS_JSON]
+                ?.let { raw ->
+                    runCatching {
+                        json.decodeFromString<List<tf.monochrome.android.domain.model.LyricsFxPreset>>(raw)
+                    }.getOrNull()
+                }
+                ?.map { it.copy(settings = it.settings.clamped()) }
+                ?: emptyList()
+        }
+
+    suspend fun setCustomLyricsFxPresets(presets: List<tf.monochrome.android.domain.model.LyricsFxPreset>) {
+        dataStore.edit { it[LYRICS_FX_CUSTOM_PRESETS_JSON] = json.encodeToString(presets) }
     }
 
     // --- Player appearance ---

--- a/app/src/main/java/tf/monochrome/android/data/preferences/SettingsSyncCodec.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/SettingsSyncCodec.kt
@@ -1,0 +1,100 @@
+package tf.monochrome.android.data.preferences
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+/**
+ * Pure, framework-free codec for the settings-sync snapshot.
+ *
+ * DataStore stores seven distinct primitive types, but JSON collapses
+ * Int/Long/Float/Double into a single "number" — so a naive encoder silently
+ * corrupts a Long into an Int or a Float into a Double on the way back. Every
+ * value is therefore tagged with its type (`t`) alongside its value (`v`), which
+ * makes the round-trip exact and lets the whole thing be unit-tested without
+ * Android, DataStore, or Supabase.
+ *
+ * Supported value types: Boolean, Int, Long, Float, Double, String, Set<String>.
+ */
+object SettingsSyncCodec {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private const val T_BOOL = "b"
+    private const val T_INT = "i"
+    private const val T_LONG = "l"
+    private const val T_FLOAT = "f"
+    private const val T_DOUBLE = "d"
+    private const val T_STRING = "s"
+    private const val T_STRING_SET = "ss"
+
+    /**
+     * Encode a `name -> value` snapshot to a tagged JSON object string. Values
+     * of an unsupported type are skipped rather than throwing.
+     */
+    fun encode(values: Map<String, Any>): String {
+        val obj = buildJsonObject {
+            values.forEach { (name, value) ->
+                val entry: JsonObject? = when (value) {
+                    is Boolean -> tagged(T_BOOL, JsonPrimitive(value))
+                    is Int -> tagged(T_INT, JsonPrimitive(value))
+                    is Long -> tagged(T_LONG, JsonPrimitive(value))
+                    is Float -> tagged(T_FLOAT, JsonPrimitive(value))
+                    is Double -> tagged(T_DOUBLE, JsonPrimitive(value))
+                    is String -> tagged(T_STRING, JsonPrimitive(value))
+                    is Set<*> -> tagged(T_STRING_SET, buildJsonArray {
+                        value.forEach { add(JsonPrimitive(it.toString())) }
+                    })
+                    else -> null
+                }
+                if (entry != null) put(name, entry)
+            }
+        }
+        return json.encodeToString(JsonObject.serializer(), obj)
+    }
+
+    /**
+     * Decode a tagged JSON snapshot back to a `name -> value` map with each
+     * value restored to its exact original type. Malformed or unknown-typed
+     * entries are skipped; a completely unparseable payload yields an empty map.
+     */
+    fun decode(payload: String): Map<String, Any> {
+        val root = runCatching { json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return emptyMap()
+        val out = LinkedHashMap<String, Any>(root.size)
+        root.forEach { (name, element) ->
+            val o = runCatching { element.jsonObject }.getOrNull() ?: return@forEach
+            val type = o["t"]?.jsonPrimitive?.contentOrNull ?: return@forEach
+            val v = o["v"] ?: return@forEach
+            val value: Any? = runCatching {
+                when (type) {
+                    T_BOOL -> v.jsonPrimitive.boolean
+                    T_INT -> v.jsonPrimitive.int
+                    T_LONG -> v.jsonPrimitive.long
+                    T_FLOAT -> v.jsonPrimitive.float
+                    T_DOUBLE -> v.jsonPrimitive.double
+                    T_STRING -> v.jsonPrimitive.contentOrNull
+                    T_STRING_SET -> v.jsonArray.map { it.jsonPrimitive.content }.toSet()
+                    else -> null
+                }
+            }.getOrNull()
+            if (value != null) out[name] = value
+        }
+        return out
+    }
+
+    private fun tagged(type: String, value: kotlinx.serialization.json.JsonElement): JsonObject =
+        buildJsonObject {
+            put("t", JsonPrimitive(type))
+            put("v", value)
+        }
+}

--- a/app/src/main/java/tf/monochrome/android/data/sync/SettingsSyncCoordinator.kt
+++ b/app/src/main/java/tf/monochrome/android/data/sync/SettingsSyncCoordinator.kt
@@ -1,0 +1,86 @@
+package tf.monochrome.android.data.sync
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
+import tf.monochrome.android.data.auth.SupabaseAuthManager
+import tf.monochrome.android.data.preferences.PreferencesManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Auto-saves the user's app settings to their Supabase row whenever they change,
+ * so "all settings" persist to the user database without a manual sync.
+ *
+ * Lifecycle (started once from [tf.monochrome.android.MonochromeApp]):
+ *  - On sign-in: PULL the cloud settings first and apply them, THEN start the
+ *    debounced change-watcher. Pulling first prevents the very first local
+ *    emission (device defaults) from clobbering the cloud copy — the sign-in
+ *    race the audit flagged.
+ *  - While signed in: every allow-listed pref change, debounced ~2s and
+ *    de-duplicated, triggers a push. Applying a remote snapshot is guarded by
+ *    [applyingRemote] so the write it causes doesn't immediately echo back as a
+ *    push (the ping-pong loop).
+ *  - On sign-out: the watcher is torn down (flatMapLatest → emptyFlow).
+ */
+@Singleton
+class SettingsSyncCoordinator @Inject constructor(
+    private val preferences: PreferencesManager,
+    private val syncRepository: SupabaseSyncRepository,
+    private val authManager: SupabaseAuthManager,
+) {
+    private val applyingRemote = AtomicBoolean(false)
+
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            authManager.userProfile
+                .distinctUntilChanged { a, b -> a?.id == b?.id }
+                .flatMapLatest { user ->
+                    if (user == null) {
+                        emptyFlow()
+                    } else {
+                        flow {
+                            // Adopt the cloud settings before watching local changes.
+                            applyingRemote.set(true)
+                            try {
+                                runCatching { syncRepository.pullSettings() }
+                                    .onFailure { Log.e(TAG, "initial pullSettings failed: ${it.message}") }
+                            } finally {
+                                applyingRemote.set(false)
+                            }
+                            // drop(1): skip the current snapshot emitted on
+                            // subscribe; only real subsequent changes push.
+                            emitAll(
+                                preferences.settingsSyncSnapshot
+                                    .drop(1)
+                                    .debounce(DEBOUNCE_MS)
+                                    .distinctUntilChanged()
+                            )
+                        }
+                    }
+                }
+                .collect {
+                    if (!applyingRemote.get()) {
+                        runCatching { syncRepository.pushSettings() }
+                            .onFailure { Log.e(TAG, "auto pushSettings failed: ${it.message}") }
+                    }
+                }
+        }
+    }
+
+    private companion object {
+        const val TAG = "SettingsSync"
+        const val DEBOUNCE_MS = 2_000L
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/sync/SupabaseSyncRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/sync/SupabaseSyncRepository.kt
@@ -182,6 +182,14 @@ data class SbPlaylistTrack(
     val added_at: String? = null
 )
 
+/** One row per user: a tagged-JSON blob of the user's allow-listed app settings. */
+@Serializable
+data class SbUserSettings(
+    val user_id: String? = null,
+    val payload: String,
+    val updated_at: String? = null,
+)
+
 // ─── Repository ───────────────────────────────────────────────────────────────
 
 @Singleton
@@ -192,11 +200,40 @@ class SupabaseSyncRepository @Inject constructor(
     private val mixPresetDao: MixPresetDao,
     private val playlistDao: PlaylistDao,
     private val playEventDao: PlayEventDao,
+    private val preferences: tf.monochrome.android.data.preferences.PreferencesManager,
 ) {
     private val supabase get() = authManager.supabase
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
     private fun userId(): String? = authManager.userProfile.value?.id
+
+    // ─── App settings (single JSON row per user) ─────────────────────────────
+
+    /** Upload the user's allow-listed settings snapshot (last-write-wins). */
+    suspend fun pushSettings() {
+        val uid = userId() ?: return
+        runCatching {
+            supabase.postgrest["user_settings"].upsert(
+                SbUserSettings(
+                    user_id = uid,
+                    payload = preferences.exportSettingsJson(),
+                    updated_at = java.time.Instant.now().toString(),
+                )
+            ) { onConflict = "user_id" }
+        }.onFailure { Log.e(TAG, "pushSettings failed: ${it.message}") }
+    }
+
+    /** Fetch the cloud settings row (if any) and apply it to local DataStore. */
+    suspend fun pullSettings() {
+        val uid = userId() ?: return
+        runCatching {
+            supabase.postgrest["user_settings"]
+                .select { filter { eq("user_id", uid) } }
+                .decodeSingleOrNull<SbUserSettings>()
+                ?.payload
+                ?.let { preferences.importSettingsJson(it) }
+        }.onFailure { Log.e(TAG, "pullSettings failed: ${it.message}") }
+    }
 
     // ─── EQ Presets ──────────────────────────────────────────────────────────
 
@@ -582,9 +619,10 @@ class SupabaseSyncRepository @Inject constructor(
      * Called once after sign-in. Pulls all cloud data and merges it into Room.
      * Existing local data wins on conflict — we don't overwrite local with cloud.
      */
-    suspend fun pullAll() {
-        val uid = userId() ?: return
+    suspend fun pullAll(): List<String> {
+        val uid = userId() ?: return listOf("not signed in")
         Log.d(TAG, "Starting full cloud pull for user $uid")
+        val failed = mutableListOf<String>()
 
         // Favorites
         runCatching {
@@ -608,7 +646,7 @@ class SupabaseSyncRepository @Inject constructor(
                     )
                 )
             }
-        }.onFailure { Log.e(TAG, "pull favorite_tracks: ${it.message}") }
+        }.onFailure { failed += "favorite_tracks"; Log.e(TAG, "pull favorite_tracks: ${it.message}") }
 
         runCatching {
             val albums = supabase.postgrest["favorite_albums"]
@@ -628,7 +666,7 @@ class SupabaseSyncRepository @Inject constructor(
                     )
                 )
             }
-        }.onFailure { Log.e(TAG, "pull favorite_albums: ${it.message}") }
+        }.onFailure { failed += "favorite_albums"; Log.e(TAG, "pull favorite_albums: ${it.message}") }
 
         runCatching {
             val artists = supabase.postgrest["favorite_artists"]
@@ -639,7 +677,7 @@ class SupabaseSyncRepository @Inject constructor(
                     FavoriteArtistEntity(id = a.id, name = a.name, picture = a.picture)
                 )
             }
-        }.onFailure { Log.e(TAG, "pull favorite_artists: ${it.message}") }
+        }.onFailure { failed += "favorite_artists"; Log.e(TAG, "pull favorite_artists: ${it.message}") }
 
         // Mix Presets
         runCatching {
@@ -656,7 +694,7 @@ class SupabaseSyncRepository @Inject constructor(
                     )
                 )
             }
-        }.onFailure { Log.e(TAG, "pull mix_presets: ${it.message}") }
+        }.onFailure { failed += "mix_presets"; Log.e(TAG, "pull mix_presets: ${it.message}") }
 
         // Playlists
         runCatching {
@@ -691,7 +729,7 @@ class SupabaseSyncRepository @Inject constructor(
                     )
                 }
             }
-        }.onFailure { Log.e(TAG, "pull playlists: ${it.message}") }
+        }.onFailure { failed += "playlists"; Log.e(TAG, "pull playlists: ${it.message}") }
 
         // Play events — pull the most recent 1000 and merge into Room so stats
         // come across on a new device. Skip events already present (same track
@@ -705,7 +743,10 @@ class SupabaseSyncRepository @Inject constructor(
                 }
                 .decodeList<SbPlayEvent>()
             events.forEach { e ->
-                playEventDao.insert(
+                // insertFromCloud is @Insert(onConflict = IGNORE) on the unique
+                // cloudRowId index — so re-pulling never duplicates local stats.
+                // Carrying cloudRowId is also what lets pushAll skip these rows.
+                playEventDao.insertFromCloud(
                     PlayEventEntity(
                         trackId = e.track_id,
                         title = e.title,
@@ -717,60 +758,59 @@ class SupabaseSyncRepository @Inject constructor(
                         albumCover = e.album_cover,
                         audioQuality = e.audio_quality,
                         source = e.source,
-                        playedAt = e.played_at_ms
+                        playedAt = e.played_at_ms,
+                        cloudRowId = e.id,
                     )
                 )
             }
-        }.onFailure { Log.e(TAG, "pull play_events: ${it.message}") }
+        }.onFailure { failed += "play_events"; Log.e(TAG, "pull play_events: ${it.message}") }
 
-        Log.d(TAG, "Cloud pull complete")
+        // App settings — apply the cloud snapshot to local DataStore.
+        runCatching { pullSettings() }
+            .onFailure { failed += "settings"; Log.e(TAG, "pull settings: ${it.message}") }
+
+        Log.d(TAG, "Cloud pull complete (${failed.size} failed sections)")
+        return failed
     }
 
     // ─── Full push (local → cloud) after import ─────────────────────────────
 
     /**
-     * Push all local favorites, playlists, and history to Supabase.
-     * Called after a JSON library import to sync imported data to cloud.
+     * Push all local library data + settings to Supabase.
+     * @return the names of any sections that failed (empty = full success). The
+     * caller must surface a non-empty result instead of reporting success — each
+     * section swallows its own exception so a failure here is otherwise silent.
      */
-    suspend fun pushAll() {
-        val uid = userId() ?: return
+    suspend fun pushAll(): List<String> {
+        val uid = userId() ?: return listOf("not signed in")
         Log.d(TAG, "Starting full cloud push for user $uid")
+        val failed = mutableListOf<String>()
+        suspend fun section(name: String, block: suspend () -> Unit) {
+            runCatching { block() }.onFailure { failed += name; Log.e(TAG, "push $name: ${it.message}") }
+        }
 
-        // Favorite tracks
-        runCatching {
-            favoritesDao.getFavoriteTracksSnapshot().forEach { pushFavoriteTrack(it) }
-        }.onFailure { Log.e(TAG, "push favorite_tracks: ${it.message}") }
-
-        // Favorite albums
-        runCatching {
-            favoritesDao.getFavoriteAlbumsSnapshot().forEach { pushFavoriteAlbum(it) }
-        }.onFailure { Log.e(TAG, "push favorite_albums: ${it.message}") }
-
-        // Favorite artists
-        runCatching {
-            favoritesDao.getFavoriteArtistsSnapshot().forEach { pushFavoriteArtist(it) }
-        }.onFailure { Log.e(TAG, "push favorite_artists: ${it.message}") }
-
-        // History (aggregated — one row per track)
-        runCatching {
-            historyDao.getHistorySnapshot(500).forEach { pushHistoryTrack(it) }
-        }.onFailure { Log.e(TAG, "push play_history: ${it.message}") }
-
-        // Play events (per-play scrobble log — drives Listening Stats)
-        runCatching {
-            playEventDao.getRecent(1000).forEach { pushPlayEvent(it) }
-        }.onFailure { Log.e(TAG, "push play_events: ${it.message}") }
-
-        // Playlists + tracks
-        runCatching {
+        section("favorite_tracks") { favoritesDao.getFavoriteTracksSnapshot().forEach { pushFavoriteTrack(it) } }
+        section("favorite_albums") { favoritesDao.getFavoriteAlbumsSnapshot().forEach { pushFavoriteAlbum(it) } }
+        section("favorite_artists") { favoritesDao.getFavoriteArtistsSnapshot().forEach { pushFavoriteArtist(it) } }
+        section("play_history") { historyDao.getHistorySnapshot(500).forEach { pushHistoryTrack(it) } }
+        // Play events: only push rows not already in the cloud (cloudRowId IS
+        // NULL), and record the assigned cloud id, so repeated syncs don't
+        // re-insert the same scrobble and inflate stats (the old code re-pushed
+        // the last 1000 every time).
+        section("play_events") {
+            playEventDao.getUnsynced(1000).forEach { e ->
+                pushPlayEvent(e)?.let { cloudId -> playEventDao.setCloudId(e.rowId, cloudId) }
+            }
+        }
+        section("playlists") {
             playlistDao.getAllPlaylistsSnapshot().forEach { playlist ->
                 pushPlaylist(playlist)
-                playlistDao.getPlaylistTracksSnapshot(playlist.id).forEach { track ->
-                    pushPlaylistTrack(track)
-                }
+                playlistDao.getPlaylistTracksSnapshot(playlist.id).forEach { track -> pushPlaylistTrack(track) }
             }
-        }.onFailure { Log.e(TAG, "push playlists: ${it.message}") }
+        }
+        section("settings") { pushSettings() }
 
-        Log.d(TAG, "Cloud push complete")
+        Log.d(TAG, "Cloud push complete (${failed.size} failed sections)")
+        return failed
     }
 }

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -90,26 +90,26 @@ data class LyricsFxSettings(
     val popAmount: Float = 0.08f,
 
     // ── God rays / glow ────────────────────────────────────────────────
-    /** Number of crepuscular light shafts fanning from above the line. 0 = off. */
-    val rayCount: Int = 14,
-    /** Shaft reach as a fraction of the surface height (grows with the pulse). */
-    val rayLength: Float = 0.85f,
-    /** Shaft width at full pulse, in dp (shafts widen toward the tip). */
-    val rayWidthDp: Float = 10f,
+    /** Light shafts emitted PER LETTER (split up/down). 0 turns rays off. */
+    val rayCount: Int = 6,
+    /** Shaft reach as a multiple of each glyph's size (grows with the pulse). */
+    val rayLength: Float = 0.5f,
+    /** Shaft width in dp (shafts widen toward the tip; grows a little with the pulse). */
+    val rayWidthDp: Float = 8f,
     /** Peak shaft alpha (shafts blend additively, so overlaps bloom). */
-    val rayBrightness: Float = 0.32f,
-    /** Drift speed of the fan, degrees per second (negative = reverse). */
-    val raySpinDegPerSec: Float = 6f,
+    val rayBrightness: Float = 0.3f,
+    /** Slow sway of each letter's shaft fan, degrees per second (negative = reverse). */
+    val raySpinDegPerSec: Float = 4f,
     /** Extra glow radius beyond the line's own height, in dp. */
     val glowRadiusDp: Float = 44f,
     /** Peak glow alpha. */
     val glowBrightness: Float = 0.22f,
-    /** Legacy: parallel-shaft mode (no longer changes the crepuscular renderer). */
+    /** Legacy: parallel-shaft mode (no longer changes the per-letter renderer). */
     val rayFixedDirection: Boolean = false,
-    /** Fan tilt in degrees, 0 = shafts pour straight down, clockwise (studio joystick). */
+    /** Emission-axis tilt in degrees, 0 = shafts pour straight up/down from each letter. */
     val rayAngleDeg: Float = 0f,
-    /** Fan cone width around the angle. 360 = full radial sun; ~140 = downward fan. */
-    val raySpreadDeg: Float = 150f,
+    /** Fan spread of each letter's shafts around the axis (tight = near-vertical column). */
+    val raySpreadDeg: Float = 30f,
     /** Falloff position along each shaft where it fades out (0 = short, 1 = reaches the tip). */
     val rayDecay: Float = 0.6f,
     /** Width taper from base to tip. 0 = even shaft, 1 = sharp spear. */

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -87,28 +87,28 @@ data class LyricsFxSettings(
     val popAmount: Float = 0.08f,
 
     // ── God rays / glow ────────────────────────────────────────────────
-    /** Beams radiating from EACH letter. 0 turns rays off. */
-    val rayCount: Int = 8,
-    /** Beam reach as a multiple of each glyph's size (grows with the pulse). */
-    val rayLength: Float = 0.62f,
-    /** Beam stroke width at full pulse, in dp. */
-    val rayWidthDp: Float = 9f,
-    /** Peak beam alpha. */
-    val rayBrightness: Float = 0.26f,
-    /** Orbit speed of the beam fan, degrees per second (negative = reverse). */
-    val raySpinDegPerSec: Float = 10f,
+    /** Number of crepuscular light shafts fanning from above the line. 0 = off. */
+    val rayCount: Int = 14,
+    /** Shaft reach as a fraction of the surface height (grows with the pulse). */
+    val rayLength: Float = 0.85f,
+    /** Shaft width at full pulse, in dp (shafts widen toward the tip). */
+    val rayWidthDp: Float = 10f,
+    /** Peak shaft alpha (shafts blend additively, so overlaps bloom). */
+    val rayBrightness: Float = 0.32f,
+    /** Drift speed of the fan, degrees per second (negative = reverse). */
+    val raySpinDegPerSec: Float = 6f,
     /** Extra glow radius beyond the line's own height, in dp. */
     val glowRadiusDp: Float = 44f,
     /** Peak glow alpha. */
     val glowBrightness: Float = 0.22f,
-    /** Off = radial burst; on = parallel directional shafts all aimed one way. */
+    /** Legacy: parallel-shaft mode (no longer changes the crepuscular renderer). */
     val rayFixedDirection: Boolean = false,
-    /** Light direction in degrees, 0 = up, clockwise (set by the studio joystick). */
+    /** Fan tilt in degrees, 0 = shafts pour straight down, clockwise (studio joystick). */
     val rayAngleDeg: Float = 0f,
-    /** Fan cone width around the angle. 360 = full even burst; small = tight cone. */
-    val raySpreadDeg: Float = 360f,
-    /** Falloff position along each beam where it fades out (0 = short, 1 = reaches the tip). */
-    val rayDecay: Float = 0.5f,
+    /** Fan cone width around the angle. 360 = full radial sun; ~140 = downward fan. */
+    val raySpreadDeg: Float = 150f,
+    /** Falloff position along each shaft where it fades out (0 = short, 1 = reaches the tip). */
+    val rayDecay: Float = 0.6f,
     /** Width taper from base to tip. 0 = even shaft, 1 = sharp spear. */
     val rayTaper: Float = 0f,
     /** Recolour the rays off the album accent, in degrees of hue rotation. */

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -13,6 +13,10 @@ data class LyricsFxSettings(
     // ── Typography ─────────────────────────────────────────────────────
     val fontSizeSp: Float = 23f,
     val letterSpacingSp: Float = -0.2f,
+    /** Side margin (dp) between the lyric lines and the screen/container edges. */
+    val edgeMarginDp: Float = 0f,
+    /** Max rows a single line may wrap to before it shrinks to fit (1 = never wrap). */
+    val maxWrapLines: Int = 1,
 
     // ── Playback sync ──────────────────────────────────────────────────
     /**
@@ -127,6 +131,8 @@ data class LyricsFxSettings(
         return LyricsFxSettings(
             fontSizeSp = fontSizeSp.c(14f, 34f, d.fontSizeSp),
             letterSpacingSp = letterSpacingSp.c(-1f, 1f, d.letterSpacingSp),
+            edgeMarginDp = edgeMarginDp.c(0f, 48f, d.edgeMarginDp),
+            maxWrapLines = maxWrapLines.coerceIn(1, 3),
             bluetoothDelayMs = bluetoothDelayMs.c(-500f, 1500f, d.bluetoothDelayMs),
             customFont = customFont,
             customFontPath = customFontPath,

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -20,8 +20,19 @@ data class LyricsFxSettings(
      * later than the reported playback position, so synced lyrics run ahead of
      * what's heard; this pushes the lyric timeline back by the same amount.
      * Positive = lyrics wait longer (the usual case); negative = lyrics lead.
+     * Personal/device setting — preserved when a theme preset is applied.
      */
     val bluetoothDelayMs: Float = 0f,
+
+    // ── Custom font ────────────────────────────────────────────────────
+    /** Override the lyric typeface with an imported font. Off = app theme font. */
+    val customFont: Boolean = false,
+    /**
+     * Absolute path to the chosen font file in filesDir/custom_fonts (the same
+     * store Settings › Appearance imports into). Blank = none. Personal setting —
+     * preserved when a theme preset is applied.
+     */
+    val customFontPath: String = "",
 
     // ── Liquid glass (refractive relight of the lyric surface) ─────────
     /** Master toggle for the refractive glass relight. Off = flat solid text. */
@@ -34,6 +45,12 @@ data class LyricsFxSettings(
     val glassRimBrightness: Float = 1f,
     /** Chromatic aberration — colour fringing where the edges refract. */
     val glassDispersion: Float = 1f,
+    /**
+     * Bevel sample rings the glass shader takes per pixel: 1/2/3 → 5/9/13 taps.
+     * Higher = smoother rounded glass but heavier GPU. Device/perf setting —
+     * preserved when a theme preset is applied.
+     */
+    val glassSampleRings: Int = 2,
 
     // ── 3D letter wave (active line) ───────────────────────────────────
     /** Tilt of the per-letter ripple. 0 disables the per-letter path entirely. */
@@ -74,6 +91,24 @@ data class LyricsFxSettings(
     val glowRadiusDp: Float = 44f,
     /** Peak glow alpha. */
     val glowBrightness: Float = 0.22f,
+    /** Off = radial burst; on = parallel directional shafts all aimed one way. */
+    val rayFixedDirection: Boolean = false,
+    /** Light direction in degrees, 0 = up, clockwise (set by the studio joystick). */
+    val rayAngleDeg: Float = 0f,
+    /** Fan cone width around the angle. 360 = full even burst; small = tight cone. */
+    val raySpreadDeg: Float = 360f,
+    /** Falloff position along each beam where it fades out (0 = short, 1 = reaches the tip). */
+    val rayDecay: Float = 0.5f,
+    /** Width taper from base to tip. 0 = even shaft, 1 = sharp spear. */
+    val rayTaper: Float = 0f,
+    /** Recolour the rays off the album accent, in degrees of hue rotation. */
+    val rayHueShift: Float = 0f,
+    /** Time-based shimmer/twinkle of each beam's alpha. 0 = steady. */
+    val rayFlicker: Float = 0f,
+    /** Per-beam random length variance for an organic burst. 0 = uniform. */
+    val rayLengthJitter: Float = 0f,
+    /** How much beam reach/width react to the bass pulse. 0 = steady, 1 = fully bass-driven. */
+    val rayPulseAmount: Float = 0.5f,
 ) {
     /** Spring damping ratio for the pulse/pop springs, derived from [bounce]. */
     val springDampingRatio: Float
@@ -87,11 +122,14 @@ data class LyricsFxSettings(
             fontSizeSp = fontSizeSp.c(14f, 34f, d.fontSizeSp),
             letterSpacingSp = letterSpacingSp.c(-1f, 1f, d.letterSpacingSp),
             bluetoothDelayMs = bluetoothDelayMs.c(-500f, 1500f, d.bluetoothDelayMs),
+            customFont = customFont,
+            customFontPath = customFontPath,
             liquidGlass = liquidGlass,
             glassBodyOpacity = glassBodyOpacity.c(0.2f, 1f, d.glassBodyOpacity),
             glassRefraction = glassRefraction.c(0f, 0.4f, d.glassRefraction),
             glassRimBrightness = glassRimBrightness.c(0f, 2f, d.glassRimBrightness),
             glassDispersion = glassDispersion.c(0f, 2f, d.glassDispersion),
+            glassSampleRings = glassSampleRings.coerceIn(1, 3),
             rotationDegrees = rotationDegrees.c(0f, 25f, d.rotationDegrees),
             waveSpeed = waveSpeed.c(0.25f, 3f, d.waveSpeed),
             wavePhaseStep = wavePhaseStep.c(0.05f, 0.9f, d.wavePhaseStep),
@@ -110,8 +148,35 @@ data class LyricsFxSettings(
             raySpinDegPerSec = raySpinDegPerSec.c(-60f, 60f, d.raySpinDegPerSec),
             glowRadiusDp = glowRadiusDp.c(0f, 160f, d.glowRadiusDp),
             glowBrightness = glowBrightness.c(0f, 0.6f, d.glowBrightness),
+            rayFixedDirection = rayFixedDirection,
+            rayAngleDeg = rayAngleDeg.c(0f, 360f, d.rayAngleDeg),
+            raySpreadDeg = raySpreadDeg.c(0f, 360f, d.raySpreadDeg),
+            rayDecay = rayDecay.c(0f, 1f, d.rayDecay),
+            rayTaper = rayTaper.c(0f, 1f, d.rayTaper),
+            rayHueShift = rayHueShift.c(-180f, 180f, d.rayHueShift),
+            rayFlicker = rayFlicker.c(0f, 1f, d.rayFlicker),
+            rayLengthJitter = rayLengthJitter.c(0f, 1f, d.rayLengthJitter),
+            rayPulseAmount = rayPulseAmount.c(0f, 1f, d.rayPulseAmount),
         )
     }
+
+    /**
+     * The user's personal/device settings — the lyric font and the perf/latency
+     * knobs — that a theme preset should carry over rather than overwrite.
+     */
+    fun withPersonalFrom(other: LyricsFxSettings): LyricsFxSettings = copy(
+        customFont = other.customFont,
+        customFontPath = other.customFontPath,
+        bluetoothDelayMs = other.bluetoothDelayMs,
+        glassSampleRings = other.glassSampleRings,
+    )
+
+    /**
+     * True when this settings object matches [preset] on every aesthetic field —
+     * i.e. it equals the preset once the personal fields (which presets never
+     * carry) are set aside. Used to light the selected preset chip.
+     */
+    fun matchesPreset(preset: LyricsFxSettings): Boolean = this == preset.withPersonalFrom(this)
 
     companion object {
         val DEFAULT = LyricsFxSettings()
@@ -154,6 +219,97 @@ data class LyricsFxSettings(
                 bassReact = 0f,
                 rayCount = 0,
                 popAmount = 0f,
+            ),
+            "Aurora" to LyricsFxSettings(
+                fontSizeSp = 24f,
+                glassBodyOpacity = 0.5f, glassRefraction = 0.2f, glassRimBrightness = 1.2f, glassDispersion = 1.4f,
+                rotationDegrees = 8f, waveSpeed = 0.8f, waveTravelDp = 4f,
+                bassReact = 0.6f, pumpAmount = 0.06f,
+                rayCount = 10, rayLength = 0.7f, rayWidthDp = 7f, rayBrightness = 0.2f, raySpinDegPerSec = 6f,
+                glowRadiusDp = 80f, glowBrightness = 0.28f,
+                rayFixedDirection = true, rayAngleDeg = 0f, rayDecay = 0.7f, rayTaper = 0.4f,
+                rayHueShift = 120f, rayFlicker = 0.2f, rayPulseAmount = 0.4f,
+            ),
+            "Neon" to LyricsFxSettings(
+                fontSizeSp = 25f, letterSpacingSp = 0f,
+                glassBodyOpacity = 0.45f, glassRefraction = 0.28f, glassRimBrightness = 1.8f, glassDispersion = 2f,
+                rotationDegrees = 14f, waveSpeed = 1.6f, wavePhaseStep = 0.3f,
+                bassReact = 1f, pumpAmount = 0.14f, bounce = 0.8f, popAmount = 0.12f,
+                rayCount = 16, rayLength = 0.9f, rayWidthDp = 6f, rayBrightness = 0.4f, raySpinDegPerSec = 30f,
+                glowRadiusDp = 60f, glowBrightness = 0.34f,
+                rayDecay = 0.6f, rayHueShift = -60f, rayFlicker = 0.4f, rayPulseAmount = 0.9f,
+            ),
+            "Frost" to LyricsFxSettings(
+                fontSizeSp = 23f,
+                glassBodyOpacity = 0.3f, glassRefraction = 0.08f, glassRimBrightness = 1.4f, glassDispersion = 0.6f,
+                rotationDegrees = 4f, waveSpeed = 0.6f, shadowDepth = 0.4f,
+                bassReact = 0.3f, pumpAmount = 0.03f,
+                rayCount = 0,
+                glowRadiusDp = 24f, glowBrightness = 0.1f,
+            ),
+            "Ember" to LyricsFxSettings(
+                fontSizeSp = 24f,
+                glassBodyOpacity = 0.55f, glassRefraction = 0.16f, glassRimBrightness = 1.1f, glassDispersion = 0.8f,
+                rotationDegrees = 10f, waveSpeed = 0.9f, waveTravelDp = 3f,
+                bassReact = 0.7f, pumpAmount = 0.1f, releaseMs = 220f,
+                rayCount = 8, rayLength = 0.75f, rayWidthDp = 9f, rayBrightness = 0.3f,
+                glowRadiusDp = 70f, glowBrightness = 0.3f,
+                rayFixedDirection = true, rayAngleDeg = 180f, rayDecay = 0.6f, rayTaper = 0.3f,
+                rayHueShift = -20f, rayFlicker = 0.3f, rayLengthJitter = 0.3f, rayPulseAmount = 0.6f,
+            ),
+            "Cinematic" to LyricsFxSettings(
+                fontSizeSp = 30f, letterSpacingSp = 0.2f,
+                glassBodyOpacity = 0.6f, glassRefraction = 0.12f, glassRimBrightness = 0.9f, glassDispersion = 0.5f,
+                rotationDegrees = 5f, waveSpeed = 0.5f, waveTravelDp = 2f, shadowDepth = 0.6f,
+                bassReact = 0.4f, pumpAmount = 0.05f,
+                rayCount = 6, rayLength = 0.6f, rayWidthDp = 10f, rayBrightness = 0.18f,
+                glowRadiusDp = 50f, glowBrightness = 0.18f,
+                rayFixedDirection = true, rayAngleDeg = 90f, rayDecay = 0.5f, rayTaper = 0.5f, rayPulseAmount = 0.3f,
+            ),
+            "Vaporwave" to LyricsFxSettings(
+                fontSizeSp = 26f, letterSpacingSp = 0.3f,
+                glassBodyOpacity = 0.5f, glassRefraction = 0.24f, glassRimBrightness = 1.5f, glassDispersion = 2f,
+                rotationDegrees = 12f, waveSpeed = 1.1f,
+                bassReact = 0.8f, pumpAmount = 0.12f, bounce = 0.7f,
+                rayCount = 12, rayLength = 0.8f, rayWidthDp = 8f, rayBrightness = 0.32f, raySpinDegPerSec = -12f,
+                glowRadiusDp = 100f, glowBrightness = 0.4f,
+                rayDecay = 0.7f, rayHueShift = 150f, rayFlicker = 0.25f, rayPulseAmount = 0.7f,
+            ),
+            "Minimal Glass" to LyricsFxSettings(
+                fontSizeSp = 23f,
+                glassBodyOpacity = 0.55f, glassRefraction = 0.14f, glassRimBrightness = 1.2f, glassDispersion = 1f,
+                rotationDegrees = 0f,
+                bassReact = 0f,
+                rayCount = 0, popAmount = 0f,
+                glowRadiusDp = 0f, glowBrightness = 0f,
+            ),
+            "Karaoke Pop" to LyricsFxSettings(
+                fontSizeSp = 27f,
+                glassBodyOpacity = 0.6f, glassRefraction = 0.16f, glassRimBrightness = 1.3f, glassDispersion = 1.2f,
+                rotationDegrees = 12f, waveSpeed = 1.2f,
+                bassReact = 1f, pumpAmount = 0.18f, attackMs = 8f, releaseMs = 120f, bounce = 0.9f, popAmount = 0.16f,
+                rayCount = 14, rayLength = 0.85f, rayWidthDp = 10f, rayBrightness = 0.38f, raySpinDegPerSec = 20f,
+                glowRadiusDp = 80f, glowBrightness = 0.34f,
+                rayDecay = 0.6f, rayFlicker = 0.3f, rayLengthJitter = 0.4f, rayPulseAmount = 1f,
+            ),
+            "Sunbeam" to LyricsFxSettings(
+                fontSizeSp = 24f,
+                glassBodyOpacity = 0.5f, glassRefraction = 0.18f, glassRimBrightness = 1.2f, glassDispersion = 0.9f,
+                rotationDegrees = 8f, waveSpeed = 0.8f,
+                bassReact = 0.6f, pumpAmount = 0.08f,
+                rayCount = 10, rayLength = 0.95f, rayWidthDp = 8f, rayBrightness = 0.3f,
+                glowRadiusDp = 70f, glowBrightness = 0.3f,
+                rayFixedDirection = true, rayAngleDeg = 45f, raySpreadDeg = 40f, rayDecay = 0.8f, rayTaper = 0.6f,
+                rayHueShift = 30f, rayFlicker = 0.15f, rayLengthJitter = 0.5f, rayPulseAmount = 0.5f,
+            ),
+            "Nightdrive" to LyricsFxSettings(
+                fontSizeSp = 24f,
+                glassBodyOpacity = 0.4f, glassRefraction = 0.12f, glassRimBrightness = 1f, glassDispersion = 1.3f,
+                rotationDegrees = 6f, waveSpeed = 0.5f, waveTravelDp = 3f,
+                bassReact = 0.4f, pumpAmount = 0.05f, releaseMs = 300f,
+                rayCount = 8, rayLength = 0.6f, rayWidthDp = 6f, rayBrightness = 0.16f, raySpinDegPerSec = 4f,
+                glowRadiusDp = 60f, glowBrightness = 0.2f,
+                rayDecay = 0.5f, rayHueShift = -120f, rayFlicker = 0.15f, rayPulseAmount = 0.4f,
             ),
         )
     }

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -14,6 +14,15 @@ data class LyricsFxSettings(
     val fontSizeSp: Float = 23f,
     val letterSpacingSp: Float = -0.2f,
 
+    // ── Playback sync ──────────────────────────────────────────────────
+    /**
+     * Bluetooth sync delay in milliseconds. Bluetooth audio reaches the ears
+     * later than the reported playback position, so synced lyrics run ahead of
+     * what's heard; this pushes the lyric timeline back by the same amount.
+     * Positive = lyrics wait longer (the usual case); negative = lyrics lead.
+     */
+    val bluetoothDelayMs: Float = 0f,
+
     // ── Liquid glass (refractive relight of the lyric surface) ─────────
     /** Master toggle for the refractive glass relight. Off = flat solid text. */
     val liquidGlass: Boolean = true,
@@ -77,6 +86,7 @@ data class LyricsFxSettings(
         return LyricsFxSettings(
             fontSizeSp = fontSizeSp.c(14f, 34f, d.fontSizeSp),
             letterSpacingSp = letterSpacingSp.c(-1f, 1f, d.letterSpacingSp),
+            bluetoothDelayMs = bluetoothDelayMs.c(-500f, 1500f, d.bluetoothDelayMs),
             liquidGlass = liquidGlass,
             glassBodyOpacity = glassBodyOpacity.c(0.2f, 1f, d.glassBodyOpacity),
             glassRefraction = glassRefraction.c(0f, 0.4f, d.glassRefraction),

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -1,6 +1,9 @@
 package tf.monochrome.android.domain.model
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 /**
  * Full parameter set for the lyric renderer — typography, the 3D letter wave,
@@ -328,5 +331,44 @@ data class LyricsFxSettings(
                 rayDecay = 0.5f, rayHueShift = -120f, rayFlicker = 0.15f, rayPulseAmount = 0.4f,
             ),
         )
+    }
+}
+
+/**
+ * A user-saved Lyrics FX preset: a name plus a full [LyricsFxSettings] snapshot.
+ * Serialises to a compact, shareable code (see [encode]/[decode]) so presets can
+ * be exported to a friend and imported back — the whole look travels in one
+ * copy-pasteable string.
+ */
+@Serializable
+data class LyricsFxPreset(
+    val name: String,
+    val settings: LyricsFxSettings,
+) {
+    companion object {
+        /** Marker so an imported blob is recognisably one of our preset codes. */
+        const val CODE_PREFIX = "TRYPTFX1:"
+
+        private val codec = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+        /** Encode a preset to a single shareable string (prefix + compact JSON). */
+        fun encode(preset: LyricsFxPreset): String =
+            CODE_PREFIX + codec.encodeToString(preset.copy(settings = preset.settings.clamped()))
+
+        /**
+         * Decode a shared code back to a preset, tolerating the prefix being
+         * present or not and any surrounding whitespace. Returns null if the
+         * text isn't a valid preset. The settings are re-clamped on the way in
+         * so a hand-edited or hostile code can't push values out of range.
+         */
+        fun decode(code: String): LyricsFxPreset? = runCatching {
+            val trimmed = code.trim()
+            val start = trimmed.indexOf('{')
+            if (start < 0) return null
+            val jsonBody = trimmed.substring(start)
+            codec.decodeFromString<LyricsFxPreset>(jsonBody).let {
+                it.copy(name = it.name.trim().ifBlank { "Imported" }, settings = it.settings.clamped())
+            }
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -364,7 +364,10 @@ data class LyricsFxPreset(
         fun decode(code: String): LyricsFxPreset? = runCatching {
             val trimmed = code.trim()
             val start = trimmed.indexOf('{')
-            if (start < 0) return null
+            // No JSON object present → not a preset code. Throwing here is caught
+            // by runCatching and surfaces as null (a plain `return` isn't allowed
+            // from an expression-body function).
+            require(start >= 0) { "no preset payload" }
             val jsonBody = trimmed.substring(start)
             codec.decodeFromString<LyricsFxPreset>(jsonBody).let {
                 it.copy(name = it.name.trim().ifBlank { "Imported" }, settings = it.settings.clamped())

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -14,6 +14,18 @@ data class LyricsFxSettings(
     val fontSizeSp: Float = 23f,
     val letterSpacingSp: Float = -0.2f,
 
+    // ── Liquid glass (refractive relight of the lyric surface) ─────────
+    /** Master toggle for the refractive glass relight. Off = flat solid text. */
+    val liquidGlass: Boolean = true,
+    /** Glass body opacity — lower lets more of the backdrop read through the letters. */
+    val glassBodyOpacity: Float = 0.62f,
+    /** Refraction strength — how hard the beveled edges lens the backdrop behind them. */
+    val glassRefraction: Float = 0.14f,
+    /** Rim highlight gain — brightness of the specular glass edge. */
+    val glassRimBrightness: Float = 1f,
+    /** Chromatic aberration — colour fringing where the edges refract. */
+    val glassDispersion: Float = 1f,
+
     // ── 3D letter wave (active line) ───────────────────────────────────
     /** Tilt of the per-letter ripple. 0 disables the per-letter path entirely. */
     val rotationDegrees: Float = 12f,
@@ -65,6 +77,11 @@ data class LyricsFxSettings(
         return LyricsFxSettings(
             fontSizeSp = fontSizeSp.c(14f, 34f, d.fontSizeSp),
             letterSpacingSp = letterSpacingSp.c(-1f, 1f, d.letterSpacingSp),
+            liquidGlass = liquidGlass,
+            glassBodyOpacity = glassBodyOpacity.c(0.2f, 1f, d.glassBodyOpacity),
+            glassRefraction = glassRefraction.c(0f, 0.4f, d.glassRefraction),
+            glassRimBrightness = glassRimBrightness.c(0f, 2f, d.glassRimBrightness),
+            glassDispersion = glassDispersion.c(0f, 2f, d.glassDispersion),
             rotationDegrees = rotationDegrees.c(0f, 25f, d.rotationDegrees),
             waveSpeed = waveSpeed.c(0.25f, 3f, d.waveSpeed),
             wavePhaseStep = wavePhaseStep.c(0.05f, 0.9f, d.wavePhaseStep),

--- a/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/LyricsFxSettings.kt
@@ -52,6 +52,12 @@ data class LyricsFxSettings(
      */
     val glassSampleRings: Int = 2,
 
+    // ── Anti-aliasing (FXAA post-process) ──────────────────────────────
+    /** Post-process FXAA on the lyric surface to smooth jagged edges. Device/perf setting. */
+    val fxaa: Boolean = false,
+    /** How hard FXAA smooths edges (final blend of the AA result). Higher softens more. */
+    val fxaaStrength: Float = 0.75f,
+
     // ── 3D letter wave (active line) ───────────────────────────────────
     /** Tilt of the per-letter ripple. 0 disables the per-letter path entirely. */
     val rotationDegrees: Float = 12f,
@@ -130,6 +136,8 @@ data class LyricsFxSettings(
             glassRimBrightness = glassRimBrightness.c(0f, 2f, d.glassRimBrightness),
             glassDispersion = glassDispersion.c(0f, 2f, d.glassDispersion),
             glassSampleRings = glassSampleRings.coerceIn(1, 3),
+            fxaa = fxaa,
+            fxaaStrength = fxaaStrength.c(0f, 1f, d.fxaaStrength),
             rotationDegrees = rotationDegrees.c(0f, 25f, d.rotationDegrees),
             waveSpeed = waveSpeed.c(0.25f, 3f, d.waveSpeed),
             wavePhaseStep = wavePhaseStep.c(0.05f, 0.9f, d.wavePhaseStep),
@@ -169,6 +177,8 @@ data class LyricsFxSettings(
         customFontPath = other.customFontPath,
         bluetoothDelayMs = other.bluetoothDelayMs,
         glassSampleRings = other.glassSampleRings,
+        fxaa = other.fxaa,
+        fxaaStrength = other.fxaaStrength,
     )
 
     /**

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -1,6 +1,9 @@
 package tf.monochrome.android.domain.model
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 /**
  * Liquid-glass parameters for the PLAYER chrome (the transport buttons) — the
@@ -77,7 +80,131 @@ data class PlayerGlassSettings(
         )
     }
 
+    /**
+     * The user's personal/perf settings — the chosen button-tint colour, the
+     * Studio-preview background, and the per-pixel quality — that a theme should
+     * carry over rather than overwrite. A theme changes only the glass MATERIAL.
+     */
+    fun withPersonalFrom(other: PlayerGlassSettings): PlayerGlassSettings = copy(
+        sampleRings = other.sampleRings,
+        tintColor = other.tintColor,
+        previewBg = other.previewBg,
+    )
+
+    /**
+     * True when this equals [preset] on every material field — i.e. once the
+     * personal fields (which themes never carry) are set aside. Lights the
+     * selected theme chip regardless of the user's colour/quality choices.
+     */
+    fun matchesPreset(preset: PlayerGlassSettings): Boolean = this == preset.withPersonalFrom(this)
+
     companion object {
         val DEFAULT = PlayerGlassSettings()
+
+        /**
+         * Built-in glass MATERIAL themes. Each varies only the aesthetic fields;
+         * tintColor / previewBg stay 0 so a theme never touches the user's colour.
+         */
+        val PRESETS: List<Pair<String, PlayerGlassSettings>> = listOf(
+            "Default" to DEFAULT,
+            "Chrome" to PlayerGlassSettings(
+                bodyOpacity = 0.62f, refraction = 0.12f, rimBrightness = 1.8f, dispersion = 0.7f,
+                roundness = 0.8f, depth = 1.2f, reflection = 1.7f, gloss = 0.85f,
+                surfaceMotion = 0.12f, edgeWidth = 0.25f, frost = 0f, shadowDepth = 0.5f,
+                shadowSoftness = 0.35f,
+            ),
+            "Frosted" to PlayerGlassSettings(
+                bodyOpacity = 0.7f, refraction = 0.1f, rimBrightness = 0.9f, dispersion = 0.6f,
+                roundness = 1.5f, depth = 0.9f, reflection = 0.55f, gloss = 0.18f,
+                surfaceMotion = 0.2f, edgeWidth = 0.7f, frost = 0.7f, shadowDepth = 0.4f,
+                shadowSoftness = 0.7f,
+            ),
+            "Liquid" to PlayerGlassSettings(
+                bodyOpacity = 0.44f, refraction = 0.3f, rimBrightness = 1.4f, dispersion = 1.4f,
+                roundness = 1.7f, depth = 1.6f, reflection = 1.2f, gloss = 0.5f,
+                surfaceMotion = 0.9f, edgeWidth = 0.6f, frost = 0.05f, shadowDepth = 0.5f,
+                shadowSoftness = 0.55f,
+            ),
+            "Crystal" to PlayerGlassSettings(
+                bodyOpacity = 0.5f, refraction = 0.22f, rimBrightness = 1.6f, dispersion = 2f,
+                roundness = 0.7f, depth = 1.4f, reflection = 1.3f, gloss = 0.8f,
+                surfaceMotion = 0.15f, edgeWidth = 0.2f, frost = 0f, shadowDepth = 0.45f,
+                shadowSoftness = 0.3f,
+            ),
+            "Bubble" to PlayerGlassSettings(
+                bodyOpacity = 0.32f, refraction = 0.34f, rimBrightness = 1.3f, dispersion = 1.1f,
+                roundness = 2f, depth = 2f, reflection = 1.1f, gloss = 0.55f,
+                surfaceMotion = 0.4f, edgeWidth = 0.85f, frost = 0f, shadowDepth = 0.6f,
+                shadowSoftness = 0.85f,
+            ),
+            "Minimal" to PlayerGlassSettings(
+                bodyOpacity = 0.85f, refraction = 0.05f, rimBrightness = 0.7f, dispersion = 0.3f,
+                roundness = 0.9f, depth = 0.7f, reflection = 0.35f, gloss = 0.3f,
+                surfaceMotion = 0.08f, edgeWidth = 0.35f, frost = 0f, shadowDepth = 0.25f,
+                shadowSoftness = 0.3f,
+            ),
+            "Neon" to PlayerGlassSettings(
+                bodyOpacity = 0.46f, refraction = 0.2f, rimBrightness = 2f, dispersion = 1.6f,
+                roundness = 1f, depth = 1.3f, reflection = 1.8f, gloss = 0.75f,
+                surfaceMotion = 0.35f, edgeWidth = 0.4f, frost = 0f, shadowDepth = 0.7f,
+                shadowSoftness = 0.7f, shadowTint = 1f,
+            ),
+            "Obsidian" to PlayerGlassSettings(
+                bodyOpacity = 0.4f, refraction = 0.14f, rimBrightness = 0.8f, dispersion = 0.5f,
+                roundness = 1.1f, depth = 1.5f, reflection = 0.4f, gloss = 0.25f,
+                surfaceMotion = 0.1f, edgeWidth = 0.5f, frost = 0.1f, shadowDepth = 0.6f,
+                shadowSoftness = 0.55f,
+            ),
+            "Pillow" to PlayerGlassSettings(
+                bodyOpacity = 0.58f, refraction = 0.14f, rimBrightness = 1f, dispersion = 0.8f,
+                roundness = 1.9f, depth = 1.1f, reflection = 0.7f, gloss = 0.3f,
+                surfaceMotion = 0.25f, edgeWidth = 0.75f, frost = 0.2f, shadowDepth = 0.8f,
+                shadowSoftness = 1f,
+            ),
+            "Mirror" to PlayerGlassSettings(
+                bodyOpacity = 0.7f, refraction = 0.08f, rimBrightness = 1.9f, dispersion = 0.6f,
+                roundness = 0.6f, depth = 1f, reflection = 2f, gloss = 1f,
+                surfaceMotion = 0.1f, edgeWidth = 0.15f, frost = 0f, shadowDepth = 0.5f,
+                shadowSoftness = 0.3f,
+            ),
+        )
+    }
+}
+
+/**
+ * A user-saved Player Glass theme: a name plus a full [PlayerGlassSettings]
+ * snapshot. Serialises to a compact, shareable code ([encode]/[decode]) so a
+ * whole glass look travels in one copy-pasteable string, exactly like the
+ * Lyrics FX presets.
+ */
+@Serializable
+data class PlayerGlassPreset(
+    val name: String,
+    val settings: PlayerGlassSettings,
+) {
+    companion object {
+        /** Marker so an imported blob is recognisably one of our glass codes. */
+        const val CODE_PREFIX = "TRYPTGLASS1:"
+
+        private val codec = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+        /** Encode a preset to a single shareable string (prefix + compact JSON). */
+        fun encode(preset: PlayerGlassPreset): String =
+            CODE_PREFIX + codec.encodeToString(preset.copy(settings = preset.settings.clamped()))
+
+        /**
+         * Decode a shared code back to a preset, tolerating the prefix being
+         * present or not and surrounding whitespace. Returns null if the text
+         * isn't a valid preset. Settings are re-clamped so a hand-edited or
+         * hostile code can't push values out of range.
+         */
+        fun decode(code: String): PlayerGlassPreset? = runCatching {
+            val trimmed = code.trim()
+            val start = trimmed.indexOf('{')
+            require(start >= 0) { "no preset payload" }
+            codec.decodeFromString<PlayerGlassPreset>(trimmed.substring(start)).let {
+                it.copy(name = it.name.trim().ifBlank { "Imported" }, settings = it.settings.clamped())
+            }
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -22,6 +22,10 @@ data class PlayerGlassSettings(
     val dispersion: Float = 1.2f,
     /** Bevel sample rings 1/2/3 → 5/9/13 taps per pixel (quality vs GPU cost). */
     val sampleRings: Int = 2,
+    /** Bevel shoulder width (1 = neutral, higher = rounder, softer glass edge). */
+    val roundness: Float = 1f,
+    /** Profondeur / relief: 1 = neutral, higher = steeper, deeper 3D bevel. */
+    val depth: Float = 1f,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT
@@ -32,6 +36,8 @@ data class PlayerGlassSettings(
             rimBrightness = rimBrightness.c(0f, 2f, d.rimBrightness),
             dispersion = dispersion.c(0f, 2f, d.dispersion),
             sampleRings = sampleRings.coerceIn(1, 3),
+            roundness = roundness.c(0.5f, 2f, d.roundness),
+            depth = depth.c(0.5f, 2f, d.depth),
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -1,0 +1,41 @@
+package tf.monochrome.android.domain.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Liquid-glass parameters for the PLAYER chrome (the transport buttons) — the
+ * same refractive-glass controls the lyrics have, but for the player. Tuned in
+ * the Lyrics FX Studio's "Player Glass" tab and persisted as one JSON blob.
+ * Defaults reproduce a chrome, lyric-like glass on the buttons.
+ */
+@Serializable
+data class PlayerGlassSettings(
+    /** Master on/off for the button glass. */
+    val enabled: Boolean = true,
+    /** Body see-through amount (lower = more transparent). */
+    val bodyOpacity: Float = 0.5f,
+    /** How hard the bevel lenses the backdrop. */
+    val refraction: Float = 0.16f,
+    /** Specular rim brightness (the lit glass edge). */
+    val rimBrightness: Float = 1.3f,
+    /** Chromatic aberration at the refracting edges. */
+    val dispersion: Float = 1.2f,
+    /** Bevel sample rings 1/2/3 → 5/9/13 taps per pixel (quality vs GPU cost). */
+    val sampleRings: Int = 2,
+) {
+    fun clamped(): PlayerGlassSettings {
+        val d = DEFAULT
+        fun Float.c(min: Float, max: Float, fb: Float) = if (isFinite()) coerceIn(min, max) else fb
+        return copy(
+            bodyOpacity = bodyOpacity.c(0.2f, 1f, d.bodyOpacity),
+            refraction = refraction.c(0f, 0.4f, d.refraction),
+            rimBrightness = rimBrightness.c(0f, 2f, d.rimBrightness),
+            dispersion = dispersion.c(0f, 2f, d.dispersion),
+            sampleRings = sampleRings.coerceIn(1, 3),
+        )
+    }
+
+    companion object {
+        val DEFAULT = PlayerGlassSettings()
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -26,6 +26,8 @@ data class PlayerGlassSettings(
     val roundness: Float = 1f,
     /** Profondeur / relief: 1 = neutral, higher = steeper, deeper 3D bevel. */
     val depth: Float = 1f,
+    /** Drop-shadow depth under the round play button (0 = flat, 1 = deepest). */
+    val shadowDepth: Float = 0.45f,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT
@@ -38,6 +40,7 @@ data class PlayerGlassSettings(
             sampleRings = sampleRings.coerceIn(1, 3),
             roundness = roundness.c(0.5f, 2f, d.roundness),
             depth = depth.c(0.5f, 2f, d.depth),
+            shadowDepth = shadowDepth.c(0f, 1f, d.shadowDepth),
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -26,8 +26,26 @@ data class PlayerGlassSettings(
     val roundness: Float = 1f,
     /** Profondeur / relief: 1 = neutral, higher = steeper, deeper 3D bevel. */
     val depth: Float = 1f,
-    /** Drop-shadow depth under the round play button (0 = flat, 1 = deepest). */
+    /** Drop-shadow depth (darkness) under the round play button (0 = flat, 1 = deepest). */
     val shadowDepth: Float = 0.45f,
+    /** Environment ("room") reflection strength on the glass (0 = none, 2 = strong). */
+    val reflection: Float = 1f,
+    /** Highlight polish: 0 = soft/frosted-wide glint, 1 = tight mirror-polished. */
+    val gloss: Float = 0.4f,
+    /** Living-liquid surface motion: 0 = still glass, 1 = full shimmer/undulation. */
+    val surfaceMotion: Float = 0.25f,
+    /** How strongly device tilt moves the light/reflection (0 = static studio light). */
+    val tiltReactivity: Float = 0.7f,
+    /** Key-light direction in degrees (0..360) — where the highlights sit. */
+    val lightAngleDeg: Float = 135f,
+    /** Reflective rim width: 0 = thin crisp edge, 1 = broad glassy shoulder. */
+    val edgeWidth: Float = 0.4f,
+    /** Frosted roughness: 0 = clear glass, 1 = misted/frosted. */
+    val frost: Float = 0f,
+    /** Drop-shadow softness (blur/spread): 0 = tight, 1 = soft diffuse. */
+    val shadowSoftness: Float = 0.4f,
+    /** Drop-shadow tint: 0 = neutral black, 1 = full accent-tinted glow. */
+    val shadowTint: Float = 0f,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT
@@ -41,6 +59,15 @@ data class PlayerGlassSettings(
             roundness = roundness.c(0.5f, 2f, d.roundness),
             depth = depth.c(0.5f, 2f, d.depth),
             shadowDepth = shadowDepth.c(0f, 1f, d.shadowDepth),
+            reflection = reflection.c(0f, 2f, d.reflection),
+            gloss = gloss.c(0f, 1f, d.gloss),
+            surfaceMotion = surfaceMotion.c(0f, 1f, d.surfaceMotion),
+            tiltReactivity = tiltReactivity.c(0f, 1.5f, d.tiltReactivity),
+            lightAngleDeg = lightAngleDeg.c(0f, 360f, d.lightAngleDeg),
+            edgeWidth = edgeWidth.c(0f, 1f, d.edgeWidth),
+            frost = frost.c(0f, 1f, d.frost),
+            shadowSoftness = shadowSoftness.c(0f, 1f, d.shadowSoftness),
+            shadowTint = shadowTint.c(0f, 1f, d.shadowTint),
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -46,6 +46,10 @@ data class PlayerGlassSettings(
     val shadowSoftness: Float = 0.4f,
     /** Drop-shadow tint: 0 = neutral black, 1 = full accent-tinted glow. */
     val shadowTint: Float = 0f,
+    /** Button glass tint as an ARGB int; 0 = use the current album accent. */
+    val tintColor: Int = 0,
+    /** Studio-preview background as an ARGB int; 0 = the current album wash. */
+    val previewBg: Int = 0,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -50,6 +50,8 @@ data class PlayerGlassSettings(
     val tintColor: Int = 0,
     /** Studio-preview background as an ARGB int; 0 = the current album wash. */
     val previewBg: Int = 0,
+    /** Glass "thermometer" scrubber (tube + sine-bulge dot) vs a plain slider. */
+    val progressGlass: Boolean = true,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT

--- a/app/src/main/java/tf/monochrome/android/player/NowPlayingLyricsHolder.kt
+++ b/app/src/main/java/tf/monochrome/android/player/NowPlayingLyricsHolder.kt
@@ -1,0 +1,31 @@
+package tf.monochrome.android.player
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tf.monochrome.android.domain.model.Lyrics
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * App-scoped mirror of the currently-playing lyrics and playback position.
+ * [tf.monochrome.android.ui.player.PlayerViewModel] (screen-scoped) publishes into
+ * it, so other screens — e.g. the Lyrics FX Studio preview — can show the real
+ * lyrics without holding a reference to the player screen's ViewModel.
+ */
+@Singleton
+class NowPlayingLyricsHolder @Inject constructor() {
+    private val _lyrics = MutableStateFlow<Lyrics?>(null)
+    val lyrics: StateFlow<Lyrics?> = _lyrics.asStateFlow()
+
+    private val _positionMs = MutableStateFlow(0L)
+    val positionMs: StateFlow<Long> = _positionMs.asStateFlow()
+
+    fun setLyrics(value: Lyrics?) {
+        _lyrics.value = value
+    }
+
+    fun setPosition(value: Long) {
+        _positionMs.value = value
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
@@ -1,6 +1,7 @@
 package tf.monochrome.android.ui.components
 
 import android.os.Build
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -37,7 +38,12 @@ fun Modifier.liquidGlass(
     borderAlpha: Float = MonoDimens.glassBorderAlpha,
     borderWidth: Dp = MonoDimens.glassBorderWidth,
     blurRadius: Dp = MonoDimens.glassBlurRadius,
-    showRefraction: Boolean = true
+    showRefraction: Boolean = true,
+    // Opt-in "liquid" treatment matching the lyric glass: a glossy top-edge
+    // highlight plus a slow diagonal light sweep across the surface. Drawn
+    // behind the surface's content, so anything sitting on the glass (buttons,
+    // labels, icons) is untouched. Off by default so list rows stay cheap.
+    liquid: Boolean = false,
 ) = composed {
     val profile = LocalPerformanceProfile.current
     val isDark = MaterialTheme.colorScheme.background.luminance() <= 0.5f
@@ -130,6 +136,44 @@ fun Modifier.liquidGlass(
             brush = refractionBrush,
             shape = shape
         )
+    }
+
+    // ── Liquid sheen (opt-in): glossy top highlight + animated light sweep ──
+    // Matches the lyric glass's swept specular so player panels read as the
+    // same liquid glass. Drawn behind the node's content, clipped to the shape.
+    if (liquid) {
+        val transition = androidx.compose.animation.core.rememberInfiniteTransition(label = "liquidGlassSweep")
+        val sweep = transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = androidx.compose.animation.core.infiniteRepeatable(
+                animation = androidx.compose.animation.core.tween(
+                    durationMillis = 5200,
+                    easing = androidx.compose.animation.core.LinearEasing,
+                ),
+            ),
+            label = "liquidGlassSweepValue",
+        )
+        val glossColor = borderColor
+        modifier = modifier.drawBehind {
+            // Light catching the top edge of the glass.
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colors = listOf(glossColor.copy(alpha = 0.14f), Color.Transparent),
+                    endY = size.height * 0.55f,
+                ),
+            )
+            // A soft diagonal band sweeping across the whole surface.
+            val span = size.width * 0.55f
+            val cx = (-0.4f + 1.8f * sweep.value) * size.width
+            drawRect(
+                brush = Brush.linearGradient(
+                    colors = listOf(Color.Transparent, glossColor.copy(alpha = 0.12f), Color.Transparent),
+                    start = Offset(cx - span, 0f),
+                    end = Offset(cx + span, size.height),
+                ),
+            )
+        }
     }
 
     modifier

--- a/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/LiquidGlass.kt
@@ -1,7 +1,6 @@
 package tf.monochrome.android.ui.components
 
 import android.os.Build
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.material3.MaterialTheme
@@ -9,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -40,11 +38,6 @@ fun Modifier.liquidGlass(
     borderWidth: Dp = MonoDimens.glassBorderWidth,
     blurRadius: Dp = MonoDimens.glassBlurRadius,
     showRefraction: Boolean = true,
-    // Opt-in "liquid" treatment matching the lyric glass: a glossy top-edge
-    // highlight plus a slow diagonal light sweep across the surface. Drawn
-    // behind the surface's content, so anything sitting on the glass (buttons,
-    // labels, icons) is untouched. Off by default so list rows stay cheap.
-    liquid: Boolean = false,
 ) = composed {
     val profile = LocalPerformanceProfile.current
     val isDark = MaterialTheme.colorScheme.background.luminance() <= 0.5f
@@ -137,44 +130,6 @@ fun Modifier.liquidGlass(
             brush = refractionBrush,
             shape = shape
         )
-    }
-
-    // ── Liquid sheen (opt-in): glossy top highlight + animated light sweep ──
-    // Matches the lyric glass's swept specular so player panels read as the
-    // same liquid glass. Drawn behind the node's content, clipped to the shape.
-    if (liquid) {
-        val transition = androidx.compose.animation.core.rememberInfiniteTransition(label = "liquidGlassSweep")
-        val sweep = transition.animateFloat(
-            initialValue = 0f,
-            targetValue = 1f,
-            animationSpec = androidx.compose.animation.core.infiniteRepeatable(
-                animation = androidx.compose.animation.core.tween(
-                    durationMillis = 5200,
-                    easing = androidx.compose.animation.core.LinearEasing,
-                ),
-            ),
-            label = "liquidGlassSweepValue",
-        )
-        val glossColor = borderColor
-        modifier = modifier.drawBehind {
-            // Light catching the top edge of the glass.
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colors = listOf(glossColor.copy(alpha = 0.14f), Color.Transparent),
-                    endY = size.height * 0.55f,
-                ),
-            )
-            // A soft diagonal band sweeping across the whole surface.
-            val span = size.width * 0.55f
-            val cx = (-0.4f + 1.8f * sweep.value) * size.width
-            drawRect(
-                brush = Brush.linearGradient(
-                    colors = listOf(Color.Transparent, glossColor.copy(alpha = 0.12f), Color.Transparent),
-                    start = Offset(cx - span, 0f),
-                    end = Offset(cx + span, size.height),
-                ),
-            )
-        }
     }
 
     modifier

--- a/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
@@ -1,9 +1,15 @@
 package tf.monochrome.android.ui.components
 
 import android.os.Build
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,25 +30,37 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
 import tf.monochrome.android.R
 import tf.monochrome.android.domain.model.Track
-import tf.monochrome.android.ui.player.liquidGlassPanel
+import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.theme.MonoDimens
 import kotlin.math.abs
 
@@ -68,9 +86,11 @@ fun MiniPlayer(
 ) {
     if (track == null) return
 
-    // The panel glass (AGSL) only exists on API 33+. Below that, keep the old
-    // haze bar + Material icons — a punched slab would be an opaque block there.
-    val useGlass = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    // The tunable player glass (AGSL) only exists on API 33+ and when the user
+    // hasn't turned button glass off. Below that, keep the old haze bar + Material
+    // icons — a punched slab with no shader would be an opaque block.
+    val glass = LocalPlayerGlass.current
+    val useGlass = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && glass.enabled
 
     val swipeGestures = Modifier.pointerInput(Unit) {
         var totalHorizontalDrag = 0f
@@ -101,7 +121,7 @@ fun MiniPlayer(
     }
 
     if (!useGlass) {
-        // ── Legacy fallback (API < 33): haze glass + Material icon buttons ──
+        // ── Legacy fallback (API < 33 or glass off): haze glass + Material icons ──
         Box(
             modifier = modifier
                 .fillMaxWidth()
@@ -112,7 +132,7 @@ fun MiniPlayer(
                 .clickable(interactionSource = null, indication = null, onClick = onClick)
                 .then(swipeGestures)
         ) {
-            MiniPlayerContent(track, isPlaying, progressProvider) {
+            MiniPlayerContent(track, progressProvider) {
                 IconButton(onClick = onPlayPauseClick) {
                     Icon(
                         imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -132,15 +152,51 @@ fun MiniPlayer(
         return
     }
 
-    // ── Glass path (API 33+): one panel-glass slab with the play/skip icons
-    // punched out as see-through holes, exactly like the player action dock. ──
-    val tint = MaterialTheme.colorScheme.primary
+    // ── Glass path (API 33+): one tunable player-glass slab with the play/skip
+    // icons punched out as see-through holes, and a smooth press-bulge under the
+    // pressed control — the same shader treatment as the player action dock. ──
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else MaterialTheme.colorScheme.primary
     val playPainter = painterResource(if (isPlaying) R.drawable.ic_glass_pause else R.drawable.ic_glass_play)
     val skipPainter = painterResource(R.drawable.ic_glass_skip_next)
+
+    // Press-bulge, mirroring PlayerActionDock: swell the glass under whichever
+    // control is held (spring in, tween out); the bulge centre follows it.
+    val playSource = remember { MutableInteractionSource() }
+    val skipSource = remember { MutableInteractionSource() }
+    val playPressed by playSource.collectIsPressedAsState()
+    val skipPressed by skipSource.collectIsPressedAsState()
+    val anyPressed = playPressed || skipPressed
+    var lastControl by remember { mutableIntStateOf(1) }   // 0 = play, 1 = skip
+    LaunchedEffect(playPressed) { if (playPressed) lastControl = 0 }
+    LaunchedEffect(skipPressed) { if (skipPressed) lastControl = 1 }
+    val bulgeAmt by animateFloatAsState(
+        targetValue = if (anyPressed) 1f else 0f,
+        animationSpec = if (anyPressed) {
+            spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessMediumLow)
+        } else {
+            tween(durationMillis = 260)
+        },
+        label = "miniBulge",
+    )
+
+    val density = LocalDensity.current
+    var barSize by remember { mutableStateOf(IntSize.Zero) }
+    val bulgeCenter = remember(barSize, lastControl) {
+        if (barSize.width == 0 || barSize.height == 0) {
+            Offset(0.85f, 0.5f)
+        } else with(density) {
+            val cell = MiniControlCell.toPx()
+            val pad = MonoDimens.spacingMd.toPx()
+            val cyPx = MiniProgressHeight.toPx() + MonoDimens.spacingSm.toPx() + cell / 2f
+            val cx = barSize.width - pad - (if (lastControl == 1) 0.5f else 1.5f) * cell
+            Offset((cx / barSize.width).coerceIn(0f, 1f), (cyPx / barSize.height).coerceIn(0f, 1f))
+        }
+    }
 
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .onSizeChanged { barSize = it }
             .clip(RoundedCornerShape(MiniCorner))
             .clickable(interactionSource = null, indication = null, onClick = onClick)
             .then(swipeGestures)
@@ -151,7 +207,7 @@ fun MiniPlayer(
         Canvas(
             modifier = Modifier
                 .matchParentSize()
-                .liquidGlassPanel(tint = tint)
+                .playerGlass(tint = tint, bulgeCenter = bulgeCenter, bulgeAmount = { bulgeAmt })
                 .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
         ) {
             val cornerPx = MiniCorner.toPx()
@@ -181,16 +237,27 @@ fun MiniPlayer(
 
         // Transparent content overlay: progress, cover, text, and the two tap
         // targets sitting exactly over the punched holes (same trailing cells).
-        MiniPlayerContent(track, isPlaying, progressProvider) {
+        // No ripple indication — the glass press-bulge is the feedback.
+        MiniPlayerContent(track, progressProvider) {
             Box(
                 modifier = Modifier
                     .size(MiniControlCell)
-                    .clickable(onClickLabel = if (isPlaying) "Pause" else "Play", onClick = onPlayPauseClick)
+                    .clickable(
+                        interactionSource = playSource,
+                        indication = null,
+                        onClickLabel = if (isPlaying) "Pause" else "Play",
+                        onClick = onPlayPauseClick,
+                    )
             )
             Box(
                 modifier = Modifier
                     .size(MiniControlCell)
-                    .clickable(onClickLabel = "Skip next", onClick = onSkipNextClick)
+                    .clickable(
+                        interactionSource = skipSource,
+                        indication = null,
+                        onClickLabel = "Skip next",
+                        onClick = onSkipNextClick,
+                    )
             )
         }
     }
@@ -204,7 +271,6 @@ fun MiniPlayer(
 @Composable
 private fun MiniPlayerContent(
     track: Track,
-    isPlaying: Boolean,
     progressProvider: () -> Float,
     controls: @Composable () -> Unit,
 ) {

--- a/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
@@ -1,7 +1,8 @@
 package tf.monochrome.android.ui.components
 
+import android.os.Build
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,7 +11,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -23,14 +26,33 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
+import tf.monochrome.android.R
 import tf.monochrome.android.domain.model.Track
+import tf.monochrome.android.ui.player.liquidGlassPanel
 import tf.monochrome.android.ui.theme.MonoDimens
 import kotlin.math.abs
+
+// Geometry shared between the punched holes and the tap-target overlay so they
+// stay aligned across DPI. The two controls are the rightmost fixed-size cells
+// of the content row; the slab punches its holes at the matching centres.
+private val MiniCorner = 16.dp
+private val MiniControlCell = 48.dp
+private val MiniGlassIcon = 26.dp
+private val MiniProgressHeight = 2.dp
 
 @Composable
 fun MiniPlayer(
@@ -46,82 +68,51 @@ fun MiniPlayer(
 ) {
     if (track == null) return
 
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .liquidGlass(
-                hazeState = hazeState,
-                shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp)
-            )
-            .clickable(
-                interactionSource = null,
-                indication = null,
-                onClick = onClick
-            )
-            .pointerInput(Unit) {
-                var totalHorizontalDrag = 0f
-                var totalVerticalDrag = 0f
-                detectDragGestures(
-                    onDragStart = {
-                        totalHorizontalDrag = 0f
-                        totalVerticalDrag = 0f
-                    },
-                    onDragEnd = {
-                        if (abs(totalVerticalDrag) > abs(totalHorizontalDrag) && totalVerticalDrag < -50f) {
-                            // Swipe Up
-                            onClick()
-                        } else if (abs(totalVerticalDrag) > abs(totalHorizontalDrag) && totalVerticalDrag > 50f) {
-                            // Swipe Down (Collapse logic, if any, could go here)
-                        } else if (totalHorizontalDrag > 50f) {
-                            onSkipPreviousClick()
-                        } else if (totalHorizontalDrag < -50f) {
-                            onSkipNextClick()
-                        }
-                    },
-                    onDrag = { change, dragAmount ->
-                        change.consume()
-                        totalHorizontalDrag += dragAmount.x
-                        totalVerticalDrag += dragAmount.y
-                    }
-                )
-            }
-    ) {
-        Column {
-            LinearProgressIndicator(
-                progress = { progressProvider().coerceIn(0f, 1f) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(2.dp),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.outline
-            )
-            Row(
-                modifier = Modifier.padding(horizontal = MonoDimens.spacingMd, vertical = MonoDimens.spacingSm),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                CoverImage(
-                    url = track.coverUrl,
-                    contentDescription = track.title,
-                    size = MonoDimens.coverMini,
-                    cornerRadius = MonoDimens.radiusSm
-                )
-                Spacer(modifier = Modifier.width(MonoDimens.spacingMd))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = track.title,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = track.displayArtist,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+    // The panel glass (AGSL) only exists on API 33+. Below that, keep the old
+    // haze bar + Material icons — a punched slab would be an opaque block there.
+    val useGlass = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    val swipeGestures = Modifier.pointerInput(Unit) {
+        var totalHorizontalDrag = 0f
+        var totalVerticalDrag = 0f
+        detectDragGestures(
+            onDragStart = {
+                totalHorizontalDrag = 0f
+                totalVerticalDrag = 0f
+            },
+            onDragEnd = {
+                if (abs(totalVerticalDrag) > abs(totalHorizontalDrag) && totalVerticalDrag < -50f) {
+                    // Swipe Up
+                    onClick()
+                } else if (abs(totalVerticalDrag) > abs(totalHorizontalDrag) && totalVerticalDrag > 50f) {
+                    // Swipe Down (Collapse logic, if any, could go here)
+                } else if (totalHorizontalDrag > 50f) {
+                    onSkipPreviousClick()
+                } else if (totalHorizontalDrag < -50f) {
+                    onSkipNextClick()
                 }
+            },
+            onDrag = { change, dragAmount ->
+                change.consume()
+                totalHorizontalDrag += dragAmount.x
+                totalVerticalDrag += dragAmount.y
+            }
+        )
+    }
+
+    if (!useGlass) {
+        // ── Legacy fallback (API < 33): haze glass + Material icon buttons ──
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .liquidGlass(
+                    hazeState = hazeState,
+                    shape = RoundedCornerShape(MiniCorner)
+                )
+                .clickable(interactionSource = null, indication = null, onClick = onClick)
+                .then(swipeGestures)
+        ) {
+            MiniPlayerContent(track, isPlaying, progressProvider) {
                 IconButton(onClick = onPlayPauseClick) {
                     Icon(
                         imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -137,6 +128,123 @@ fun MiniPlayer(
                     )
                 }
             }
+        }
+        return
+    }
+
+    // ── Glass path (API 33+): one panel-glass slab with the play/skip icons
+    // punched out as see-through holes, exactly like the player action dock. ──
+    val tint = MaterialTheme.colorScheme.primary
+    val playPainter = painterResource(if (isPlaying) R.drawable.ic_glass_pause else R.drawable.ic_glass_play)
+    val skipPainter = painterResource(R.drawable.ic_glass_skip_next)
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(MiniCorner))
+            .clickable(interactionSource = null, indication = null, onClick = onClick)
+            .then(swipeGestures)
+    ) {
+        // The glass slab with the two controls carved out of it. One offscreen
+        // layer so the DstOut punch clears only the glyph shapes (revealing the
+        // app behind the bar), not the whole rectangle.
+        Canvas(
+            modifier = Modifier
+                .matchParentSize()
+                .liquidGlassPanel(tint = tint)
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+        ) {
+            val cornerPx = MiniCorner.toPx()
+            drawRoundRect(color = tint, cornerRadius = CornerRadius(cornerPx, cornerPx))
+
+            val cellPx = MiniControlCell.toPx()
+            val iconPx = MiniGlassIcon.toPx()
+            val padPx = MonoDimens.spacingMd.toPx()
+            // Row content centre = progress line + row top padding + half the
+            // (48dp) control cell — the tallest child, so the row's content box.
+            val cy = MiniProgressHeight.toPx() + MonoDimens.spacingSm.toPx() + cellPx / 2f
+            // Rightmost cell is skip-next, the one before it is play/pause; both
+            // inset from the right edge by the row's horizontal padding.
+            val skipCx = size.width - padPx - cellPx * 0.5f
+            val playCx = size.width - padPx - cellPx * 1.5f
+
+            val punch = Paint().apply { blendMode = BlendMode.DstOut }
+            val canvas = drawContext.canvas
+            canvas.saveLayer(Rect(0f, 0f, size.width, size.height), punch)
+            listOf(playCx to playPainter, skipCx to skipPainter).forEach { (cx, painter) ->
+                translate(cx - iconPx / 2f, cy - iconPx / 2f) {
+                    with(painter) { draw(Size(iconPx, iconPx)) }
+                }
+            }
+            canvas.restore()
+        }
+
+        // Transparent content overlay: progress, cover, text, and the two tap
+        // targets sitting exactly over the punched holes (same trailing cells).
+        MiniPlayerContent(track, isPlaying, progressProvider) {
+            Box(
+                modifier = Modifier
+                    .size(MiniControlCell)
+                    .clickable(onClickLabel = if (isPlaying) "Pause" else "Play", onClick = onPlayPauseClick)
+            )
+            Box(
+                modifier = Modifier
+                    .size(MiniControlCell)
+                    .clickable(onClickLabel = "Skip next", onClick = onSkipNextClick)
+            )
+        }
+    }
+}
+
+/**
+ * The shared bar content: the thin progress line, cover, and title/artist, with
+ * the two trailing control slots supplied by [controls] (glass holes' tap targets
+ * on the glass path, Material icon buttons on the legacy path).
+ */
+@Composable
+private fun MiniPlayerContent(
+    track: Track,
+    isPlaying: Boolean,
+    progressProvider: () -> Float,
+    controls: @Composable () -> Unit,
+) {
+    Column {
+        LinearProgressIndicator(
+            progress = { progressProvider().coerceIn(0f, 1f) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(MiniProgressHeight),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.outline
+        )
+        Row(
+            modifier = Modifier.padding(horizontal = MonoDimens.spacingMd, vertical = MonoDimens.spacingSm),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CoverImage(
+                url = track.coverUrl,
+                contentDescription = track.title,
+                size = MonoDimens.coverMini,
+                cornerRadius = MonoDimens.radiusSm
+            )
+            Spacer(modifier = Modifier.width(MonoDimens.spacingMd))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = track.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = track.displayArtist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            controls()
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -507,7 +507,7 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                             onSkipNextClick = { playerViewModel.skipToNext() },
                             onSkipPreviousClick = { playerViewModel.skipToPrevious() },
                             onClick = { navController.navigate(Screen.NowPlaying.route) },
-                            modifier = Modifier.padding(horizontal = 8.dp),
+                            modifier = Modifier.padding(horizontal = 16.dp),
                             hazeState = hazeState
                         )
                     }
@@ -534,6 +534,7 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                         onSkipNextClick = { playerViewModel.skipToNext() },
                         onSkipPreviousClick = { playerViewModel.skipToPrevious() },
                         onClick = { navController.navigate(Screen.NowPlaying.route) },
+                        modifier = Modifier.padding(horizontal = 16.dp),
                         hazeState = hazeState
                     )
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -152,6 +153,8 @@ fun MonochromeNavHost(initialRoute: String? = null) {
 
     val currentTrack by playerViewModel.currentTrack.collectAsState()
     val isPlaying by playerViewModel.isPlaying.collectAsState()
+    // Mini-player glass settings (its own blob; Studio › Mini Player tab).
+    val miniPlayerGlass by playerViewModel.miniPlayerGlass.collectAsState()
 
     // Position/duration tick every 250 ms. Keep them as State<Long> and read
     // only inside the draw-scope progress lambda below — reading `.value` here
@@ -493,17 +496,21 @@ fun MonochromeNavHost(initialRoute: String? = null) {
             Column(modifier = Modifier.align(Alignment.BottomCenter)) {
                 // Mini player — sits below nav bar with its own space
                 if (showMiniPlayer) {
-                    MiniPlayer(
-                        track = currentTrack,
-                        isPlaying = isPlaying,
-                        progressProvider = progressProvider,
-                        onPlayPauseClick = { playerViewModel.togglePlayPause() },
-                        onSkipNextClick = { playerViewModel.skipToNext() },
-                        onSkipPreviousClick = { playerViewModel.skipToPrevious() },
-                        onClick = { navController.navigate(Screen.NowPlaying.route) },
-                        modifier = Modifier.padding(horizontal = 8.dp),
-                        hazeState = hazeState
-                    )
+                    CompositionLocalProvider(
+                        tf.monochrome.android.ui.player.LocalPlayerGlass provides miniPlayerGlass,
+                    ) {
+                        MiniPlayer(
+                            track = currentTrack,
+                            isPlaying = isPlaying,
+                            progressProvider = progressProvider,
+                            onPlayPauseClick = { playerViewModel.togglePlayPause() },
+                            onSkipNextClick = { playerViewModel.skipToNext() },
+                            onSkipPreviousClick = { playerViewModel.skipToPrevious() },
+                            onClick = { navController.navigate(Screen.NowPlaying.route) },
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            hazeState = hazeState
+                        )
+                    }
                 }
 
                 // Fill the system nav bar area
@@ -516,16 +523,20 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                     .align(Alignment.BottomCenter)
                     .padding(bottom = navBarHeight)
             ) {
-                MiniPlayer(
-                    track = currentTrack,
-                    isPlaying = isPlaying,
-                    progressProvider = progressProvider,
-                    onPlayPauseClick = { playerViewModel.togglePlayPause() },
-                    onSkipNextClick = { playerViewModel.skipToNext() },
-                    onSkipPreviousClick = { playerViewModel.skipToPrevious() },
-                    onClick = { navController.navigate(Screen.NowPlaying.route) },
-                    hazeState = hazeState
-                )
+                CompositionLocalProvider(
+                    tf.monochrome.android.ui.player.LocalPlayerGlass provides miniPlayerGlass,
+                ) {
+                    MiniPlayer(
+                        track = currentTrack,
+                        isPlaying = isPlaying,
+                        progressProvider = progressProvider,
+                        onPlayPauseClick = { playerViewModel.togglePlayPause() },
+                        onSkipNextClick = { playerViewModel.skipToNext() },
+                        onSkipPreviousClick = { playerViewModel.skipToPrevious() },
+                        onClick = { navController.navigate(Screen.NowPlaying.route) },
+                        hazeState = hazeState
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -320,34 +320,67 @@ private fun playerGlassModifier(
     }
 }
 
-/** Low-pass-filtered gravity in [-1, 1] per axis; Offset.Zero if no sensor. */
+/**
+ * Low-pass-filtered gravity in [-1, 1] per axis; Offset.Zero if no sensor.
+ *
+ * Every glass surface (each lyric line, the panel, every player button) reads
+ * the same tilt, so instead of each modifier registering its OWN gravity
+ * listener — the player alone had ~7 running at once — they all share ONE
+ * process-wide [GravityTiltSource], ref-counted so the single hardware
+ * registration lives exactly as long as at least one glass surface is composed.
+ */
 @Composable
 private fun rememberGravityTilt(): State<Offset> {
     val context = LocalContext.current
-    val tilt = remember { mutableStateOf(Offset.Zero) }
     DisposableEffect(context) {
-        val manager = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
-        val sensor = manager?.getDefaultSensor(Sensor.TYPE_GRAVITY)
-            ?: manager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-        val listener = object : SensorEventListener {
-            private var fx = 0f
-            private var fy = 0f
-            override fun onSensorChanged(event: SensorEvent) {
-                val gx = (event.values[0] / SensorManager.GRAVITY_EARTH).coerceIn(-1f, 1f)
-                val gy = (event.values[1] / SensorManager.GRAVITY_EARTH).coerceIn(-1f, 1f)
-                fx += (gx - fx) * 0.12f
-                fy += (gy - fy) * 0.12f
-                tilt.value = Offset(fx, fy)
-            }
-
-            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
-        }
-        if (manager != null && sensor != null) {
-            manager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_GAME)
-        }
-        onDispose { manager?.unregisterListener(listener) }
+        GravityTiltSource.acquire(context)
+        onDispose { GravityTiltSource.release() }
     }
-    return tilt
+    return GravityTiltSource.tilt
+}
+
+/**
+ * Shared, ref-counted gravity tilt for all liquid-glass surfaces. Registers a
+ * single [SensorEventListener] on the first [acquire] and unregisters it on the
+ * last [release]. All access is on the main thread (Compose effects + the
+ * main-Looper sensor callback), so the counter and filter need no locking.
+ */
+private object GravityTiltSource : SensorEventListener {
+    val tilt = mutableStateOf(Offset.Zero)
+    private var manager: SensorManager? = null
+    private var refCount = 0
+    private var fx = 0f
+    private var fy = 0f
+
+    fun acquire(context: Context) {
+        if (refCount++ > 0) return
+        val mgr = context.applicationContext
+            .getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+        val sensor = mgr?.getDefaultSensor(Sensor.TYPE_GRAVITY)
+            ?: mgr?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (mgr != null && sensor != null) {
+            manager = mgr
+            mgr.registerListener(this, sensor, SensorManager.SENSOR_DELAY_GAME)
+        }
+    }
+
+    fun release() {
+        if (refCount <= 0) return
+        if (--refCount == 0) {
+            manager?.unregisterListener(this)
+            manager = null
+        }
+    }
+
+    override fun onSensorChanged(event: SensorEvent) {
+        val gx = (event.values[0] / SensorManager.GRAVITY_EARTH).coerceIn(-1f, 1f)
+        val gy = (event.values[1] / SensorManager.GRAVITY_EARTH).coerceIn(-1f, 1f)
+        fx += (gx - fx) * 0.12f
+        fy += (gy - fy) * 0.12f
+        tilt.value = Offset(fx, fy)
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
 }
 
 // Static (not time-animated) noise: fixes banding without shimmer. Noise is

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -444,6 +444,29 @@ float3 backdropTintAt(float2 uv) {
     return mix(uTint, two, uBackdropMix);
 }
 
+// Procedural studio environment, sampled by the reflection vector. A soft
+// vertical light gradient plus a moving key light and a cooler fill, so the
+// glass catches a believable "room" that streaks across the bevel as the
+// surface normal turns — instead of one flat, generic highlight. Device tilt
+// and a slow drift move the lights so the reflections stay alive.
+float3 environment(float3 r, float2 tilt, float t, float liquid) {
+    float2 d = r.xy;
+    // Screen y is down, so the bright sky is where the reflection points up
+    // (r.y < 0): a soft top->bottom studio gradient.
+    float up = clamp(0.5 - 0.5 * r.y, 0.0, 1.0);
+    float3 sky = mix(float3(0.05, 0.06, 0.08), float3(0.82, 0.88, 1.0),
+                     smoothstep(0.12, 0.96, up));
+    // Bright soft key light near the top, nudged by tilt + a slow drift.
+    float2 key = float2(-0.30, -0.62) + tilt * 0.5
+               + 0.06 * float2(sin(t * 0.40), cos(t * 0.33)) * liquid;
+    float keyI = smoothstep(0.55, 0.0, distance(d, key));
+    // Cooler fill light from the opposite corner.
+    float2 fill = float2(0.52, 0.5) - tilt * 0.4;
+    float fillI = smoothstep(0.72, 0.0, distance(d, fill)) * 0.5;
+    return sky + float3(1.0, 0.97, 0.92) * keyI * 1.7
+              + float3(0.65, 0.82, 1.0) * fillI;
+}
+
 half4 main(float2 p) {
     half4 src = content.eval(p);
     float a = float(src.a);
@@ -486,81 +509,80 @@ half4 main(float2 p) {
                              (aNW + aNE) - (aSW + aSE));
     }
 
-    // Liquid: the surface itself undulates, so highlights swim over glyphs.
+    // Liquid: subtle surface undulation so highlights swim over the glass.
     // uLiquid scales this unrest — the big button disc dials it down so its
-    // glass reads clean and smooth instead of cloudy/blotchy.
+    // glass reads clean and smooth rather than cloudy.
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);
     float w2 = sin((p.x + p.y) * 0.035 - uTime * 0.9);
     grad += 0.05 * uLiquid * float2(w1, w2) * a;
 
-    float2 slope = grad;                        // raw bevel slope → lens displacement
-    // Depth (profondeur): a shallower z base tips the bevel normal further off
-    // the surface, so the glass reads thicker with a deeper, rounder relief.
-    // uDepth = 1 keeps the original 0.62 z; higher = steeper, more 3D.
-    float zbase = clamp(0.62 / max(uDepth, 0.25), 0.14, 1.4);
-    float3 N = normalize(float3(grad, zbase));
+    // Surface normal from the alpha heightfield. Depth (profondeur) scales how
+    // hard the bevel tips the normal off the surface — the dominant "3D" knob,
+    // now a strong multiplier on the slope instead of a small z-base nudge.
+    float slopeGain = 3.5 * uDepth;
+    float3 N = normalize(float3(grad * slopeGain, 1.0));
 
-    // Light = device tilt + slow autonomous drift, biased above the screen.
-    float3 L = normalize(float3(
-        -uTilt.x * 0.7 + 0.30 * sin(uTime * 0.37),
-         uTilt.y * 0.7 + 0.22 * cos(uTime * 0.29) - 0.35,
-         0.80));
-    float3 H = normalize(L + float3(0.0, 0.0, 1.0));
-
-    float ndh   = max(dot(N, H), 0.0);
-    float spec  = pow(ndh, 110.0);
-    float sheen = pow(ndh, 8.0);
-    float fres  = pow(1.0 - clamp(N.z, 0.0, 1.0), 3.0);
-
-    // Chromatic dispersion: red/blue speculars from nudged normals.
-    float disp = 0.02 * uDispersion;
-    float specR = pow(max(dot(normalize(N + float3(disp, 0.0, 0.0)), H), 0.0), 110.0);
-    float specB = pow(max(dot(normalize(N - float3(disp, 0.0, 0.0)), H), 0.0), 110.0);
-
-    // Refraction: the bevel slope bends where we read the backdrop, and each
-    // colour channel bends by a slightly different amount (chromatic aberration
-    // at the rim), so the glass genuinely lenses the field behind it.
     float2 uv = p / uSize;
-    float2 lens = slope * uRefraction;
-    float aberr = 0.12 * uDispersion;
-    float2 uvR = uv + lens * (1.0 + aberr);
-    float2 uvG = uv + lens;
-    float2 uvB = uv + lens * (1.0 - aberr);
-    // Per-channel lens weight (as before) modulated by the local album tone, so
-    // when the blurred cover is behind the glass the refraction bends real colour
-    // (Apple-OS look); with no blurred art this equals uTint * field (unchanged).
-    float3 bg = float3(
+    float3 I = float3(0.0, 0.0, -1.0);   // view ray, into the screen
+
+    // Fresnel (Schlick, F0 = 0.04 for glass): ~4% reflection head-on, climbing
+    // to ~100% at grazing edges. This is what makes the rim catch the light and
+    // the face stay see-through — the core of the glass look.
+    float cosV = clamp(N.z, 0.0, 1.0);
+    float fres = 0.04 + 0.96 * pow(1.0 - cosV, 5.0);
+
+    // Refraction (Snell, via refract) with a per-channel index of refraction so
+    // R/G/B bend by different amounts — true chromatic dispersion, strongest at
+    // the edges where the bevel turns. eta = n_air / n_glass ~ 0.66.
+    float dispSpread = 0.06 * uDispersion;
+    float3 Tr = refract(I, N, 0.66 - dispSpread);
+    float3 Tg = refract(I, N, 0.66);
+    float3 Tb = refract(I, N, 0.66 + dispSpread);
+    float power = uRefraction * 1.6;
+    float2 uvR = uv + Tr.xy * power;
+    float2 uvG = uv + Tg.xy * power;
+    float2 uvB = uv + Tb.xy * power;
+    float3 refr = float3(
         backdropTintAt(uvR).r * backdropField(uvR),
         backdropTintAt(uvG).g * backdropField(uvG),
         backdropTintAt(uvB).b * backdropField(uvB));
 
-    // A sheet of light sweeping diagonally across the whole surface.
-    float band = 1.0 - smoothstep(0.0, 0.18,
-        abs(uv.x * 0.8 + uv.y * 0.5 - mix(-0.35, 1.65, fract(uTime * 0.11))));
+    // Reflected environment: the room the glass catches, turning with N so the
+    // reflection streaks across the bevel as the surface curves.
+    float3 refl = environment(reflect(I, N), uTilt, uTime, uLiquid);
 
-    // Frost body: mostly the glyph's own colour (so the active accent line stays
-    // legible), with the lensed backdrop bleeding in for depth.
-    float3 tint = float3(src.rgb) / a;
-    float lum = clamp(dot(tint, float3(0.299, 0.587, 0.114)), 0.0, 1.0);
-    // Over the blurred album art the glass leans more see-through (more lensed
-    // backdrop, less solid frost) so it reads as real glass on the artwork;
-    // with no blurred art it holds the legible 0.7 glyph-colour mix.
-    float3 frost = mix(bg, tint, mix(0.7, 0.42, uBackdropMix));
+    // Crisp specular glint from a tilt-driven key light, dispersed for sparkle.
+    float3 L = normalize(float3(
+        -uTilt.x * 0.8 + 0.25 * sin(uTime * 0.37),
+         uTilt.y * 0.8 + 0.20 * cos(uTime * 0.29) - 0.5,
+         0.85));
+    float3 H = normalize(L + float3(0.0, 0.0, 1.0));
+    float ndh   = max(dot(N, H), 0.0);
+    float spec  = pow(ndh, 90.0);
+    float dsp   = 0.015 * uDispersion;
+    float specR = pow(max(dot(normalize(N + float3(dsp, 0.0, 0.0)), H), 0.0), 90.0);
+    float specB = pow(max(dot(normalize(N - float3(dsp, 0.0, 0.0)), H), 0.0), 90.0);
 
-    // Transparent body, opaque bright rim. Alpha is low across the letter face
-    // (backdrop reads through) and climbs to full at the beveled edge, so the
-    // rim's specular can shine as a crisp glass edge instead of being clamped
-    // away. Dim past/upcoming lines (low src alpha) stay subtle automatically.
-    float rim = clamp(spec * 1.3 + fres * 0.9, 0.0, 1.0);
-    float bodyOpacity = uBodyOpacity;
-    float outA = clamp(a * (bodyOpacity + (1.0 - bodyOpacity) * rim), 0.0, a);
-    float lightGain = (0.30 + 0.70 * lum) * uRimGain;
+    // Body: the glyph's own colour (kept legible) with a hint of the lensed
+    // backdrop; leans more see-through over real blurred art.
+    float3 glyphTint = float3(src.rgb) / a;
+    float bodyMix = mix(0.72, 0.42, uBackdropMix);
+    float3 bodyCol = mix(refr, glyphTint, bodyMix);
 
-    float3 col = frost * (0.9 + 0.14 * band * uLiquid) * outA;   // premultiplied frost body
-    col += (float3(specR, spec, specB) * 1.10
-            + float3(0.80, 0.90, 1.00) * (fres * 0.40)
-            + float3(sheen) * (0.05 + 0.22 * band * uLiquid)) * (outA * lightGain);
-    col = min(col, float3(outA));
+    // Fresnel-blend the reflection over the body (edges reflect, the face
+    // transmits), then add the dispersed glint. uRimGain scales both the
+    // reflection and the glint, so "Edge highlight" is a real brightness knob.
+    float3 col3 = mix(bodyCol, refl * uRimGain, clamp(fres * 1.1, 0.0, 1.0));
+    col3 += float3(specR, spec, specB) * uRimGain;
+
+    // Transparent face, opaque bright rim: alpha is low across the body (backdrop
+    // reads through) and climbs to full where Fresnel and the glint peak, so the
+    // rim highlight reads as a crisp glass edge rather than being clamped away.
+    float rim = clamp(fres * 1.2 + spec, 0.0, 1.0);
+    float outA = clamp(a * (uBodyOpacity + (1.0 - uBodyOpacity) * rim), 0.0, a);
+
+    float3 col = col3 * outA;              // premultiplied
+    col = min(col, float3(outA));          // keep rgb <= alpha (premult-valid)
     return half4(half3(col), half(outA));
 }
 """

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -181,6 +181,8 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uRimGain", fx.glassRimBrightness)
             shader.setFloatUniform("uDispersion", fx.glassDispersion)
             shader.setFloatUniform("uSampleRings", fx.glassSampleRings.toFloat())
+            shader.setFloatUniform("uRoundness", 1f)
+            shader.setFloatUniform("uDepth", 1f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -230,6 +232,8 @@ private fun liquidGlassPanelModifier(tint: Color): Modifier {
             shader.setFloatUniform("uRimGain", 1.30f)
             shader.setFloatUniform("uDispersion", 1.0f)
             shader.setFloatUniform("uSampleRings", 2f)
+            shader.setFloatUniform("uRoundness", 1f)
+            shader.setFloatUniform("uDepth", 1f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -280,6 +284,8 @@ private fun playerGlassModifier(
             shader.setFloatUniform("uRimGain", g.rimBrightness)
             shader.setFloatUniform("uDispersion", g.dispersion)
             shader.setFloatUniform("uSampleRings", g.sampleRings.toFloat())
+            shader.setFloatUniform("uRoundness", g.roundness)
+            shader.setFloatUniform("uDepth", g.depth)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -411,6 +417,8 @@ uniform float uDispersion;    // chromatic aberration at the refracting edges
 uniform float uSampleRings;   // bevel sample rings 1/2/3 → 5/9/13 taps per pixel
 uniform float3 uTint2;        // second album tone (blurred-art backdrop)
 uniform float uBackdropMix;   // 0 = flat single-tint wash; >0 = lens the album art
+uniform float uRoundness;     // bevel shoulder width: 1 = neutral, higher = rounder/softer edge
+uniform float uDepth;         // profondeur: 1 = neutral, higher = steeper relief / more 3D
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -444,26 +452,30 @@ half4 main(float2 p) {
     // setting (uSampleRings): the fine cross is always taken; the broad ring and
     // the diagonal ring are gated so lower quality skips those texture fetches —
     // fewer taps per pixel is a real GPU saving.
-    float aL1 = float(content.eval(p + float2(-1.25, 0.0)).a);
-    float aR1 = float(content.eval(p + float2( 1.25, 0.0)).a);
-    float aU1 = float(content.eval(p + float2(0.0, -1.25)).a);
-    float aD1 = float(content.eval(p + float2(0.0,  1.25)).a);
+    // Roundness widens the taps: a broader sampling radius reads the alpha edge
+    // over a wider band, so the bevel shoulder rolls off round and pillowy
+    // instead of a tight, sharp edge (rr = 1 reproduces the original look).
+    float rr = uRoundness;
+    float aL1 = float(content.eval(p + float2(-1.25 * rr, 0.0)).a);
+    float aR1 = float(content.eval(p + float2( 1.25 * rr, 0.0)).a);
+    float aU1 = float(content.eval(p + float2(0.0, -1.25 * rr)).a);
+    float aD1 = float(content.eval(p + float2(0.0,  1.25 * rr)).a);
     float2 grad = float2(aL1 - aR1, aU1 - aD1);
 
     if (uSampleRings > 1.5) {
         // Broad ring: rounder, softer bevel.
-        float aL2 = float(content.eval(p + float2(-2.5, 0.0)).a);
-        float aR2 = float(content.eval(p + float2( 2.5, 0.0)).a);
-        float aU2 = float(content.eval(p + float2(0.0, -2.5)).a);
-        float aD2 = float(content.eval(p + float2(0.0,  2.5)).a);
+        float aL2 = float(content.eval(p + float2(-2.5 * rr, 0.0)).a);
+        float aR2 = float(content.eval(p + float2( 2.5 * rr, 0.0)).a);
+        float aU2 = float(content.eval(p + float2(0.0, -2.5 * rr)).a);
+        float aD2 = float(content.eval(p + float2(0.0,  2.5 * rr)).a);
         grad += 0.4 * float2(aL2 - aR2, aU2 - aD2);
     }
     if (uSampleRings > 2.5) {
         // Diagonal ring: smoother normals on curved strokes.
-        float aNW = float(content.eval(p + float2(-1.8, -1.8)).a);
-        float aNE = float(content.eval(p + float2( 1.8, -1.8)).a);
-        float aSW = float(content.eval(p + float2(-1.8,  1.8)).a);
-        float aSE = float(content.eval(p + float2( 1.8,  1.8)).a);
+        float aNW = float(content.eval(p + float2(-1.8 * rr, -1.8 * rr)).a);
+        float aNE = float(content.eval(p + float2( 1.8 * rr, -1.8 * rr)).a);
+        float aSW = float(content.eval(p + float2(-1.8 * rr,  1.8 * rr)).a);
+        float aSE = float(content.eval(p + float2( 1.8 * rr,  1.8 * rr)).a);
         grad += 0.3 * float2((aNW + aSW) - (aNE + aSE),
                              (aNW + aNE) - (aSW + aSE));
     }
@@ -474,7 +486,11 @@ half4 main(float2 p) {
     grad += 0.05 * float2(w1, w2) * a;
 
     float2 slope = grad;                        // raw bevel slope → lens displacement
-    float3 N = normalize(float3(grad, 0.62));
+    // Depth (profondeur): a shallower z base tips the bevel normal further off
+    // the surface, so the glass reads thicker with a deeper, rounder relief.
+    // uDepth = 1 keeps the original 0.62 z; higher = steeper, more 3D.
+    float zbase = clamp(0.62 / max(uDepth, 0.25), 0.14, 1.4);
+    float3 N = normalize(float3(grad, zbase));
 
     // Light = device tilt + slow autonomous drift, biased above the screen.
     float3 L = normalize(float3(

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -47,8 +47,9 @@ internal fun Modifier.liquidGlass(
     enabled: Boolean = true,
     tint: Color = Color(0xFF8FB4FF),
 ): Modifier {
-    if (!enabled || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
-    return this.then(liquidGlassModifier(tint))
+    val fx = LocalLyricsFx.current
+    if (!enabled || !fx.liquidGlass || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
+    return this.then(liquidGlassModifier(tint, fx))
 }
 
 // One process-wide epoch so every rememberFrameSeconds() instance reports the
@@ -95,7 +96,10 @@ internal fun Modifier.dithered(): Modifier {
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
-private fun liquidGlassModifier(tint: Color): Modifier {
+private fun liquidGlassModifier(
+    tint: Color,
+    fx: tf.monochrome.android.domain.model.LyricsFxSettings,
+): Modifier {
     val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() }
         ?: return Modifier
 
@@ -108,6 +112,10 @@ private fun liquidGlassModifier(tint: Color): Modifier {
             shader.setFloatUniform("uTime", timeSec.value)
             shader.setFloatUniform("uTilt", tilt.value.x, tilt.value.y)
             shader.setFloatUniform("uTint", tint.red, tint.green, tint.blue)
+            shader.setFloatUniform("uBodyOpacity", fx.glassBodyOpacity)
+            shader.setFloatUniform("uRefraction", fx.glassRefraction)
+            shader.setFloatUniform("uRimGain", fx.glassRimBrightness)
+            shader.setFloatUniform("uDispersion", fx.glassDispersion)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -178,6 +186,10 @@ uniform float2 uSize;
 uniform float uTime;
 uniform float2 uTilt;
 uniform float3 uTint;
+uniform float uBodyOpacity;   // glass body opacity (lower = more see-through)
+uniform float uRefraction;    // how hard the bevel lenses the backdrop
+uniform float uRimGain;       // brightness of the specular glass edge
+uniform float uDispersion;    // chromatic aberration at the refracting edges
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -232,17 +244,19 @@ half4 main(float2 p) {
     float fres  = pow(1.0 - clamp(N.z, 0.0, 1.0), 3.0);
 
     // Chromatic dispersion: red/blue speculars from nudged normals.
-    float specR = pow(max(dot(normalize(N + float3(0.02, 0.0, 0.0)), H), 0.0), 110.0);
-    float specB = pow(max(dot(normalize(N - float3(0.02, 0.0, 0.0)), H), 0.0), 110.0);
+    float disp = 0.02 * uDispersion;
+    float specR = pow(max(dot(normalize(N + float3(disp, 0.0, 0.0)), H), 0.0), 110.0);
+    float specB = pow(max(dot(normalize(N - float3(disp, 0.0, 0.0)), H), 0.0), 110.0);
 
     // Refraction: the bevel slope bends where we read the backdrop, and each
     // colour channel bends by a slightly different amount (chromatic aberration
     // at the rim), so the glass genuinely lenses the field behind it.
     float2 uv = p / uSize;
-    float2 lens = slope * 0.14;
-    float fieldR = backdropField(uv + lens * 1.12);
+    float2 lens = slope * uRefraction;
+    float aberr = 0.12 * uDispersion;
+    float fieldR = backdropField(uv + lens * (1.0 + aberr));
     float fieldG = backdropField(uv + lens);
-    float fieldB = backdropField(uv + lens * 0.88);
+    float fieldB = backdropField(uv + lens * (1.0 - aberr));
     float3 bg = uTint * float3(fieldR, fieldG, fieldB);
 
     // A sheet of light sweeping diagonally across the whole surface.
@@ -260,9 +274,9 @@ half4 main(float2 p) {
     // rim's specular can shine as a crisp glass edge instead of being clamped
     // away. Dim past/upcoming lines (low src alpha) stay subtle automatically.
     float rim = clamp(spec * 1.3 + fres * 0.9, 0.0, 1.0);
-    float bodyOpacity = 0.62;
+    float bodyOpacity = uBodyOpacity;
     float outA = clamp(a * (bodyOpacity + (1.0 - bodyOpacity) * rim), 0.0, a);
-    float lightGain = 0.30 + 0.70 * lum;
+    float lightGain = (0.30 + 0.70 * lum) * uRimGain;
 
     float3 col = frost * (0.9 + 0.14 * band) * outA;   // premultiplied frost body
     col += (float3(specR, spec, specB) * 1.10

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -121,7 +121,6 @@ private fun fxaaModifier(strength: Float): Modifier {
     } ?: return Modifier
     return Modifier.graphicsLayer {
         if (size.minDimension > 0f) {
-            shader.setFloatUniform("uSize", size.width, size.height)
             shader.setFloatUniform("uStrength", strength)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
@@ -217,11 +216,9 @@ half4 main(float2 p) {
 // cross-fades the anti-aliased result back over the original.
 private const val FXAA_SRC = """
 uniform shader content;
-uniform float2 uSize;
 uniform float uStrength;
 
 half4 main(float2 frag) {
-    float2 inv = 1.0 / uSize;
     float3 luma = float3(0.299, 0.587, 0.114);
     float SPAN_MAX = 8.0;
     float REDUCE_MUL = 1.0 / 8.0;
@@ -247,7 +244,9 @@ half4 main(float2 frag) {
          ((lumaNW + lumaSW) - (lumaNE + lumaSE)));
     float dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * REDUCE_MUL), REDUCE_MIN);
     float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
-    dir = clamp(dir * rcpDirMin, -SPAN_MAX, SPAN_MAX) * inv;
+    // frag is in pixels (see the +/-1px luma taps above), so the blend offsets
+    // must stay in pixels too — no texel-size (1/uSize) scaling here.
+    dir = clamp(dir * rcpDirMin, -SPAN_MAX, SPAN_MAX);
 
     // Do the blend in float precision (the codebase's convention) to avoid
     // half/float mismatch on scalar-vector ops, then convert back at the end.

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -19,26 +19,36 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 
 /**
  * "Liquid glass" treatment for the lyric surfaces: an AGSL RenderEffect that
- * relights the already-drawn glyphs as beveled, undulating glass. Normals are
- * derived from the text's own alpha field, so it is draw-only — layout, font
- * size and line spacing are untouched. The light direction follows device
- * tilt (gravity sensor) plus a slow autonomous drift, and a light sheet
- * sweeps across the surface periodically.
+ * turns the already-drawn glyphs into real, refractive glass. The bevel normal
+ * is derived from the text's own alpha field (so it stays draw-only — layout,
+ * font size and line spacing are untouched); the glyph body is rendered
+ * see-through, the smooth album-tinted backdrop is reconstructed and *lensed*
+ * through that bevel (with chromatic aberration), and a bright specular rim
+ * rides the beveled edge. The light direction follows device tilt (gravity
+ * sensor) plus a slow autonomous drift, and a light sheet sweeps the surface.
+ *
+ * [tint] is the album colour the reconstructed backdrop and the glass frost are
+ * tinted with — pass the active accent so the refraction matches what's behind
+ * the lyrics.
  *
  * Requires API 33 (RuntimeShader); below that, or if the shader fails to
- * compile on some GPU driver, the modifier is a no-op and lyrics render as
- * before.
+ * compile on some GPU driver, the modifier is a no-op and lyrics render as the
+ * solid text they were handed.
  */
 @Composable
-internal fun Modifier.liquidGlass(enabled: Boolean = true): Modifier {
+internal fun Modifier.liquidGlass(
+    enabled: Boolean = true,
+    tint: Color = Color(0xFF8FB4FF),
+): Modifier {
     if (!enabled || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
-    return this.then(liquidGlassModifier())
+    return this.then(liquidGlassModifier(tint))
 }
 
 // One process-wide epoch so every rememberFrameSeconds() instance reports the
@@ -85,7 +95,7 @@ internal fun Modifier.dithered(): Modifier {
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
-private fun liquidGlassModifier(): Modifier {
+private fun liquidGlassModifier(tint: Color): Modifier {
     val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() }
         ?: return Modifier
 
@@ -97,6 +107,7 @@ private fun liquidGlassModifier(): Modifier {
             shader.setFloatUniform("uSize", size.width, size.height)
             shader.setFloatUniform("uTime", timeSec.value)
             shader.setFloatUniform("uTilt", tilt.value.x, tilt.value.y)
+            shader.setFloatUniform("uTint", tint.red, tint.green, tint.blue)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -150,18 +161,39 @@ half4 main(float2 p) {
 }
 """
 
-// All colour math below is in premultiplied alpha (RenderEffect contract):
-// additive light terms are scaled by src.a and the result clamped to <= a,
-// which keeps anti-aliased glyph edges valid and free of halos.
+// True refractive glass. Output stays in premultiplied alpha (RenderEffect
+// contract): the final rgb is clamped to <= the emitted alpha, so anti-aliased
+// glyph edges remain valid and halo-free. The glyph body is emitted at reduced
+// alpha (the backdrop shows through), while the beveled rim rises back to full
+// alpha so its bright specular can read as a crisp glass edge.
+//
+// Smooth-backdrop note: the field the glass refracts is reconstructed in-shader
+// (a soft vertical wash + a top glow, album-tinted) to mirror the smooth
+// gradient that actually sits behind the lyrics. Because that real backdrop is
+// low-frequency, a reconstructed field lenses indistinguishably from sampling
+// the real pixels — and it needs no fragile per-frame backdrop capture.
 private const val LIQUID_GLASS_SRC = """
 uniform shader content;
 uniform float2 uSize;
 uniform float uTime;
 uniform float2 uTilt;
+uniform float3 uTint;
+
+// Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
+// Returns a 0..1 luminance weight for the tint at uv (matches the vertical
+// wash + soft top glow drawn behind the lyrics).
+float backdropField(float2 uv) {
+    float wash = mix(0.45, 0.0, clamp(uv.y, 0.0, 1.0));
+    float glow = smoothstep(1.0, 0.0, distance(uv, float2(0.5, 0.22)) * 1.5);
+    return clamp(wash + glow * 0.5, 0.0, 1.0);
+}
 
 half4 main(float2 p) {
     half4 src = content.eval(p);
     float a = float(src.a);
+    // Outside the glyphs the surface is empty, so the glass exists only where a
+    // letter is: hand those pixels straight back (transparent) and the real
+    // backdrop behind the lyric layer shows through untouched.
     if (a < 0.004) {
         return src;
     }
@@ -172,18 +204,19 @@ half4 main(float2 p) {
     float aR1 = float(content.eval(p + float2( 1.25, 0.0)).a);
     float aU1 = float(content.eval(p + float2(0.0, -1.25)).a);
     float aD1 = float(content.eval(p + float2(0.0,  1.25)).a);
-    float aL2 = float(content.eval(p + float2(-2.0, 0.0)).a);
-    float aR2 = float(content.eval(p + float2( 2.0, 0.0)).a);
-    float aU2 = float(content.eval(p + float2(0.0, -2.0)).a);
-    float aD2 = float(content.eval(p + float2(0.0,  2.0)).a);
-    float2 grad = float2((aL1 - aR1) + 0.35 * (aL2 - aR2),
-                         (aU1 - aD1) + 0.35 * (aU2 - aD2));
+    float aL2 = float(content.eval(p + float2(-2.5, 0.0)).a);
+    float aR2 = float(content.eval(p + float2( 2.5, 0.0)).a);
+    float aU2 = float(content.eval(p + float2(0.0, -2.5)).a);
+    float aD2 = float(content.eval(p + float2(0.0,  2.5)).a);
+    float2 grad = float2((aL1 - aR1) + 0.4 * (aL2 - aR2),
+                         (aU1 - aD1) + 0.4 * (aU2 - aD2));
 
     // Liquid: the surface itself undulates, so highlights swim over glyphs.
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);
     float w2 = sin((p.x + p.y) * 0.035 - uTime * 0.9);
     grad += 0.05 * float2(w1, w2) * a;
 
+    float2 slope = grad;                        // raw bevel slope → lens displacement
     float3 N = normalize(float3(grad, 0.62));
 
     // Light = device tilt + slow autonomous drift, biased above the screen.
@@ -193,31 +226,49 @@ half4 main(float2 p) {
          0.80));
     float3 H = normalize(L + float3(0.0, 0.0, 1.0));
 
-    float ndl   = max(dot(N, L), 0.0);
-    float spec  = pow(max(dot(N, H), 0.0), 96.0);
-    float sheen = pow(max(dot(N, H), 0.0), 7.0);
+    float ndh   = max(dot(N, H), 0.0);
+    float spec  = pow(ndh, 110.0);
+    float sheen = pow(ndh, 8.0);
     float fres  = pow(1.0 - clamp(N.z, 0.0, 1.0), 3.0);
 
-    // Slight dispersion: red/blue speculars from nudged normals.
-    float specR = pow(max(dot(normalize(N + float3(0.015, 0.0, 0.0)), H), 0.0), 96.0);
-    float specB = pow(max(dot(normalize(N - float3(0.015, 0.0, 0.0)), H), 0.0), 96.0);
+    // Chromatic dispersion: red/blue speculars from nudged normals.
+    float specR = pow(max(dot(normalize(N + float3(0.02, 0.0, 0.0)), H), 0.0), 110.0);
+    float specB = pow(max(dot(normalize(N - float3(0.02, 0.0, 0.0)), H), 0.0), 110.0);
+
+    // Refraction: the bevel slope bends where we read the backdrop, and each
+    // colour channel bends by a slightly different amount (chromatic aberration
+    // at the rim), so the glass genuinely lenses the field behind it.
+    float2 uv = p / uSize;
+    float2 lens = slope * 0.14;
+    float fieldR = backdropField(uv + lens * 1.12);
+    float fieldG = backdropField(uv + lens);
+    float fieldB = backdropField(uv + lens * 0.88);
+    float3 bg = uTint * float3(fieldR, fieldG, fieldB);
 
     // A sheet of light sweeping diagonally across the whole surface.
-    float2 uv = p / uSize;
     float band = 1.0 - smoothstep(0.0, 0.18,
         abs(uv.x * 0.8 + uv.y * 0.5 - mix(-0.35, 1.65, fract(uTime * 0.11))));
 
-    float3 base = float3(src.rgb);
-    // Light scales with the line's own brightness: dim past/upcoming lines
-    // keep tight, quiet edges instead of full-brightness rims that read as
-    // blur; the bright active line gets the full glass treatment.
-    float lum = clamp(dot(base / a, float3(0.299, 0.587, 0.114)), 0.0, 1.0);
-    float lightGain = 0.10 + 0.90 * lum * lum;
-    float3 col = base * (0.82 + 0.16 * ndl + 0.06 * band);
-    col += (float3(specR, spec, specB) * 0.85
-            + float3(0.75, 0.85, 1.0) * (fres * 0.22)
-            + float3(sheen) * (0.06 + 0.30 * band)) * (a * lightGain);
-    col = min(col, float3(a));
-    return half4(half3(col), src.a);
+    // Frost body: mostly the glyph's own colour (so the active accent line stays
+    // legible), with the lensed backdrop bleeding in for depth.
+    float3 tint = float3(src.rgb) / a;
+    float lum = clamp(dot(tint, float3(0.299, 0.587, 0.114)), 0.0, 1.0);
+    float3 frost = mix(bg, tint, 0.7);
+
+    // Transparent body, opaque bright rim. Alpha is low across the letter face
+    // (backdrop reads through) and climbs to full at the beveled edge, so the
+    // rim's specular can shine as a crisp glass edge instead of being clamped
+    // away. Dim past/upcoming lines (low src alpha) stay subtle automatically.
+    float rim = clamp(spec * 1.3 + fres * 0.9, 0.0, 1.0);
+    float bodyOpacity = 0.62;
+    float outA = clamp(a * (bodyOpacity + (1.0 - bodyOpacity) * rim), 0.0, a);
+    float lightGain = 0.30 + 0.70 * lum;
+
+    float3 col = frost * (0.9 + 0.14 * band) * outA;   // premultiplied frost body
+    col += (float3(specR, spec, specB) * 1.10
+            + float3(0.80, 0.90, 1.00) * (fres * 0.40)
+            + float3(sheen) * (0.05 + 0.22 * band)) * (outA * lightGain);
+    col = min(col, float3(outA));
+    return half4(half3(col), half(outA));
 }
 """

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -113,8 +113,12 @@ internal fun Modifier.fxaa(): Modifier {
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 private fun fxaaModifier(strength: Float): Modifier {
-    val shader = remember { runCatching { RuntimeShader(FXAA_SRC) }.getOrNull() }
-        ?: return Modifier
+    val shader = remember {
+        runCatching { RuntimeShader(FXAA_SRC) }
+            .onSuccess { LyricsDebug.log("FXAA shader compiled") }
+            .onFailure { LyricsDebug.log("FXAA shader FAILED to compile: ${it.message}") }
+            .getOrNull()
+    } ?: return Modifier
     return Modifier.graphicsLayer {
         if (size.minDimension > 0f) {
             shader.setFloatUniform("uSize", size.width, size.height)
@@ -132,8 +136,12 @@ private fun liquidGlassModifier(
     tint: Color,
     fx: tf.monochrome.android.domain.model.LyricsFxSettings,
 ): Modifier {
-    val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() }
-        ?: return Modifier
+    val shader = remember {
+        runCatching { RuntimeShader(LIQUID_GLASS_SRC) }
+            .onSuccess { LyricsDebug.log("liquid-glass shader compiled") }
+            .onFailure { LyricsDebug.log("liquid-glass shader FAILED to compile: ${it.message}") }
+            .getOrNull()
+    } ?: return Modifier
 
     val timeSec = rememberFrameSeconds()
     val tilt = rememberGravityTilt()

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -184,6 +184,13 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uRoundness", 1f)
             shader.setFloatUniform("uDepth", 1f)
             shader.setFloatUniform("uLiquid", 1f)
+            // Lyrics keep the neutral (non-player-tunable) relight parameters.
+            shader.setFloatUniform("uReflection", 1f)
+            shader.setFloatUniform("uGloss", 90f)
+            shader.setFloatUniform("uTiltAmount", 0.7f)
+            shader.setFloatUniform("uLightAngle", 2.3561945f)   // 135°
+            shader.setFloatUniform("uFresnelPower", 5f)
+            shader.setFloatUniform("uFrost", 0f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -236,6 +243,13 @@ private fun liquidGlassPanelModifier(tint: Color): Modifier {
             shader.setFloatUniform("uRoundness", 1f)
             shader.setFloatUniform("uDepth", 1f)
             shader.setFloatUniform("uLiquid", 1f)
+            // Panel keeps the neutral relight parameters.
+            shader.setFloatUniform("uReflection", 1f)
+            shader.setFloatUniform("uGloss", 90f)
+            shader.setFloatUniform("uTiltAmount", 0.7f)
+            shader.setFloatUniform("uLightAngle", 2.3561945f)   // 135°
+            shader.setFloatUniform("uFresnelPower", 5f)
+            shader.setFloatUniform("uFrost", 0f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -288,9 +302,17 @@ private fun playerGlassModifier(
             shader.setFloatUniform("uSampleRings", g.sampleRings.toFloat())
             shader.setFloatUniform("uRoundness", g.roundness)
             shader.setFloatUniform("uDepth", g.depth)
-            // Calmer surface for the button chrome so the big disc reads clean
-            // and smooth rather than cloudy.
-            shader.setFloatUniform("uLiquid", 0.25f)
+            // Player-tunable relight (Studio "Player Glass" tab). Surface motion
+            // replaces the old fixed 0.25 calm; gloss maps to a specular exponent
+            // (20 = soft/frosted-wide .. 260 = tight mirror), edge width to the
+            // Fresnel falloff (8 = thin crisp .. 2 = broad shoulder).
+            shader.setFloatUniform("uLiquid", g.surfaceMotion)
+            shader.setFloatUniform("uReflection", g.reflection)
+            shader.setFloatUniform("uGloss", 20f + 240f * g.gloss)
+            shader.setFloatUniform("uTiltAmount", g.tiltReactivity)
+            shader.setFloatUniform("uLightAngle", g.lightAngleDeg * 0.017453292f)
+            shader.setFloatUniform("uFresnelPower", 8f - 6f * g.edgeWidth)
+            shader.setFloatUniform("uFrost", g.frost)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -425,6 +447,12 @@ uniform float uBackdropMix;   // 0 = flat single-tint wash; >0 = lens the album 
 uniform float uRoundness;     // bevel shoulder width: 1 = neutral, higher = rounder/softer edge
 uniform float uDepth;         // profondeur: 1 = neutral, higher = steeper relief / more 3D
 uniform float uLiquid;        // surface unrest: 1 = full moving sheen, lower = calmer, cleaner glass
+uniform float uReflection;    // environment ("room") reflection strength
+uniform float uGloss;         // specular exponent: higher = tighter, mirror-polished glint
+uniform float uTiltAmount;    // how strongly device tilt moves the light/reflection
+uniform float uLightAngle;    // key-light direction, radians
+uniform float uFresnelPower;  // Fresnel falloff: lower = broader reflective rim
+uniform float uFrost;         // frosted roughness: 0 = clear, higher = misted
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -449,19 +477,20 @@ float3 backdropTintAt(float2 uv) {
 // glass catches a believable "room" that streaks across the bevel as the
 // surface normal turns — instead of one flat, generic highlight. Device tilt
 // and a slow drift move the lights so the reflections stay alive.
-float3 environment(float3 r, float2 tilt, float t, float liquid) {
+float3 environment(float3 r, float2 tilt, float2 keyDir, float t, float liquid) {
     float2 d = r.xy;
     // Screen y is down, so the bright sky is where the reflection points up
     // (r.y < 0): a soft top->bottom studio gradient.
     float up = clamp(0.5 - 0.5 * r.y, 0.0, 1.0);
     float3 sky = mix(float3(0.05, 0.06, 0.08), float3(0.82, 0.88, 1.0),
                      smoothstep(0.12, 0.96, up));
-    // Bright soft key light near the top, nudged by tilt + a slow drift.
-    float2 key = float2(-0.30, -0.62) + tilt * 0.5
+    // Bright soft key light placed along the chosen light angle (keyDir),
+    // nudged by device tilt + a slow drift.
+    float2 key = keyDir + tilt * 0.5
                + 0.06 * float2(sin(t * 0.40), cos(t * 0.33)) * liquid;
     float keyI = smoothstep(0.55, 0.0, distance(d, key));
     // Cooler fill light from the opposite corner.
-    float2 fill = float2(0.52, 0.5) - tilt * 0.4;
+    float2 fill = -keyDir * 0.85 - tilt * 0.4;
     float fillI = smoothstep(0.72, 0.0, distance(d, fill)) * 0.5;
     return sky + float3(1.0, 0.97, 0.92) * keyI * 1.7
               + float3(0.65, 0.82, 1.0) * fillI;
@@ -526,14 +555,23 @@ half4 main(float2 p) {
     float slopeGain = 3.5 * uDepth;
     float3 N = normalize(float3(grad * slopeGain, 1.0));
 
+    // Frost: per-pixel micro-roughness scatters the reflection, refraction and
+    // glint into a misted, frosted surface. Gated so uFrost = 0 is unchanged.
+    if (uFrost > 0.001) {
+        float h1 = fract(sin(dot(p, float2(12.9898, 78.233))) * 43758.5453);
+        float h2 = fract(sin(dot(p, float2(39.346, 11.135))) * 24634.6345);
+        N = normalize(N + float3((float2(h1, h2) - 0.5) * uFrost * 0.6, 0.0));
+    }
+
     float2 uv = p / uSize;
     float3 I = float3(0.0, 0.0, -1.0);   // view ray, into the screen
 
     // Fresnel (Schlick, F0 = 0.04 for glass): ~4% reflection head-on, climbing
     // to ~100% at grazing edges. This is what makes the rim catch the light and
-    // the face stay see-through — the core of the glass look.
+    // the face stay see-through — the core of the glass look. uFresnelPower sets
+    // how broad the reflective rim band is (lower = wider shoulder).
     float cosV = clamp(N.z, 0.0, 1.0);
-    float fres = 0.04 + 0.96 * pow(1.0 - cosV, 5.0);
+    float fres = 0.04 + 0.96 * pow(1.0 - cosV, uFresnelPower);
 
     // Refraction (Snell, via refract) with a per-channel index of refraction so
     // R/G/B bend by different amounts — true chromatic dispersion, strongest at
@@ -552,20 +590,24 @@ half4 main(float2 p) {
         backdropTintAt(uvB).b * backdropField(uvB));
 
     // Reflected environment: the room the glass catches, turning with N so the
-    // reflection streaks across the bevel as the surface curves.
-    float3 refl = environment(reflect(I, N), uTilt, uTime, uLiquid);
+    // reflection streaks across the bevel as the surface curves. The key light
+    // sits along uLightAngle; uTiltAmount scales how much device tilt sways it.
+    float2 keyDir = float2(cos(uLightAngle), -sin(uLightAngle)) * 0.69;
+    float3 refl = environment(reflect(I, N), uTilt * uTiltAmount, keyDir, uTime, uLiquid);
 
-    // Crisp specular glint from a tilt-driven key light, dispersed for sparkle.
+    // Crisp specular glint from the same key light (uLightAngle + tilt), with a
+    // uGloss-controlled exponent (higher = tighter mirror), dispersed for sparkle.
+    float2 lightXY = float2(cos(uLightAngle), -sin(uLightAngle));
     float3 L = normalize(float3(
-        -uTilt.x * 0.8 + 0.25 * sin(uTime * 0.37),
-         uTilt.y * 0.8 + 0.20 * cos(uTime * 0.29) - 0.5,
-         0.85));
+        lightXY.x * 0.5 - uTilt.x * 0.8 * uTiltAmount + 0.25 * sin(uTime * 0.37),
+        lightXY.y * 0.5 + uTilt.y * 0.8 * uTiltAmount + 0.20 * cos(uTime * 0.29),
+        0.85));
     float3 H = normalize(L + float3(0.0, 0.0, 1.0));
     float ndh   = max(dot(N, H), 0.0);
-    float spec  = pow(ndh, 90.0);
+    float spec  = pow(ndh, uGloss);
     float dsp   = 0.015 * uDispersion;
-    float specR = pow(max(dot(normalize(N + float3(dsp, 0.0, 0.0)), H), 0.0), 90.0);
-    float specB = pow(max(dot(normalize(N - float3(dsp, 0.0, 0.0)), H), 0.0), 90.0);
+    float specR = pow(max(dot(normalize(N + float3(dsp, 0.0, 0.0)), H), 0.0), uGloss);
+    float specB = pow(max(dot(normalize(N - float3(dsp, 0.0, 0.0)), H), 0.0), uGloss);
 
     // Body: the glyph's own colour (kept legible) with a hint of the lensed
     // backdrop; leans more see-through over real blurred art.
@@ -579,7 +621,7 @@ half4 main(float2 p) {
     // The glint is Fresnel-weighted too, so it rides the bevel edge rather than
     // washing the whole flat face white (a front-facing flat surface would
     // otherwise fire the specular uniformly).
-    float3 col3 = mix(bodyCol, refl * uRimGain, clamp(fres * 1.1, 0.0, 1.0));
+    float3 col3 = mix(bodyCol, refl * uReflection, clamp(fres * 1.1, 0.0, 1.0));
     col3 += float3(specR, spec, specB) * uRimGain * fres;
 
     // Transparent face, opaque bright rim: alpha is low across the body (backdrop

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -229,6 +230,56 @@ private fun liquidGlassPanelModifier(tint: Color): Modifier {
             shader.setFloatUniform("uRimGain", 1.30f)
             shader.setFloatUniform("uDispersion", 1.0f)
             shader.setFloatUniform("uSampleRings", 2f)
+            renderEffect = RenderEffect
+                .createRuntimeShaderEffect(shader, "content")
+                .asComposeRenderEffect()
+        }
+    }
+}
+
+/**
+ * Player-chrome glass settings (the transport buttons), provided at the player
+ * route from the persisted [tf.monochrome.android.domain.model.PlayerGlassSettings].
+ */
+val LocalPlayerGlass = compositionLocalOf { tf.monochrome.android.domain.model.PlayerGlassSettings() }
+
+/**
+ * The SAME refractive lyric glass ([LIQUID_GLASS_SRC]) applied to a player
+ * button's icon, so the play/skip shapes read as 3D chrome liquid glass just
+ * like the active lyric line. Reads [LocalPlayerGlass] for its parameters
+ * (tunable in the Studio's "Player Glass" tab). Apply it to the Icon so the
+ * shader bevels the (solid) glyph shape. No-op when disabled, below API 33, or
+ * on shader-compile failure.
+ */
+@Composable
+internal fun Modifier.playerGlass(tint: Color): Modifier {
+    val g = LocalPlayerGlass.current
+    if (!g.enabled || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
+    return this.then(playerGlassModifier(tint, g))
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun playerGlassModifier(
+    tint: Color,
+    g: tf.monochrome.android.domain.model.PlayerGlassSettings,
+): Modifier {
+    val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() } ?: return Modifier
+    val timeSec = rememberFrameSeconds()
+    val tilt = rememberGravityTilt()
+    return Modifier.graphicsLayer {
+        if (size.minDimension > 0f) {
+            shader.setFloatUniform("uSize", size.width, size.height)
+            shader.setFloatUniform("uTime", timeSec.value)
+            shader.setFloatUniform("uTilt", tilt.value.x, tilt.value.y)
+            shader.setFloatUniform("uTint", tint.red, tint.green, tint.blue)
+            shader.setFloatUniform("uTint2", tint.red, tint.green, tint.blue)
+            shader.setFloatUniform("uBackdropMix", 0f)
+            shader.setFloatUniform("uBodyOpacity", g.bodyOpacity)
+            shader.setFloatUniform("uRefraction", g.refraction)
+            shader.setFloatUniform("uRimGain", g.rimBrightness)
+            shader.setFloatUniform("uDispersion", g.dispersion)
+            shader.setFloatUniform("uSampleRings", g.sampleRings.toFloat())
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -116,6 +116,7 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uRefraction", fx.glassRefraction)
             shader.setFloatUniform("uRimGain", fx.glassRimBrightness)
             shader.setFloatUniform("uDispersion", fx.glassDispersion)
+            shader.setFloatUniform("uSampleRings", fx.glassSampleRings.toFloat())
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -190,6 +191,7 @@ uniform float uBodyOpacity;   // glass body opacity (lower = more see-through)
 uniform float uRefraction;    // how hard the bevel lenses the backdrop
 uniform float uRimGain;       // brightness of the specular glass edge
 uniform float uDispersion;    // chromatic aberration at the refracting edges
+uniform float uSampleRings;   // bevel sample rings 1/2/3 → 5/9/13 taps per pixel
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -210,18 +212,33 @@ half4 main(float2 p) {
         return src;
     }
 
-    // Bevel normals from the glyph alpha field: a fine rim gradient plus a
-    // broader one so letters read as rounded glass, not flat stickers.
+    // Bevel normals from the glyph alpha field. The sample count is a user
+    // setting (uSampleRings): the fine cross is always taken; the broad ring and
+    // the diagonal ring are gated so lower quality skips those texture fetches —
+    // fewer taps per pixel is a real GPU saving.
     float aL1 = float(content.eval(p + float2(-1.25, 0.0)).a);
     float aR1 = float(content.eval(p + float2( 1.25, 0.0)).a);
     float aU1 = float(content.eval(p + float2(0.0, -1.25)).a);
     float aD1 = float(content.eval(p + float2(0.0,  1.25)).a);
-    float aL2 = float(content.eval(p + float2(-2.5, 0.0)).a);
-    float aR2 = float(content.eval(p + float2( 2.5, 0.0)).a);
-    float aU2 = float(content.eval(p + float2(0.0, -2.5)).a);
-    float aD2 = float(content.eval(p + float2(0.0,  2.5)).a);
-    float2 grad = float2((aL1 - aR1) + 0.4 * (aL2 - aR2),
-                         (aU1 - aD1) + 0.4 * (aU2 - aD2));
+    float2 grad = float2(aL1 - aR1, aU1 - aD1);
+
+    if (uSampleRings > 1.5) {
+        // Broad ring: rounder, softer bevel.
+        float aL2 = float(content.eval(p + float2(-2.5, 0.0)).a);
+        float aR2 = float(content.eval(p + float2( 2.5, 0.0)).a);
+        float aU2 = float(content.eval(p + float2(0.0, -2.5)).a);
+        float aD2 = float(content.eval(p + float2(0.0,  2.5)).a);
+        grad += 0.4 * float2(aL2 - aR2, aU2 - aD2);
+    }
+    if (uSampleRings > 2.5) {
+        // Diagonal ring: smoother normals on curved strokes.
+        float aNW = float(content.eval(p + float2(-1.8, -1.8)).a);
+        float aNE = float(content.eval(p + float2( 1.8, -1.8)).a);
+        float aSW = float(content.eval(p + float2(-1.8,  1.8)).a);
+        float aSE = float(content.eval(p + float2( 1.8,  1.8)).a);
+        grad += 0.3 * float2((aNW + aSW) - (aNE + aSE),
+                             (aNW + aNE) - (aSW + aSE));
+    }
 
     // Liquid: the surface itself undulates, so highlights swim over glyphs.
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -48,9 +48,25 @@ internal fun Modifier.liquidGlass(
     tint: Color = Color(0xFF8FB4FF),
 ): Modifier {
     val fx = LocalLyricsFx.current
+    val backdrop = LocalPlayerBackdrop.current
     if (!enabled || !fx.liquidGlass || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
-    return this.then(liquidGlassModifier(tint, fx))
+    return this.then(liquidGlassModifier(tint, fx, backdrop))
 }
+
+/**
+ * What actually sits behind the lyric glass, so the shader can lens the real
+ * album tones (Apple-OS style) instead of only a flat wash. Provided at the
+ * player route from the album palette + the "Blurred Album Background" setting.
+ * The default (disabled) leaves the glass numerically identical to the flat
+ * single-tint reconstruction it used before.
+ */
+internal data class PlayerBackdrop(
+    val blurredArt: Boolean = false,
+    val dominant: Color = Color(0xFF101018),
+    val secondary: Color = Color(0xFF101018),
+)
+
+internal val LocalPlayerBackdrop = androidx.compose.runtime.compositionLocalOf { PlayerBackdrop() }
 
 // One process-wide epoch so every rememberFrameSeconds() instance reports the
 // same timeline: a surface composed later (e.g. the lyrics expand morph)
@@ -134,6 +150,7 @@ private fun fxaaModifier(strength: Float): Modifier {
 private fun liquidGlassModifier(
     tint: Color,
     fx: tf.monochrome.android.domain.model.LyricsFxSettings,
+    backdrop: PlayerBackdrop,
 ): Modifier {
     val shader = remember {
         runCatching { RuntimeShader(LIQUID_GLASS_SRC) }
@@ -151,6 +168,13 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uTime", timeSec.value)
             shader.setFloatUniform("uTilt", tilt.value.x, tilt.value.y)
             shader.setFloatUniform("uTint", tint.red, tint.green, tint.blue)
+            // Second album tone + how strongly the lensed backdrop bleeds into the
+            // glass body. Only non-zero when the blurred album background is on, so
+            // the glass reads as sitting over the real artwork (Apple-OS style);
+            // otherwise uBackdropMix = 0 keeps the flat single-tint look unchanged.
+            val secondary = backdrop.secondary
+            shader.setFloatUniform("uTint2", secondary.red, secondary.green, secondary.blue)
+            shader.setFloatUniform("uBackdropMix", if (backdrop.blurredArt) 0.6f else 0f)
             shader.setFloatUniform("uBodyOpacity", fx.glassBodyOpacity)
             shader.setFloatUniform("uRefraction", fx.glassRefraction)
             shader.setFloatUniform("uRimGain", fx.glassRimBrightness)
@@ -285,6 +309,8 @@ uniform float uRefraction;    // how hard the bevel lenses the backdrop
 uniform float uRimGain;       // brightness of the specular glass edge
 uniform float uDispersion;    // chromatic aberration at the refracting edges
 uniform float uSampleRings;   // bevel sample rings 1/2/3 → 5/9/13 taps per pixel
+uniform float3 uTint2;        // second album tone (blurred-art backdrop)
+uniform float uBackdropMix;   // 0 = flat single-tint wash; >0 = lens the album art
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -293,6 +319,15 @@ float backdropField(float2 uv) {
     float wash = mix(0.45, 0.0, clamp(uv.y, 0.0, 1.0));
     float glow = smoothstep(1.0, 0.0, distance(uv, float2(0.5, 0.22)) * 1.5);
     return clamp(wash + glow * 0.5, 0.0, 1.0);
+}
+
+// Album tone the glass lenses at uv. With the blurred cover behind the lyrics
+// (uBackdropMix > 0) this is a two-tone vertical album blend, so the refraction
+// carries real colour variation like a photo behind glass. With no blurred art
+// (uBackdropMix = 0) it collapses to uTint — identical to the old single tone.
+float3 backdropTintAt(float2 uv) {
+    float3 two = mix(uTint, uTint2, smoothstep(0.0, 1.0, clamp(uv.y, 0.0, 1.0)));
+    return mix(uTint, two, uBackdropMix);
 }
 
 half4 main(float2 p) {
@@ -364,10 +399,16 @@ half4 main(float2 p) {
     float2 uv = p / uSize;
     float2 lens = slope * uRefraction;
     float aberr = 0.12 * uDispersion;
-    float fieldR = backdropField(uv + lens * (1.0 + aberr));
-    float fieldG = backdropField(uv + lens);
-    float fieldB = backdropField(uv + lens * (1.0 - aberr));
-    float3 bg = uTint * float3(fieldR, fieldG, fieldB);
+    float2 uvR = uv + lens * (1.0 + aberr);
+    float2 uvG = uv + lens;
+    float2 uvB = uv + lens * (1.0 - aberr);
+    // Per-channel lens weight (as before) modulated by the local album tone, so
+    // when the blurred cover is behind the glass the refraction bends real colour
+    // (Apple-OS look); with no blurred art this equals uTint * field (unchanged).
+    float3 bg = float3(
+        backdropTintAt(uvR).r * backdropField(uvR),
+        backdropTintAt(uvG).g * backdropField(uvG),
+        backdropTintAt(uvB).b * backdropField(uvB));
 
     // A sheet of light sweeping diagonally across the whole surface.
     float band = 1.0 - smoothstep(0.0, 0.18,
@@ -377,7 +418,10 @@ half4 main(float2 p) {
     // legible), with the lensed backdrop bleeding in for depth.
     float3 tint = float3(src.rgb) / a;
     float lum = clamp(dot(tint, float3(0.299, 0.587, 0.114)), 0.0, 1.0);
-    float3 frost = mix(bg, tint, 0.7);
+    // Over the blurred album art the glass leans more see-through (more lensed
+    // backdrop, less solid frost) so it reads as real glass on the artwork;
+    // with no blurred art it holds the legible 0.7 glyph-colour mix.
+    float3 frost = mix(bg, tint, mix(0.7, 0.42, uBackdropMix));
 
     // Transparent body, opaque bright rim. Alpha is low across the letter face
     // (backdrop reads through) and climbs to full at the beveled edge, so the

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -187,6 +187,55 @@ private fun liquidGlassModifier(
     }
 }
 
+/**
+ * The SAME refractive lyric glass ([LIQUID_GLASS_SRC]), applied to a solid PANEL
+ * surface (the player's dock / sheet) instead of glyphs — so the player chrome
+ * reads as the exact liquid glass the active lyric line does, not a flat frost.
+ *
+ * Apply it to a Box that already has a rounded, translucent fill: the shader
+ * bevels that fill's edges into a lit, tilt-reactive refractive rim (with
+ * chromatic dispersion and the animated light sweep) over a see-through,
+ * album-tinted body. Place it BEHIND the panel's content so the buttons and
+ * labels sitting on the glass stay crisp and untouched.
+ *
+ * Unlike [liquidGlass] it is NOT gated on the lyric-FX toggle (player chrome is
+ * always glass) and is tuned for a panel: a more present body and a stronger
+ * rim. Requires API 33; a no-op (plain fill) below that or on shader failure.
+ */
+@Composable
+internal fun Modifier.liquidGlassPanel(tint: Color): Modifier {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
+    return this.then(liquidGlassPanelModifier(tint))
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun liquidGlassPanelModifier(tint: Color): Modifier {
+    val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() } ?: return Modifier
+    val timeSec = rememberFrameSeconds()
+    val tilt = rememberGravityTilt()
+    return Modifier.graphicsLayer {
+        if (size.minDimension > 0f) {
+            shader.setFloatUniform("uSize", size.width, size.height)
+            shader.setFloatUniform("uTime", timeSec.value)
+            shader.setFloatUniform("uTilt", tilt.value.x, tilt.value.y)
+            shader.setFloatUniform("uTint", tint.red, tint.green, tint.blue)
+            shader.setFloatUniform("uTint2", tint.red, tint.green, tint.blue)
+            shader.setFloatUniform("uBackdropMix", 0f)
+            // Panel tuning: a body that stays fairly present (a panel, not a
+            // glyph), with a strong lit rim and gentle edge refraction.
+            shader.setFloatUniform("uBodyOpacity", 0.82f)
+            shader.setFloatUniform("uRefraction", 0.10f)
+            shader.setFloatUniform("uRimGain", 1.30f)
+            shader.setFloatUniform("uDispersion", 1.0f)
+            shader.setFloatUniform("uSampleRings", 2f)
+            renderEffect = RenderEffect
+                .createRuntimeShaderEffect(shader, "content")
+                .asComposeRenderEffect()
+        }
+    }
+}
+
 /** Low-pass-filtered gravity in [-1, 1] per axis; Offset.Zero if no sensor. */
 @Composable
 private fun rememberGravityTilt(): State<Offset> {

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -191,6 +191,8 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uLightAngle", 2.3561945f)   // 135°
             shader.setFloatUniform("uFresnelPower", 5f)
             shader.setFloatUniform("uFrost", 0f)
+            shader.setFloatUniform("uBulge", 0.5f, 0.5f)
+            shader.setFloatUniform("uBulgeAmt", 0f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -250,6 +252,8 @@ private fun liquidGlassPanelModifier(tint: Color): Modifier {
             shader.setFloatUniform("uLightAngle", 2.3561945f)   // 135°
             shader.setFloatUniform("uFresnelPower", 5f)
             shader.setFloatUniform("uFrost", 0f)
+            shader.setFloatUniform("uBulge", 0.5f, 0.5f)
+            shader.setFloatUniform("uBulgeAmt", 0f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -272,10 +276,14 @@ val LocalPlayerGlass = compositionLocalOf { tf.monochrome.android.domain.model.P
  * on shader-compile failure.
  */
 @Composable
-internal fun Modifier.playerGlass(tint: Color): Modifier {
+internal fun Modifier.playerGlass(
+    tint: Color,
+    bulgeCenter: Offset = Offset(0.5f, 0.5f),
+    bulgeAmount: () -> Float = { 0f },
+): Modifier {
     val g = LocalPlayerGlass.current
     if (!g.enabled || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
-    return this.then(playerGlassModifier(tint, g))
+    return this.then(playerGlassModifier(tint, g, bulgeCenter, bulgeAmount))
 }
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
@@ -283,6 +291,8 @@ internal fun Modifier.playerGlass(tint: Color): Modifier {
 private fun playerGlassModifier(
     tint: Color,
     g: tf.monochrome.android.domain.model.PlayerGlassSettings,
+    bulgeCenter: Offset,
+    bulgeAmount: () -> Float,
 ): Modifier {
     val shader = remember { runCatching { RuntimeShader(LIQUID_GLASS_SRC) }.getOrNull() } ?: return Modifier
     val timeSec = rememberFrameSeconds()
@@ -313,6 +323,8 @@ private fun playerGlassModifier(
             shader.setFloatUniform("uLightAngle", g.lightAngleDeg * 0.017453292f)
             shader.setFloatUniform("uFresnelPower", 8f - 6f * g.edgeWidth)
             shader.setFloatUniform("uFrost", g.frost)
+            shader.setFloatUniform("uBulge", bulgeCenter.x, bulgeCenter.y)
+            shader.setFloatUniform("uBulgeAmt", bulgeAmount())
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -486,6 +498,8 @@ uniform float uTiltAmount;    // how strongly device tilt moves the light/reflec
 uniform float uLightAngle;    // key-light direction, radians
 uniform float uFresnelPower;  // Fresnel falloff: lower = broader reflective rim
 uniform float uFrost;         // frosted roughness: 0 = clear, higher = misted
+uniform float2 uBulge;        // press-bulge centre, normalized (0..1) in the surface
+uniform float uBulgeAmt;      // press-bulge swell, 0 = none .. 1 = full dome
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -581,6 +595,18 @@ half4 main(float2 p) {
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);
     float w2 = sin((p.x + p.y) * 0.035 - uTime * 0.9);
     grad += 0.04 * uLiquid * float2(w1, w2) * a * edge;
+
+    // Press bulge: a soft dome that swells the glass under a pressed button. The
+    // radial slope peaks mid-radius (derivative of a dome) so the surface reads as
+    // a smooth bump that lenses the backdrop; uBulgeAmt animates it in/out.
+    if (uBulgeAmt > 0.001) {
+        float2 bc = uBulge * uSize;
+        float R = uSize.x / 6.0;
+        float rr2 = distance(p, bc);
+        float dome = smoothstep(R, 0.0, rr2);
+        float2 bdir = (rr2 > 0.5) ? (p - bc) / rr2 : float2(0.0, 0.0);
+        grad += bdir * (dome * (1.0 - dome)) * uBulgeAmt * 10.0;
+    }
 
     // Surface normal from the alpha heightfield. Depth (profondeur) scales how
     // hard the bevel tips the normal off the surface — the dominant "3D" knob,

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -94,6 +94,38 @@ internal fun Modifier.dithered(): Modifier {
     }
 }
 
+/**
+ * Post-process FXAA (single-pass luma edge anti-aliasing) for the lyric
+ * surface: smooths the jagged edges the 3D letter tilts, the glass relight and
+ * a reduced panel resolution leave behind. Chain it OUTSIDE (before) the
+ * [liquidGlass] modifier so it runs on the glass output.
+ *
+ * Requires API 33 (RuntimeShader) and the fx toggle; below that, or if the
+ * shader fails to compile, the modifier is a no-op and lyrics render unchanged.
+ */
+@Composable
+internal fun Modifier.fxaa(): Modifier {
+    val fx = LocalLyricsFx.current
+    if (!fx.fxaa || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
+    return this.then(fxaaModifier(fx.fxaaStrength))
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun fxaaModifier(strength: Float): Modifier {
+    val shader = remember { runCatching { RuntimeShader(FXAA_SRC) }.getOrNull() }
+        ?: return Modifier
+    return Modifier.graphicsLayer {
+        if (size.minDimension > 0f) {
+            shader.setFloatUniform("uSize", size.width, size.height)
+            shader.setFloatUniform("uStrength", strength)
+            renderEffect = RenderEffect
+                .createRuntimeShaderEffect(shader, "content")
+                .asComposeRenderEffect()
+        }
+    }
+}
+
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 private fun liquidGlassModifier(
@@ -167,6 +199,60 @@ half4 main(float2 p) {
     float a = float(c.a);
     float3 rgb = clamp(float3(c.rgb) + d * a, 0.0, a);
     return half4(half3(rgb), c.a);
+}
+"""
+
+// Single-pass luma FXAA (the classic NVIDIA/Geeks3D formulation). Operates on
+// the premultiplied-alpha lyric surface: luma is read from premultiplied rgb so
+// glyph alpha-edges register, and the directional 4-tap blend runs on the full
+// premultiplied colour (averaging premultiplied samples stays valid). uStrength
+// cross-fades the anti-aliased result back over the original.
+private const val FXAA_SRC = """
+uniform shader content;
+uniform float2 uSize;
+uniform float uStrength;
+
+half4 main(float2 frag) {
+    float2 inv = 1.0 / uSize;
+    float3 luma = float3(0.299, 0.587, 0.114);
+    float SPAN_MAX = 8.0;
+    float REDUCE_MUL = 1.0 / 8.0;
+    float REDUCE_MIN = 1.0 / 128.0;
+
+    half4 c = content.eval(frag);
+    float lumaM  = dot(float3(c.rgb), luma);
+    float lumaNW = dot(float3(content.eval(frag + float2(-1.0, -1.0)).rgb), luma);
+    float lumaNE = dot(float3(content.eval(frag + float2( 1.0, -1.0)).rgb), luma);
+    float lumaSW = dot(float3(content.eval(frag + float2(-1.0,  1.0)).rgb), luma);
+    float lumaSE = dot(float3(content.eval(frag + float2( 1.0,  1.0)).rgb), luma);
+
+    float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+    float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+
+    // Flat region: nothing to smooth, return the source untouched.
+    if (lumaMax - lumaMin < 0.02) {
+        return c;
+    }
+
+    float2 dir = float2(
+        -((lumaNW + lumaNE) - (lumaSW + lumaSE)),
+         ((lumaNW + lumaSW) - (lumaNE + lumaSE)));
+    float dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * REDUCE_MUL), REDUCE_MIN);
+    float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+    dir = clamp(dir * rcpDirMin, -SPAN_MAX, SPAN_MAX) * inv;
+
+    // Do the blend in float precision (the codebase's convention) to avoid
+    // half/float mismatch on scalar-vector ops, then convert back at the end.
+    float4 rgbA = 0.5 * (
+        float4(content.eval(frag + dir * (1.0 / 3.0 - 0.5))) +
+        float4(content.eval(frag + dir * (2.0 / 3.0 - 0.5))));
+    float4 rgbB = rgbA * 0.5 + 0.25 * (
+        float4(content.eval(frag + dir * -0.5)) +
+        float4(content.eval(frag + dir *  0.5)));
+
+    float lumaB = dot(rgbB.rgb, luma);
+    float4 aa = (lumaB < lumaMin || lumaB > lumaMax) ? rgbA : rgbB;
+    return half4(mix(float4(c), aa, uStrength));
 }
 """
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -183,6 +183,7 @@ private fun liquidGlassModifier(
             shader.setFloatUniform("uSampleRings", fx.glassSampleRings.toFloat())
             shader.setFloatUniform("uRoundness", 1f)
             shader.setFloatUniform("uDepth", 1f)
+            shader.setFloatUniform("uLiquid", 1f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -234,6 +235,7 @@ private fun liquidGlassPanelModifier(tint: Color): Modifier {
             shader.setFloatUniform("uSampleRings", 2f)
             shader.setFloatUniform("uRoundness", 1f)
             shader.setFloatUniform("uDepth", 1f)
+            shader.setFloatUniform("uLiquid", 1f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -286,6 +288,9 @@ private fun playerGlassModifier(
             shader.setFloatUniform("uSampleRings", g.sampleRings.toFloat())
             shader.setFloatUniform("uRoundness", g.roundness)
             shader.setFloatUniform("uDepth", g.depth)
+            // Calmer surface for the button chrome so the big disc reads clean
+            // and smooth rather than cloudy.
+            shader.setFloatUniform("uLiquid", 0.25f)
             renderEffect = RenderEffect
                 .createRuntimeShaderEffect(shader, "content")
                 .asComposeRenderEffect()
@@ -419,6 +424,7 @@ uniform float3 uTint2;        // second album tone (blurred-art backdrop)
 uniform float uBackdropMix;   // 0 = flat single-tint wash; >0 = lens the album art
 uniform float uRoundness;     // bevel shoulder width: 1 = neutral, higher = rounder/softer edge
 uniform float uDepth;         // profondeur: 1 = neutral, higher = steeper relief / more 3D
+uniform float uLiquid;        // surface unrest: 1 = full moving sheen, lower = calmer, cleaner glass
 
 // Smooth album-tinted backdrop field, reconstructed so the glass can lens it.
 // Returns a 0..1 luminance weight for the tint at uv (matches the vertical
@@ -481,9 +487,11 @@ half4 main(float2 p) {
     }
 
     // Liquid: the surface itself undulates, so highlights swim over glyphs.
+    // uLiquid scales this unrest — the big button disc dials it down so its
+    // glass reads clean and smooth instead of cloudy/blotchy.
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);
     float w2 = sin((p.x + p.y) * 0.035 - uTime * 0.9);
-    grad += 0.05 * float2(w1, w2) * a;
+    grad += 0.05 * uLiquid * float2(w1, w2) * a;
 
     float2 slope = grad;                        // raw bevel slope → lens displacement
     // Depth (profondeur): a shallower z base tips the bevel normal further off
@@ -548,10 +556,10 @@ half4 main(float2 p) {
     float outA = clamp(a * (bodyOpacity + (1.0 - bodyOpacity) * rim), 0.0, a);
     float lightGain = (0.30 + 0.70 * lum) * uRimGain;
 
-    float3 col = frost * (0.9 + 0.14 * band) * outA;   // premultiplied frost body
+    float3 col = frost * (0.9 + 0.14 * band * uLiquid) * outA;   // premultiplied frost body
     col += (float3(specR, spec, specB) * 1.10
             + float3(0.80, 0.90, 1.00) * (fres * 0.40)
-            + float3(sheen) * (0.05 + 0.22 * band)) * (outA * lightGain);
+            + float3(sheen) * (0.05 + 0.22 * band * uLiquid)) * (outA * lightGain);
     col = min(col, float3(outA));
     return half4(half3(col), half(outA));
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -510,11 +510,15 @@ half4 main(float2 p) {
     }
 
     // Liquid: subtle surface undulation so highlights swim over the glass.
-    // uLiquid scales this unrest — the big button disc dials it down so its
-    // glass reads clean and smooth rather than cloudy.
+    // CRUCIAL: gate it by the real bevel strength (the geometric gradient BEFORE
+    // the ripple), so the undulation only lives where there already IS an edge.
+    // A big flat face — a button disc, the dock slab — has zero gradient inside,
+    // so it stays a clean, uniform surface instead of a lattice of ripple
+    // highlights. Thin glyphs are all edge, so lyrics keep their liquid life.
+    float edge = clamp(length(grad) * 1.5, 0.0, 1.0);
     float w1 = sin(p.x * 0.055 + uTime * 1.7) * cos(p.y * 0.081 - uTime * 1.3);
     float w2 = sin((p.x + p.y) * 0.035 - uTime * 0.9);
-    grad += 0.05 * uLiquid * float2(w1, w2) * a;
+    grad += 0.04 * uLiquid * float2(w1, w2) * a * edge;
 
     // Surface normal from the alpha heightfield. Depth (profondeur) scales how
     // hard the bevel tips the normal off the surface — the dominant "3D" knob,
@@ -572,8 +576,11 @@ half4 main(float2 p) {
     // Fresnel-blend the reflection over the body (edges reflect, the face
     // transmits), then add the dispersed glint. uRimGain scales both the
     // reflection and the glint, so "Edge highlight" is a real brightness knob.
+    // The glint is Fresnel-weighted too, so it rides the bevel edge rather than
+    // washing the whole flat face white (a front-facing flat surface would
+    // otherwise fire the specular uniformly).
     float3 col3 = mix(bodyCol, refl * uRimGain, clamp(fres * 1.1, 0.0, 1.0));
-    col3 += float3(specR, spec, specB) * uRimGain;
+    col3 += float3(specR, spec, specB) * uRimGain * fres;
 
     // Transparent face, opaque bright rim: alpha is low across the body (backdrop
     // reads through) and climbs to full where Fresnel and the glint peak, so the

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -20,8 +20,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -29,8 +31,10 @@ import androidx.compose.ui.unit.dp
 import tf.monochrome.android.audio.eq.SpectrumAnalyzerTap
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
+import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.sin
 import kotlin.math.sqrt
@@ -210,57 +214,138 @@ internal fun LyricsFxLayer(
                 val p = (pulse.value * fx.bassReact).coerceIn(0f, 1.6f)
                 if (p <= 0.03f) return@drawBehind
 
+                // Rays and glow share one album-accent colour, hue-rotated by the
+                // user's setting.
+                val rayColor = accent.shiftHue(fx.rayHueShift)
+
                 // One soft bloom behind the whole line.
                 anchors.lineCenter?.let { lc ->
                     val c = lc - origin
                     val glowR = anchors.lineHalf.height + fx.glowRadiusDp.dp.toPx() * (1f + p)
-                    drawGlow(c, glowR, p, accent, fx)
+                    drawGlow(c, glowR, p, rayColor, fx)
                 }
 
                 // Per-glyph rays: each burst rooted on its own letter, sized to
-                // the glyph, sweeping with the glyph's wave phase.
+                // the glyph. Reach breathes with the pulse by rayPulseAmount.
                 if (fx.rayCount > 0) {
-                    val spin = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
+                    val spinRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
+                    val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
                     anchors.glyphs.values.forEach { g ->
                         val c = g.center - origin
                         val glyph = max(g.halfW, g.halfH)
-                        val reach = glyph * 2f * (0.6f + 2.4f * fx.rayLength) * (0.5f + 0.5f * p)
-                        drawBeams(c, g.halfW * 0.55f, g.halfH * 0.55f, reach, p, accent, fx, spin + g.phase)
+                        val reach = glyph * 2f * (0.6f + 2.4f * fx.rayLength) * pulseReach
+                        drawBeams(c, g.halfW * 0.55f, g.halfH * 0.55f, reach, p, rayColor, fx, spinRad, g.phase, time.value)
                     }
                 }
             },
     )
 }
 
+/** Rotate a colour's hue by [degrees] (0 = unchanged), keeping saturation/value. */
+private fun Color.shiftHue(degrees: Float): Color {
+    if (degrees == 0f) return this
+    val hsv = FloatArray(3)
+    android.graphics.Color.colorToHSV(toArgb(), hsv)
+    hsv[0] = ((hsv[0] + degrees) % 360f + 360f) % 360f
+    return Color(android.graphics.Color.HSVToColor((alpha * 255f).toInt().coerceIn(0, 255), hsv))
+}
+
+/**
+ * Draws one glyph's god rays. Honours the full ray parameter set: direction +
+ * spread (or parallel directional shafts when [LyricsFxSettings.rayFixedDirection]),
+ * decay-shaped fade, width taper, per-beam length jitter, flicker, and how hard
+ * reach/width react to the bass pulse.
+ */
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBeams(
     center: Offset,
     rx: Float,
     ry: Float,
     reach: Float,
     p: Float,
-    accent: Color,
+    rayColor: Color,
     fx: LyricsFxSettings,
-    sweepRad: Float,
+    spinRad: Float,
+    seed: Float,
+    timeSec: Float,
 ) {
     val count = fx.rayCount
     if (count <= 0) return
+
+    val fixedRad = fx.rayAngleDeg * PI.toFloat() / 180f
+    val spreadRad = fx.raySpreadDeg * PI.toFloat() / 180f
+    val widthPulse = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * p
+    val stroke = (2f + (fx.rayWidthDp - 2f) * widthPulse).coerceAtLeast(1f) * density
+    val decay = fx.rayDecay.coerceIn(0.05f, 0.95f)
+
+    // Parallel-shaft geometry (fixed-direction mode): direction (sin,-cos) with
+    // 0 = up, clockwise; shafts spread along the perpendicular across the glyph.
+    val fdx = sin(fixedRad)
+    val fdy = -cos(fixedRad)
+    val perpX = cos(fixedRad)
+    val perpY = sin(fixedRad)
+    val shaftSpread = 3f * max(rx, ry)
+    val spacing = if (count > 1) shaftSpread / (count - 1) else 0f
+
     repeat(count) { i ->
-        val a = sweepRad + i * (2f * PI.toFloat() / count)
-        val dirX = cos(a)
-        val dirY = sin(a)
-        val start = Offset(center.x + dirX * rx, center.y + dirY * ry)
-        val end = Offset(start.x + dirX * reach, start.y + dirY * reach)
-        drawLine(
-            brush = Brush.linearGradient(
-                colors = listOf(accent.copy(alpha = fx.rayBrightness * p), Color.Transparent),
-                start = start,
-                end = end,
+        val rnd = abs(sin(i * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
+        val beamReach = reach * (1f - fx.rayLengthJitter * rnd)
+        val flick = if (fx.rayFlicker > 0f) {
+            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 7f + i * 1.7f + seed))
+        } else 1f
+        val alpha = (fx.rayBrightness * flick * widthPulse).coerceIn(0f, 1f)
+        if (alpha <= 0.003f) return@repeat
+
+        val ang: Float
+        val start: Offset
+        if (fx.rayFixedDirection) {
+            ang = fixedRad
+            val t = (i - (count - 1) / 2f) * spacing
+            start = Offset(center.x + perpX * t, center.y + perpY * t)
+        } else {
+            ang = if (fx.raySpreadDeg >= 359.5f) {
+                spinRad + seed + i * (2f * PI.toFloat() / count)
+            } else {
+                val frac = if (count > 1) (i / (count - 1f) - 0.5f) else 0f
+                fixedRad + spinRad + frac * spreadRad
+            }
+            start = Offset(center.x + sin(ang) * rx, center.y - cos(ang) * ry)
+        }
+        val dirX = if (fx.rayFixedDirection) fdx else sin(ang)
+        val dirY = if (fx.rayFixedDirection) fdy else -cos(ang)
+        val end = Offset(start.x + dirX * beamReach, start.y + dirY * beamReach)
+
+        val brush = Brush.linearGradient(
+            colorStops = arrayOf(
+                0f to rayColor.copy(alpha = alpha),
+                decay to rayColor.copy(alpha = alpha * 0.5f),
+                1f to Color.Transparent,
             ),
             start = start,
             end = end,
-            strokeWidth = (2f + (fx.rayWidthDp - 2f) * p).coerceAtLeast(1f) * density,
-            cap = StrokeCap.Round,
         )
+        if (fx.rayTaper > 0.01f) {
+            // Tapered spear: wide base → narrow tip, perpendicular to the beam.
+            val nx = -dirY
+            val ny = dirX
+            val half = stroke / 2f
+            val tip = half * (1f - fx.rayTaper)
+            val path = Path().apply {
+                moveTo(start.x + nx * half, start.y + ny * half)
+                lineTo(start.x - nx * half, start.y - ny * half)
+                lineTo(end.x - nx * tip, end.y - ny * tip)
+                lineTo(end.x + nx * tip, end.y + ny * tip)
+                close()
+            }
+            drawPath(path = path, brush = brush)
+        } else {
+            drawLine(
+                brush = brush,
+                start = start,
+                end = end,
+                strokeWidth = stroke,
+                cap = StrokeCap.Round,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -18,10 +18,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.boundsInRoot
@@ -35,7 +35,6 @@ import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
 import kotlin.math.floor
-import kotlin.math.max
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -229,16 +228,17 @@ internal fun LyricsFxLayer(
                     drawGlow(c, glowR, p, rayColor, fx)
                 }
 
-                // Per-glyph rays: each burst rooted on its own letter, sized to
-                // the glyph. Reach breathes with the pulse by rayPulseAmount.
+                // Crepuscular god rays: soft, wide, volumetric light shafts fanning
+                // out from ONE source above the lyric line (like sun/underwater god
+                // rays), additively blended so overlaps bloom — instead of a busy
+                // starburst rooted on every letter. Reach breathes with the pulse.
                 if (fx.rayCount > 0) {
-                    val spinRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
-                    val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
-                    anchors.glyphs.values.forEach { g ->
-                        val c = g.center - origin
-                        val glyph = max(g.halfW, g.halfH)
-                        val reach = glyph * 2f * (0.6f + 2.4f * fx.rayLength) * pulseReach
-                        drawBeams(c, g.halfW * 0.55f, g.halfH * 0.55f, reach, p, rayColor, fx, spinRad, g.phase, time.value)
+                    anchors.lineCenter?.let { lc ->
+                        val c = lc - origin
+                        val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
+                        val reach = size.height * (0.5f + 1.0f * fx.rayLength) * pulseReach
+                        val driftRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
+                        drawGodRayShafts(c, reach, p, rayColor, fx, driftRad, time.value)
                     }
                 }
             },
@@ -255,103 +255,90 @@ private fun Color.shiftHue(degrees: Float): Color {
 }
 
 /**
- * Draws one glyph's god rays. Honours the full ray parameter set: direction +
- * spread (or parallel directional shafts when [LyricsFxSettings.rayFixedDirection]),
- * decay-shaped fade, width taper, per-beam length jitter, flicker, and how hard
- * reach/width react to the bass pulse.
+ * Draws the lyric line's crepuscular god rays: soft, wide light shafts fanning
+ * out from a single source above the line and blended additively so overlaps
+ * bloom into volumetric light (sun / underwater god-ray look), rather than a
+ * per-letter starburst.
+ *
+ * Honours the full ray parameter set: [LyricsFxSettings.rayAngleDeg] tilts the
+ * whole fan, [raySpreadDeg] is the fan's cone angle (360 → a full radial sun),
+ * [rayCount] the number of shafts, [rayLength]→reach, [rayWidthDp] shaft width,
+ * [rayBrightness] alpha, [rayDecay] the fade shape, [rayTaper] how much shafts
+ * widen toward the tip, [rayLengthJitter]/[rayFlicker] the per-shaft variation,
+ * [raySpinDegPerSec] a slow drift, and [rayPulseAmount] the bass reactivity.
  */
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBeams(
-    center: Offset,
-    rx: Float,
-    ry: Float,
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawGodRayShafts(
+    lineCenter: Offset,
     reach: Float,
     p: Float,
     rayColor: Color,
     fx: LyricsFxSettings,
-    spinRad: Float,
-    seed: Float,
+    driftRad: Float,
     timeSec: Float,
 ) {
     val count = fx.rayCount
-    if (count <= 0) return
+    if (count <= 0 || reach <= 1f) return
 
-    val fixedRad = fx.rayAngleDeg * PI.toFloat() / 180f
-    val spreadRad = fx.raySpreadDeg * PI.toFloat() / 180f
+    // Base direction points DOWN (0 = up in this convention, so PI = down),
+    // tilted by rayAngleDeg; shafts spread across raySpreadDeg. The source sits
+    // above the line so the fan pours down through and past the lyric.
+    val baseRad = PI.toFloat() + fx.rayAngleDeg * PI.toFloat() / 180f
+    val spreadRad = fx.raySpreadDeg.coerceIn(0f, 360f) * PI.toFloat() / 180f
+    val source = Offset(lineCenter.x, lineCenter.y - reach * 0.42f)
+
     val widthPulse = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * p
-    val stroke = (2f + (fx.rayWidthDp - 2f) * widthPulse).coerceAtLeast(1f) * density
-    val decay = fx.rayDecay.coerceIn(0.05f, 0.95f)
-
-    // Parallel-shaft geometry (fixed-direction mode): direction (sin,-cos) with
-    // 0 = up, clockwise; shafts spread along the perpendicular across the glyph.
-    val fdx = sin(fixedRad)
-    val fdy = -cos(fixedRad)
-    val perpX = cos(fixedRad)
-    val perpY = sin(fixedRad)
-    val shaftSpread = 3f * max(rx, ry)
-    val spacing = if (count > 1) shaftSpread / (count - 1) else 0f
-    // One reusable Path for the tapered beams (drawPath consumes it synchronously),
-    // instead of allocating a fresh Path per beam per glyph per frame.
-    val beamPath = if (fx.rayTaper > 0.01f) Path() else null
+    val baseHalf = (fx.rayWidthDp * 1.3f * density) * (0.6f + 0.5f * widthPulse)
+    // Kept above the 0.10 peak stop below so the gradient stops stay strictly
+    // increasing (Brush.linearGradient requires monotonic offsets).
+    val decay = fx.rayDecay.coerceIn(0.2f, 0.95f)
+    // Volumetric shafts overlap additively, so each is faint; the pile-up near
+    // the source is what reads as bright light. Mostly steady ambient light with
+    // a bass lift on top, so the fan reads as continuous god rays (not a strobe).
+    val baseAlpha = (fx.rayBrightness * 0.7f * (0.78f + 0.22f * p)).coerceIn(0f, 0.6f)
+    val beamPath = Path()
 
     repeat(count) { i ->
+        val frac = if (count > 1) (i / (count - 1f) - 0.5f) else 0f
+        // Slow independent wobble so the fan gently breathes/shimmers.
+        val wobble = 0.05f * sin(timeSec * 0.5f + i * 1.3f)
+        val ang = baseRad + driftRad * 0.15f + frac * spreadRad + wobble
+        val dirX = sin(ang)
+        val dirY = -cos(ang)
+
         val rnd = abs(sin(i * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
         val beamReach = reach * (1f - fx.rayLengthJitter * rnd)
         val flick = if (fx.rayFlicker > 0f) {
-            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 7f + i * 1.7f + seed))
+            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 6f + i * 1.7f))
         } else 1f
-        val alpha = (fx.rayBrightness * flick * widthPulse).coerceIn(0f, 1f)
-        if (alpha <= 0.003f) return@repeat
+        val alpha = (baseAlpha * flick).coerceIn(0f, 0.6f)
+        if (alpha <= 0.002f) return@repeat
 
-        val ang: Float
-        val start: Offset
-        if (fx.rayFixedDirection) {
-            ang = fixedRad
-            val t = (i - (count - 1) / 2f) * spacing
-            start = Offset(center.x + perpX * t, center.y + perpY * t)
-        } else {
-            ang = if (fx.raySpreadDeg >= 359.5f) {
-                spinRad + seed + i * (2f * PI.toFloat() / count)
-            } else {
-                val frac = if (count > 1) (i / (count - 1f) - 0.5f) else 0f
-                fixedRad + spinRad + frac * spreadRad
-            }
-            start = Offset(center.x + sin(ang) * rx, center.y - cos(ang) * ry)
-        }
-        val dirX = if (fx.rayFixedDirection) fdx else sin(ang)
-        val dirY = if (fx.rayFixedDirection) fdy else -cos(ang)
-        val end = Offset(start.x + dirX * beamReach, start.y + dirY * beamReach)
-
+        val end = Offset(source.x + dirX * beamReach, source.y + dirY * beamReach)
         val brush = Brush.linearGradient(
             colorStops = arrayOf(
-                0f to rayColor.copy(alpha = alpha),
-                decay to rayColor.copy(alpha = alpha * 0.5f),
+                // Fade in from the source (which sits off above the text), peak,
+                // then decay to nothing so the shaft dissolves into the backdrop.
+                0f to Color.Transparent,
+                0.10f to rayColor.copy(alpha = alpha),
+                decay to rayColor.copy(alpha = alpha * 0.45f),
                 1f to Color.Transparent,
             ),
-            start = start,
+            start = source,
             end = end,
         )
-        if (beamPath != null) {
-            // Tapered spear: wide base → narrow tip, perpendicular to the beam.
-            val nx = -dirY
-            val ny = dirX
-            val half = stroke / 2f
-            val tip = half * (1f - fx.rayTaper)
-            beamPath.reset()
-            beamPath.moveTo(start.x + nx * half, start.y + ny * half)
-            beamPath.lineTo(start.x - nx * half, start.y - ny * half)
-            beamPath.lineTo(end.x - nx * tip, end.y - ny * tip)
-            beamPath.lineTo(end.x + nx * tip, end.y + ny * tip)
-            beamPath.close()
-            drawPath(path = beamPath, brush = brush)
-        } else {
-            drawLine(
-                brush = brush,
-                start = start,
-                end = end,
-                strokeWidth = stroke,
-                cap = StrokeCap.Round,
-            )
-        }
+        // Soft shaft: narrow near the source, widening toward the tip as light
+        // spreads (rayTaper controls how much). Perpendicular to the beam.
+        val nx = -dirY
+        val ny = dirX
+        val nearHalf = baseHalf * 0.35f
+        val farHalf = baseHalf * (0.9f + 1.1f * fx.rayTaper)
+        beamPath.reset()
+        beamPath.moveTo(source.x + nx * nearHalf, source.y + ny * nearHalf)
+        beamPath.lineTo(source.x - nx * nearHalf, source.y - ny * nearHalf)
+        beamPath.lineTo(end.x - nx * farHalf, end.y - ny * farHalf)
+        beamPath.lineTo(end.x + nx * farHalf, end.y + ny * farHalf)
+        beamPath.close()
+        drawPath(path = beamPath, brush = brush, blendMode = BlendMode.Plus)
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -289,6 +289,9 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBeams(
     val perpY = sin(fixedRad)
     val shaftSpread = 3f * max(rx, ry)
     val spacing = if (count > 1) shaftSpread / (count - 1) else 0f
+    // One reusable Path for the tapered beams (drawPath consumes it synchronously),
+    // instead of allocating a fresh Path per beam per glyph per frame.
+    val beamPath = if (fx.rayTaper > 0.01f) Path() else null
 
     repeat(count) { i ->
         val rnd = abs(sin(i * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
@@ -327,20 +330,19 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBeams(
             start = start,
             end = end,
         )
-        if (fx.rayTaper > 0.01f) {
+        if (beamPath != null) {
             // Tapered spear: wide base → narrow tip, perpendicular to the beam.
             val nx = -dirY
             val ny = dirX
             val half = stroke / 2f
             val tip = half * (1f - fx.rayTaper)
-            val path = Path().apply {
-                moveTo(start.x + nx * half, start.y + ny * half)
-                lineTo(start.x - nx * half, start.y - ny * half)
-                lineTo(end.x - nx * tip, end.y - ny * tip)
-                lineTo(end.x + nx * tip, end.y + ny * tip)
-                close()
-            }
-            drawPath(path = path, brush = brush)
+            beamPath.reset()
+            beamPath.moveTo(start.x + nx * half, start.y + ny * half)
+            beamPath.lineTo(start.x - nx * half, start.y - ny * half)
+            beamPath.lineTo(end.x - nx * tip, end.y - ny * tip)
+            beamPath.lineTo(end.x + nx * tip, end.y + ny * tip)
+            beamPath.close()
+            drawPath(path = beamPath, brush = brush)
         } else {
             drawLine(
                 brush = brush,

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -18,25 +18,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.audio.eq.SpectrumAnalyzerTap
 import tf.monochrome.android.domain.model.LyricsFxSettings
-import kotlin.math.PI
-import kotlin.math.abs
-import kotlin.math.cos
 import kotlin.math.exp
-import kotlin.math.floor
-import kotlin.math.max
-import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
@@ -194,10 +185,9 @@ internal fun Modifier.reportGlyphAnchor(
 }
 
 /**
- * Full-screen god-ray + glow layer. Draws each active glyph's rays at its
- * reported screen position, plus one soft glow behind the whole line. Lives
- * on a layer with no clipping ancestor, so the light can never be cut by a
- * canvas — beams simply run off the screen edge at worst. Draw-phase only.
+ * Full-screen glow layer: one soft album-accent bloom behind the whole active
+ * line, breathing with the bass. Lives on a layer with no clipping ancestor, so
+ * the light can never be cut by a canvas. Draw-phase only.
  */
 @Composable
 internal fun LyricsFxLayer(
@@ -208,7 +198,6 @@ internal fun LyricsFxLayer(
     modifier: Modifier = Modifier,
 ) {
     if (fx.bassReact <= 0.01f) return
-    val time = rememberFrameSeconds()
     var origin by remember { mutableStateOf(Offset.Zero) }
     Box(
         modifier
@@ -218,134 +207,14 @@ internal fun LyricsFxLayer(
                 val p = (pulse.value * fx.bassReact).coerceIn(0f, 1.6f)
                 if (p <= 0.03f) return@drawBehind
 
-                // Rays and glow share one album-accent colour, hue-rotated by the
-                // user's setting.
-                val rayColor = accent.shiftHue(fx.rayHueShift)
-
-                // One soft bloom behind the whole line.
+                // One soft album-accent bloom behind the whole active line.
                 anchors.lineCenter?.let { lc ->
                     val c = lc - origin
                     val glowR = anchors.lineHalf.height + fx.glowRadiusDp.dp.toPx() * (1f + p)
-                    drawGlow(c, glowR, p, rayColor, fx)
-                }
-
-                // Per-letter god rays: each glyph is its own light source, emitting
-                // soft near-vertical shafts UP and DOWN through the letter (like the
-                // reference), additively blended so overlaps bloom. Rooted on every
-                // active glyph, sized to the glyph, breathing with the bass pulse.
-                if (fx.rayCount > 0) {
-                    val driftRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
-                    val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
-                    anchors.glyphs.values.forEach { g ->
-                        val c = g.center - origin
-                        val glyph = max(g.halfW, g.halfH)
-                        // Reach scales with the glyph so bigger letters throw longer
-                        // light; rayLength stretches it, the pulse makes it breathe.
-                        val reach = glyph * (3f + 9f * fx.rayLength) * pulseReach
-                        drawLetterRays(c, reach, p, rayColor, fx, driftRad, g.phase, time.value)
-                    }
+                    drawGlow(c, glowR, p, accent, fx)
                 }
             },
     )
-}
-
-/** Rotate a colour's hue by [degrees] (0 = unchanged), keeping saturation/value. */
-private fun Color.shiftHue(degrees: Float): Color {
-    if (degrees == 0f) return this
-    val hsv = FloatArray(3)
-    android.graphics.Color.colorToHSV(toArgb(), hsv)
-    hsv[0] = ((hsv[0] + degrees) % 360f + 360f) % 360f
-    return Color(android.graphics.Color.HSVToColor((alpha * 255f).toInt().coerceIn(0, 255), hsv))
-}
-
-/**
- * Draws ONE glyph's god rays: the letter is its own light source, throwing soft
- * near-vertical shafts UP and DOWN through itself (like the reference), each a
- * translucent gradient blended additively so where a letter's shafts and its
- * neighbours' overlap the light blooms. The shaft origin sits ON the glyph so
- * the rays clearly emanate from the letter rather than from some far source.
- *
- * Honours the ray parameter set: [LyricsFxSettings.rayAngleDeg] tilts the
- * up/down axis, [raySpreadDeg] fans the shafts around it, [rayCount] is the
- * shafts per letter (split across the two directions), [rayLength]→reach,
- * [rayWidthDp] width, [rayBrightness] alpha, [rayDecay] the fade shape,
- * [rayTaper] how much they widen, [rayLengthJitter]/[rayFlicker] the variation,
- * [raySpinDegPerSec] a slow sway, and [rayPulseAmount] the bass reactivity.
- */
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawLetterRays(
-    center: Offset,
-    reach: Float,
-    p: Float,
-    rayColor: Color,
-    fx: LyricsFxSettings,
-    driftRad: Float,
-    seed: Float,
-    timeSec: Float,
-) {
-    val count = fx.rayCount.coerceIn(1, 12)
-    if (reach <= 1f) return
-
-    // rayAngleDeg tilts the emission axis; 0 = straight up/down. Shafts fan by
-    // raySpreadDeg around each of the two opposite directions.
-    val axisRad = fx.rayAngleDeg * PI.toFloat() / 180f
-    val spreadRad = fx.raySpreadDeg.coerceIn(0f, 180f) * PI.toFloat() / 180f
-
-    val widthPulse = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * p
-    val baseHalf = (fx.rayWidthDp * 0.6f * density) * (0.6f + 0.5f * widthPulse)
-    // Kept above the 0.12 peak stop below so the gradient offsets stay strictly
-    // increasing (Brush.linearGradient requires monotonic stops).
-    val decay = fx.rayDecay.coerceIn(0.2f, 0.9f)
-    // Soft, mostly-steady light with a bass lift; low alpha because the shafts
-    // pile up additively (that overlap is what reads as bright light).
-    val baseAlpha = (fx.rayBrightness * 0.85f * (0.72f + 0.28f * p)).coerceIn(0f, 0.6f)
-    val beamPath = Path()
-
-    repeat(count) { i ->
-        // Alternate shafts between the two opposite directions (up vs down), each
-        // side fanned within its own spread, so light pours out both faces of the
-        // letter — a vertical light column, not a one-sided fan.
-        val down = (i % 2 == 1)
-        val pairIdx = i / 2
-        val pairCount = (count + 1) / 2
-        val frac = if (pairCount > 1) (pairIdx / (pairCount - 1f) - 0.5f) else 0f
-        val wobble = 0.05f * sin(timeSec * 0.6f + i * 1.4f + seed)
-        val ang = axisRad + (if (down) PI.toFloat() else 0f) + driftRad * 0.12f + frac * spreadRad + wobble
-        val dirX = sin(ang)
-        val dirY = -cos(ang)
-
-        val rnd = abs(sin((i + seed) * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
-        val beamReach = reach * (1f - fx.rayLengthJitter * rnd)
-        val flick = if (fx.rayFlicker > 0f) {
-            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 6f + i * 1.7f + seed))
-        } else 1f
-        val alpha = (baseAlpha * flick).coerceIn(0f, 0.6f)
-        if (alpha <= 0.002f) return@repeat
-
-        val end = Offset(center.x + dirX * beamReach, center.y + dirY * beamReach)
-        val brush = Brush.linearGradient(
-            colorStops = arrayOf(
-                // Brightest at the letter, fading to nothing along the shaft.
-                0f to rayColor.copy(alpha = alpha),
-                decay to rayColor.copy(alpha = alpha * 0.4f),
-                1f to Color.Transparent,
-            ),
-            start = center,
-            end = end,
-        )
-        // Soft shaft: narrow at the letter, widening toward the tip as the light
-        // spreads (rayTaper controls how much). Perpendicular to the beam.
-        val nx = -dirY
-        val ny = dirX
-        val nearHalf = baseHalf * 0.4f
-        val farHalf = baseHalf * (0.9f + 1.1f * fx.rayTaper)
-        beamPath.reset()
-        beamPath.moveTo(center.x + nx * nearHalf, center.y + ny * nearHalf)
-        beamPath.lineTo(center.x - nx * nearHalf, center.y - ny * nearHalf)
-        beamPath.lineTo(end.x - nx * farHalf, end.y - ny * farHalf)
-        beamPath.lineTo(end.x + nx * farHalf, end.y + ny * farHalf)
-        beamPath.close()
-        drawPath(path = beamPath, brush = brush, blendMode = BlendMode.Plus)
-    }
 }
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawGlow(

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -35,6 +35,7 @@ import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
 import kotlin.math.floor
+import kotlin.math.max
 import kotlin.math.sin
 import kotlin.math.sqrt
 
@@ -228,17 +229,20 @@ internal fun LyricsFxLayer(
                     drawGlow(c, glowR, p, rayColor, fx)
                 }
 
-                // Crepuscular god rays: soft, wide, volumetric light shafts fanning
-                // out from ONE source above the lyric line (like sun/underwater god
-                // rays), additively blended so overlaps bloom — instead of a busy
-                // starburst rooted on every letter. Reach breathes with the pulse.
+                // Per-letter god rays: each glyph is its own light source, emitting
+                // soft near-vertical shafts UP and DOWN through the letter (like the
+                // reference), additively blended so overlaps bloom. Rooted on every
+                // active glyph, sized to the glyph, breathing with the bass pulse.
                 if (fx.rayCount > 0) {
-                    anchors.lineCenter?.let { lc ->
-                        val c = lc - origin
-                        val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
-                        val reach = size.height * (0.5f + 1.0f * fx.rayLength) * pulseReach
-                        val driftRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
-                        drawGodRayShafts(c, reach, p, rayColor, fx, driftRad, time.value)
+                    val driftRad = time.value * (fx.raySpinDegPerSec * PI.toFloat() / 180f)
+                    val pulseReach = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * (0.5f + 0.5f * p)
+                    anchors.glyphs.values.forEach { g ->
+                        val c = g.center - origin
+                        val glyph = max(g.halfW, g.halfH)
+                        // Reach scales with the glyph so bigger letters throw longer
+                        // light; rayLength stretches it, the pulse makes it breathe.
+                        val reach = glyph * (3f + 9f * fx.rayLength) * pulseReach
+                        drawLetterRays(c, reach, p, rayColor, fx, driftRad, g.phase, time.value)
                     }
                 }
             },
@@ -255,86 +259,88 @@ private fun Color.shiftHue(degrees: Float): Color {
 }
 
 /**
- * Draws the lyric line's crepuscular god rays: soft, wide light shafts fanning
- * out from a single source above the line and blended additively so overlaps
- * bloom into volumetric light (sun / underwater god-ray look), rather than a
- * per-letter starburst.
+ * Draws ONE glyph's god rays: the letter is its own light source, throwing soft
+ * near-vertical shafts UP and DOWN through itself (like the reference), each a
+ * translucent gradient blended additively so where a letter's shafts and its
+ * neighbours' overlap the light blooms. The shaft origin sits ON the glyph so
+ * the rays clearly emanate from the letter rather than from some far source.
  *
- * Honours the full ray parameter set: [LyricsFxSettings.rayAngleDeg] tilts the
- * whole fan, [raySpreadDeg] is the fan's cone angle (360 → a full radial sun),
- * [rayCount] the number of shafts, [rayLength]→reach, [rayWidthDp] shaft width,
- * [rayBrightness] alpha, [rayDecay] the fade shape, [rayTaper] how much shafts
- * widen toward the tip, [rayLengthJitter]/[rayFlicker] the per-shaft variation,
- * [raySpinDegPerSec] a slow drift, and [rayPulseAmount] the bass reactivity.
+ * Honours the ray parameter set: [LyricsFxSettings.rayAngleDeg] tilts the
+ * up/down axis, [raySpreadDeg] fans the shafts around it, [rayCount] is the
+ * shafts per letter (split across the two directions), [rayLength]→reach,
+ * [rayWidthDp] width, [rayBrightness] alpha, [rayDecay] the fade shape,
+ * [rayTaper] how much they widen, [rayLengthJitter]/[rayFlicker] the variation,
+ * [raySpinDegPerSec] a slow sway, and [rayPulseAmount] the bass reactivity.
  */
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawGodRayShafts(
-    lineCenter: Offset,
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawLetterRays(
+    center: Offset,
     reach: Float,
     p: Float,
     rayColor: Color,
     fx: LyricsFxSettings,
     driftRad: Float,
+    seed: Float,
     timeSec: Float,
 ) {
-    val count = fx.rayCount
-    if (count <= 0 || reach <= 1f) return
+    val count = fx.rayCount.coerceIn(1, 12)
+    if (reach <= 1f) return
 
-    // Base direction points DOWN (0 = up in this convention, so PI = down),
-    // tilted by rayAngleDeg; shafts spread across raySpreadDeg. The source sits
-    // above the line so the fan pours down through and past the lyric.
-    val baseRad = PI.toFloat() + fx.rayAngleDeg * PI.toFloat() / 180f
-    val spreadRad = fx.raySpreadDeg.coerceIn(0f, 360f) * PI.toFloat() / 180f
-    val source = Offset(lineCenter.x, lineCenter.y - reach * 0.42f)
+    // rayAngleDeg tilts the emission axis; 0 = straight up/down. Shafts fan by
+    // raySpreadDeg around each of the two opposite directions.
+    val axisRad = fx.rayAngleDeg * PI.toFloat() / 180f
+    val spreadRad = fx.raySpreadDeg.coerceIn(0f, 180f) * PI.toFloat() / 180f
 
     val widthPulse = (1f - fx.rayPulseAmount) + fx.rayPulseAmount * p
-    val baseHalf = (fx.rayWidthDp * 1.3f * density) * (0.6f + 0.5f * widthPulse)
-    // Kept above the 0.10 peak stop below so the gradient stops stay strictly
-    // increasing (Brush.linearGradient requires monotonic offsets).
-    val decay = fx.rayDecay.coerceIn(0.2f, 0.95f)
-    // Volumetric shafts overlap additively, so each is faint; the pile-up near
-    // the source is what reads as bright light. Mostly steady ambient light with
-    // a bass lift on top, so the fan reads as continuous god rays (not a strobe).
-    val baseAlpha = (fx.rayBrightness * 0.7f * (0.78f + 0.22f * p)).coerceIn(0f, 0.6f)
+    val baseHalf = (fx.rayWidthDp * 0.6f * density) * (0.6f + 0.5f * widthPulse)
+    // Kept above the 0.12 peak stop below so the gradient offsets stay strictly
+    // increasing (Brush.linearGradient requires monotonic stops).
+    val decay = fx.rayDecay.coerceIn(0.2f, 0.9f)
+    // Soft, mostly-steady light with a bass lift; low alpha because the shafts
+    // pile up additively (that overlap is what reads as bright light).
+    val baseAlpha = (fx.rayBrightness * 0.85f * (0.72f + 0.28f * p)).coerceIn(0f, 0.6f)
     val beamPath = Path()
 
     repeat(count) { i ->
-        val frac = if (count > 1) (i / (count - 1f) - 0.5f) else 0f
-        // Slow independent wobble so the fan gently breathes/shimmers.
-        val wobble = 0.05f * sin(timeSec * 0.5f + i * 1.3f)
-        val ang = baseRad + driftRad * 0.15f + frac * spreadRad + wobble
+        // Alternate shafts between the two opposite directions (up vs down), each
+        // side fanned within its own spread, so light pours out both faces of the
+        // letter — a vertical light column, not a one-sided fan.
+        val down = (i % 2 == 1)
+        val pairIdx = i / 2
+        val pairCount = (count + 1) / 2
+        val frac = if (pairCount > 1) (pairIdx / (pairCount - 1f) - 0.5f) else 0f
+        val wobble = 0.05f * sin(timeSec * 0.6f + i * 1.4f + seed)
+        val ang = axisRad + (if (down) PI.toFloat() else 0f) + driftRad * 0.12f + frac * spreadRad + wobble
         val dirX = sin(ang)
         val dirY = -cos(ang)
 
-        val rnd = abs(sin(i * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
+        val rnd = abs(sin((i + seed) * 12.9898f + 3.7f) * 43758.545f).let { it - floor(it) }
         val beamReach = reach * (1f - fx.rayLengthJitter * rnd)
         val flick = if (fx.rayFlicker > 0f) {
-            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 6f + i * 1.7f))
+            (1f - fx.rayFlicker) + fx.rayFlicker * (0.5f + 0.5f * sin(timeSec * 6f + i * 1.7f + seed))
         } else 1f
         val alpha = (baseAlpha * flick).coerceIn(0f, 0.6f)
         if (alpha <= 0.002f) return@repeat
 
-        val end = Offset(source.x + dirX * beamReach, source.y + dirY * beamReach)
+        val end = Offset(center.x + dirX * beamReach, center.y + dirY * beamReach)
         val brush = Brush.linearGradient(
             colorStops = arrayOf(
-                // Fade in from the source (which sits off above the text), peak,
-                // then decay to nothing so the shaft dissolves into the backdrop.
-                0f to Color.Transparent,
-                0.10f to rayColor.copy(alpha = alpha),
-                decay to rayColor.copy(alpha = alpha * 0.45f),
+                // Brightest at the letter, fading to nothing along the shaft.
+                0f to rayColor.copy(alpha = alpha),
+                decay to rayColor.copy(alpha = alpha * 0.4f),
                 1f to Color.Transparent,
             ),
-            start = source,
+            start = center,
             end = end,
         )
-        // Soft shaft: narrow near the source, widening toward the tip as light
+        // Soft shaft: narrow at the letter, widening toward the tip as the light
         // spreads (rayTaper controls how much). Perpendicular to the beam.
         val nx = -dirY
         val ny = dirX
-        val nearHalf = baseHalf * 0.35f
+        val nearHalf = baseHalf * 0.4f
         val farHalf = baseHalf * (0.9f + 1.1f * fx.rayTaper)
         beamPath.reset()
-        beamPath.moveTo(source.x + nx * nearHalf, source.y + ny * nearHalf)
-        beamPath.lineTo(source.x - nx * nearHalf, source.y - ny * nearHalf)
+        beamPath.moveTo(center.x + nx * nearHalf, center.y + ny * nearHalf)
+        beamPath.lineTo(center.x - nx * nearHalf, center.y - ny * nearHalf)
         beamPath.lineTo(end.x - nx * farHalf, end.y - ny * farHalf)
         beamPath.lineTo(end.x + nx * farHalf, end.y + ny * farHalf)
         beamPath.close()

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsBassFx.kt
@@ -103,7 +103,11 @@ internal fun rememberBassPulse(tap: SpectrumAnalyzerTap?, fx: LyricsFxSettings):
 
     DisposableEffect(tap) {
         tap.acquire()
-        onDispose { tap.release() }
+        LyricsDebug.log("FFT analyzer staked (bass pulse active)")
+        onDispose {
+            tap.release()
+            LyricsDebug.log("FFT analyzer released (bass pulse stopped)")
+        }
     }
     LaunchedEffect(tap, fx.attackMs, fx.releaseMs, fx.bounce) {
         val attackSec = (fx.attackMs / 1000f).coerceAtLeast(0.001f)

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsDebug.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsDebug.kt
@@ -1,0 +1,63 @@
+package tf.monochrome.android.ui.player
+
+import android.util.Log
+import tf.monochrome.android.domain.model.LyricsFxSettings
+
+/**
+ * Structured debug logging for the lyrics subsystem. Every line lands in the
+ * in-app Debug Log (Settings › Debug Log) because [tf.monochrome.android.debug.DebugLogCollector]
+ * pipes our own logcat back into the buffer — so a plain [Log] call under the
+ * [TAG] shows up there with no extra wiring.
+ *
+ * Call sites are lifecycle/state transitions only (settings change, shader
+ * compile, font load, lyrics load, active-line change, beat engine acquire/
+ * release). Nothing here is called from a draw/graphicsLayer lambda — the
+ * lyric renderer runs its shaders and clocks every frame, and logging at that
+ * rate would flood the ring buffer.
+ */
+internal object LyricsDebug {
+    const val TAG = "LyricsFx"
+
+    fun log(message: String) {
+        Log.d(TAG, message)
+    }
+
+    /** One line naming every effect currently running on the lyrics and its key params. */
+    fun summary(fx: LyricsFxSettings): String = buildString {
+        append("config: ")
+        append("font=").append(
+            if (fx.customFont && fx.customFontPath.isNotBlank()) fx.customFontPath.substringAfterLast('/')
+            else "theme",
+        )
+        append(" btDelay=").append(fx.bluetoothDelayMs.toInt()).append("ms")
+
+        append(" | glass=").append(if (fx.liquidGlass) "ON" else "off")
+        if (fx.liquidGlass) {
+            append("[opacity=").append((fx.glassBodyOpacity * 100).toInt()).append('%')
+            append(" refr=").append(fx.glassRefraction)
+            append(" rim=").append(fx.glassRimBrightness)
+            append(" disp=").append(fx.glassDispersion)
+            append(" taps=").append(1 + 4 * fx.glassSampleRings).append(']')
+        }
+
+        append(" | fxaa=").append(if (fx.fxaa) "ON[${(fx.fxaaStrength * 100).toInt()}%]" else "off")
+
+        append(" | wave=").append(
+            if (fx.rotationDegrees > 0.05f) "ON[tilt=${fx.rotationDegrees} speed=${fx.waveSpeed}]" else "off",
+        )
+
+        append(" | beat=").append(
+            if (fx.bassReact > 0.01f) "ON[react=${(fx.bassReact * 100).toInt()}% pump=${fx.pumpAmount}]" else "off",
+        )
+
+        val raysOn = fx.rayCount > 0 && fx.bassReact > 0.01f
+        append(" | rays=").append(
+            if (raysOn) {
+                val dir = if (fx.rayFixedDirection) "fixed@${fx.rayAngleDeg.toInt()}°"
+                else "burst/spread=${fx.raySpreadDeg.toInt()}°"
+                "ON[n=${fx.rayCount} $dir bright=${fx.rayBrightness}]"
+            } else "off",
+        )
+        append(" glow=").append(if (fx.bassReact > 0.01f && fx.glowBrightness > 0.001f) "ON" else "off")
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -248,10 +248,11 @@ internal fun Modifier.lyricsEdgeFade(): Modifier = this
     // drawWithCache builds the mask gradient once per size, not on every draw —
     // and this surface redraws every frame (the glass shader animates).
     .drawWithCache {
-        // Density-aware fade depth. The old cap was 120 raw PIXELS — ~40dp on
-        // a 3x panel — so lines sliced off at what looked like an invisible
-        // border instead of dissolving.
-        val edge = (size.height * 0.18f).coerceAtMost(56.dp.toPx())
+        // Thin edge feather only: lines reach the top and bottom borders (like
+        // they now reach the side borders) instead of being padded away by a deep
+        // fade. Just enough of a feather to soften the scroll clip and the glass
+        // shader edge — not a visible top/bottom inset.
+        val edge = (size.height * 0.05f).coerceAtMost(14.dp.toPx())
         val top = edge / size.height
         val mask = Brush.verticalGradient(
             0f to Color.Transparent,

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -308,10 +308,17 @@ internal fun SyncedLyricsView(
     onSeekTo: (Long) -> Unit,
 ) {
     val position by positionMs.collectAsState()
+    // Bluetooth sync delay: the audio reaches the ears later than the reported
+    // playback position, so lyrics run ahead. Rewinding the position we match
+    // against by the delay pushes the whole lyric timeline back into step with
+    // what's actually being heard. (Tunable in the Lyrics FX Studio.)
+    val syncDelayMs = LocalLyricsFx.current.bluetoothDelayMs.toLong()
     // Start composed at the current line so a freshly created instance (the
     // expand morph spawns one) never flashes the top of the song before the
     // centring effect runs.
-    val initialLine = remember { lines.indexOfLast { it.timeMs <= positionMs.value }.coerceAtLeast(0) }
+    val initialLine = remember {
+        lines.indexOfLast { it.timeMs <= positionMs.value - syncDelayMs }.coerceAtLeast(0)
+    }
     val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialLine)
     val lastCentredLine = remember { mutableIntStateOf(initialLine) }
 
@@ -322,8 +329,9 @@ internal fun SyncedLyricsView(
     // earlier version extrapolated the position between samples, which jittered
     // the index at line boundaries — the highlight looked stuck and the
     // constant re-scroll ate taps. The polled position is stable and accurate.)
-    val currentLineIndex by remember(lines) {
-        derivedStateOf { lines.indexOfLast { it.timeMs <= position } }
+    // Keyed on the delay too so retuning it re-selects the active line at once.
+    val currentLineIndex by remember(lines, syncDelayMs) {
+        derivedStateOf { lines.indexOfLast { it.timeMs <= position - syncDelayMs } }
     }
 
     // Bass-reactive FX for the active line: pulse from the FFT tap, a frame
@@ -424,7 +432,8 @@ internal fun SyncedLyricsView(
                     line = line,
                     isActive = isActive,
                     isPast = isPast,
-                    position = position,
+                    // Word-level highlight rides the same Bluetooth-adjusted clock.
+                    position = position - syncDelayMs,
                     accent = accent,
                     onClick = { onSeekTo(line.timeMs) },
                     beatModifier = beatModifier,

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -191,8 +191,9 @@ internal fun LyricsHeroPanel(
 internal fun PlayerBlurredArtBackground(
     coverUrl: String?,
     albumColors: AlbumColors,
+    alpha: () -> Float = { 1f },
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().graphicsLayer { this.alpha = alpha() }) {
         if (!coverUrl.isNullOrBlank()) {
             SubcomposeAsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
@@ -210,9 +211,12 @@ internal fun PlayerBlurredArtBackground(
                     .dithered(),
             )
         }
-        // Album-tinted legibility scrim: darker top and bottom so the top bar and
-        // the transport/track text keep contrast over bright artwork; the middle
-        // stays clearer so the blurred art is clearly visible behind the hero.
+        // Album-tinted legibility scrim, Apple-Music style: a deep, moody
+        // darkening across the whole background so the stretched art reads as a
+        // dim backdrop, not a bright wallpaper. The middle keeps a *darkened*
+        // album tone (dominant mixed toward black) for colour without brightness,
+        // and the top/bottom fall off darker still for top-bar and transport
+        // legibility.
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -220,9 +224,9 @@ internal fun PlayerBlurredArtBackground(
                 .background(
                     Brush.verticalGradient(
                         colors = listOf(
-                            Color.Black.copy(alpha = 0.42f),
-                            albumColors.dominant.copy(alpha = 0.20f),
-                            Color.Black.copy(alpha = 0.55f),
+                            Color.Black.copy(alpha = 0.58f),
+                            lerp(albumColors.dominant, Color.Black, 0.62f).copy(alpha = 0.52f),
+                            Color.Black.copy(alpha = 0.72f),
                         )
                     )
                 )

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -34,7 +34,7 @@ import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -244,22 +244,24 @@ internal fun LyricsBackdropStain(
  */
 internal fun Modifier.lyricsEdgeFade(): Modifier = this
     .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
-    .drawWithContent {
-        drawContent()
+    // drawWithCache builds the mask gradient once per size, not on every draw —
+    // and this surface redraws every frame (the glass shader animates).
+    .drawWithCache {
         // Density-aware fade depth. The old cap was 120 raw PIXELS — ~40dp on
         // a 3x panel — so lines sliced off at what looked like an invisible
         // border instead of dissolving.
         val edge = (size.height * 0.18f).coerceAtMost(56.dp.toPx())
         val top = edge / size.height
-        drawRect(
-            brush = Brush.verticalGradient(
-                0f to Color.Transparent,
-                top to Color.Black,
-                1f - top to Color.Black,
-                1f to Color.Transparent,
-            ),
-            blendMode = BlendMode.DstIn,
+        val mask = Brush.verticalGradient(
+            0f to Color.Transparent,
+            top to Color.Black,
+            1f - top to Color.Black,
+            1f to Color.Transparent,
         )
+        onDrawWithContent {
+            drawContent()
+            drawRect(brush = mask, blendMode = BlendMode.DstIn)
+        }
     }
 
 @Composable
@@ -384,6 +386,9 @@ internal fun SyncedLyricsView(
         // Half-height padding top and bottom lets any line — including the
         // first and last — settle at the exact vertical centre.
         val halfViewport = maxHeight / 2
+        // The line width is the same for every item (no per-item horizontal
+        // padding), so read it once here instead of a BoxWithConstraints per line.
+        val lineWidth = maxWidth
 
         // Keyed on maxHeight as well so the active line is re-centred while
         // the surface is being resized (the expand/collapse morph animates
@@ -432,8 +437,6 @@ internal fun SyncedLyricsView(
             // Each line gets ONE row: the font is fitted to the available width so
             // a long line reaches toward the screen edges (shrinking if it must)
             // instead of wrapping or being cut off inside the compact player.
-            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            val availWidth = maxWidth
             val isActive = index == currentLineIndex
             val isPast = index < currentLineIndex
             // Bass FX rides only the active line: the line pumps + pops
@@ -454,7 +457,7 @@ internal fun SyncedLyricsView(
             // height never moves with the fitted size — the list never reflows.
             val fittedSp = rememberFittedLyricSizeSp(
                 text = line.text.ifBlank { "♪" },
-                availableWidth = availWidth,
+                availableWidth = lineWidth,
                 baseSp = fx.fontSizeSp,
                 style = MaterialTheme.typography.titleMedium.copy(
                     letterSpacing = fx.letterSpacingSp.sp,
@@ -527,7 +530,6 @@ internal fun SyncedLyricsView(
                     )
                 }
             }
-            }
         }
         }
     }
@@ -552,6 +554,15 @@ internal fun KaraokeLyricLine(
     val perLetter = isActive &&
         (fx.rotationDegrees > 0.05f || (fx.bassReact > 0.01f && fx.rayCount > 0))
     val time = if (perLetter) rememberFrameSeconds() else null
+    // Font + base style are identical for every word — build them ONCE per line
+    // instead of per word inside the loop (only the colour varies per word).
+    val lyricFont = rememberLyricFontFamily(fx)
+    val wordStyle = MaterialTheme.typography.titleMedium.copy(
+        fontSize = fontSizeSp.sp,
+        lineHeight = (fx.fontSizeSp * 1.26f).sp,
+        letterSpacing = fx.letterSpacingSp.sp,
+        fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
+    ).withLyricFont(lyricFont)
     // Single row (no wrap): the whole line stays on one line, fitted to width by
     // the caller. Overflow (a very long line) simply runs toward the screen edge.
     Row(
@@ -573,12 +584,6 @@ internal fun KaraokeLyricLine(
             }
             val color by animateColorAsState(targetValue = target, label = "wordColor")
             val display = word.text + " "
-            val wordStyle = MaterialTheme.typography.titleMedium.copy(
-                fontSize = fontSizeSp.sp,
-                lineHeight = (fx.fontSizeSp * 1.26f).sp,
-                letterSpacing = fx.letterSpacingSp.sp,
-                fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
-            ).withLyricFont(rememberLyricFontFamily(fx))
             if (time != null) {
                 val phaseBase = letterBase
                 Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx, fontSizeSp))) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -408,6 +408,7 @@ internal fun SyncedLyricsView(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 28.dp)
+                .fxaa()
                 .liquidGlass(tint = accent),
             contentPadding = PaddingValues(top = halfViewport, bottom = halfViewport),
             verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -728,6 +729,7 @@ internal fun UnsyncedLyricsView(lines: List<LyricLine>) {
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 28.dp)
+            .fxaa()
             .liquidGlass(),
         contentPadding = PaddingValues(vertical = 60.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -438,9 +438,12 @@ internal fun SyncedLyricsView(
         // Half-height padding top and bottom lets any line — including the
         // first and last — settle at the exact vertical centre.
         val halfViewport = maxHeight / 2
-        // The line width is the same for every item, so read it once here (minus
-        // the user's edge margin) instead of a BoxWithConstraints per line.
-        val lineWidth = (maxWidth - fx.edgeMarginDp.dp * 2).coerceAtLeast(0.dp)
+        // The line width is the same for every item, so read it once here.
+        // A fixed bevel-safe inset (on top of the user's edge margin) keeps the
+        // outermost glyphs — and their puffy 3D glass bevels — off the layer's
+        // clip edge, so edge letters never get corner-cut against the border.
+        val sideInset = fx.edgeMarginDp.dp + LYRIC_BEVEL_SAFE_DP
+        val lineWidth = (maxWidth - sideInset * 2).coerceAtLeast(0.dp)
 
         // Keyed on maxHeight as well so the active line is re-centred while
         // the surface is being resized (the expand/collapse morph animates
@@ -477,9 +480,10 @@ internal fun SyncedLyricsView(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                // Side margin between the lyrics and the edges (user setting; 0 by
-                // default so the hero uses the full screen width).
-                .padding(horizontal = fx.edgeMarginDp.dp)
+                // User edge margin + a fixed bevel-safe inset, so the outermost
+                // glyphs (and their glass bevels) never sit flush against the
+                // clip edge where they'd be corner-cut.
+                .padding(horizontal = sideInset)
                 .fxaa()
                 .liquidGlass(tint = accent),
             contentPadding = PaddingValues(top = halfViewport, bottom = halfViewport),
@@ -704,6 +708,13 @@ internal fun TextStyle.withLyricFont(family: FontFamily?): TextStyle =
 
 /** Smallest lyric font we'll shrink to before a line is simply allowed to run wide. */
 private const val MIN_LYRIC_SP = 11f
+
+/**
+ * Fixed side inset that keeps the outermost glyphs (and their puffy 3D glass
+ * bevels) clear of the lyric layer's clip edge, so edge letters are never
+ * corner-cut against the screen border. Added on top of the user's edge margin.
+ */
+private val LYRIC_BEVEL_SAFE_DP = 14.dp
 
 /**
  * The largest font size (≤ [baseSp], down to [MIN_LYRIC_SP]) at which [text]

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -336,6 +336,18 @@ internal fun SyncedLyricsView(
         derivedStateOf { lines.indexOfLast { it.timeMs <= position - syncDelayMs } }
     }
 
+    // Debug log: what's playing (once per song load) and each active-line change.
+    LaunchedEffect(lines) {
+        val wordLevel = lines.any { it.words.isNotEmpty() }
+        LyricsDebug.log("synced lyrics loaded: ${lines.size} lines, ${if (wordLevel) "word-level (karaoke)" else "line-level"}")
+    }
+    LaunchedEffect(currentLineIndex) {
+        val idx = currentLineIndex
+        if (idx in lines.indices) {
+            LyricsDebug.log("active line $idx/${lines.size}: \"${lines[idx].text.take(48)}\"")
+        }
+    }
+
     // Bass-reactive FX for the active line: pulse from the FFT tap, a frame
     // clock for the ray sweep, and a pop-in spring per line change. All
     // disabled (and the analyzer never acquired) at intensity 0.
@@ -589,8 +601,15 @@ internal fun rememberLyricFontFamily(fx: LyricsFxSettings): FontFamily? {
     return remember(path) {
         runCatching {
             val file = java.io.File(path)
-            if (file.exists()) FontFamily(Font(file)) else null
-        }.getOrNull()
+            if (file.exists()) {
+                LyricsDebug.log("custom font loaded: ${file.name}")
+                FontFamily(Font(file))
+            } else {
+                LyricsDebug.log("custom font MISSING, falling back to theme: $path")
+                null
+            }
+        }.onFailure { LyricsDebug.log("custom font FAILED to load ($path): ${it.message}") }
+            .getOrNull()
     }
 }
 
@@ -725,6 +744,7 @@ private fun Letter3DText(
 
 @Composable
 internal fun UnsyncedLyricsView(lines: List<LyricLine>) {
+    LaunchedEffect(lines) { LyricsDebug.log("unsynced lyrics loaded: ${lines.size} lines (no timing)") }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -180,6 +180,56 @@ internal fun LyricsHeroPanel(
 }
 
 /**
+ * Persistent full-screen album-art background (Appearance › "Blurred Album
+ * Background"): the cover stretched to fill the whole player and heavily
+ * blurred, the way Apple Music / Spotify paint the now-playing page. A soft
+ * album-tinted scrim keeps the foreground controls and lyrics legible, and
+ * the lyric liquid glass refracts these same album tones so the glass reads
+ * as sitting over the artwork.
+ */
+@Composable
+internal fun PlayerBlurredArtBackground(
+    coverUrl: String?,
+    albumColors: AlbumColors,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (!coverUrl.isNullOrBlank()) {
+            SubcomposeAsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(coverUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                // Crop = fill the whole rectangle (stretch to cover), so a square
+                // cover blooms across the full portrait screen.
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .blur(64.dp)
+                    .dithered(),
+            )
+        }
+        // Album-tinted legibility scrim: darker top and bottom so the top bar and
+        // the transport/track text keep contrast over bright artwork; the middle
+        // stays clearer so the blurred art is clearly visible behind the hero.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .dithered()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Black.copy(alpha = 0.42f),
+                            albumColors.dominant.copy(alpha = 0.20f),
+                            Color.Black.copy(alpha = 0.55f),
+                        )
+                    )
+                )
+        )
+    }
+}
+
+/**
  * The album artwork as a full-screen blurred stain: opaque base + blurred
  * cover + dominant-colour gradient. Pure backdrop for expanded lyrics —
  * drawn behind the player content, never a foreground element.

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSp
 import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
@@ -516,6 +515,7 @@ internal fun SyncedLyricsView(
                         modifier = lineModifier,
                         anchors = lineAnchors,
                         glyphKeyBase = glyphKeyBase,
+                        fontSizeSp = fittedSp,
                     )
                 } else {
                     Text(
@@ -724,18 +724,20 @@ internal fun Letters3DLine(
     modifier: Modifier = Modifier,
     anchors: LyricGlyphAnchors? = null,
     glyphKeyBase: Int = 0,
+    // The fitted size the caller used for [style], so the inter-letter gap scales
+    // with the actual glyph size (passed explicitly rather than read off [style]).
+    fontSizeSp: Float = 23f,
 ) {
     val fx = LocalLyricsFx.current
     val time = rememberFrameSeconds()
     val shadowed = style.copy(shadow = letter3DShadow(fx.shadowDepth))
-    val sizeSp = style.fontSize.takeIf { it.isSp }?.value ?: fx.fontSizeSp
     Row(modifier = modifier, horizontalArrangement = Arrangement.Center) {
         var letterBase = 0
         val words = text.split(" ")
         words.forEachIndexed { index, word ->
             val display = if (index < words.lastIndex) "$word " else word
             val phaseBase = letterBase
-            Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx, sizeSp))) {
+            Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx, fontSizeSp))) {
                 display.forEachIndexed { j, ch ->
                     val idx = phaseBase + j
                     Letter3DText(

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -582,10 +582,8 @@ internal fun SyncedLyricsView(
                     .fillMaxWidth()
                     .clickable { onSeekTo(line.timeMs) }
                     .padding(vertical = 2.dp)
-                // Render letters individually (so each reports its position for
-                // rays) whenever the 3D wave OR the god rays are active.
-                val perLetter = isActive &&
-                    (fx.rotationDegrees > 0.05f || (beatIntensity > 0.01f && fx.rayCount > 0))
+                // Render letters individually whenever the 3D wave is active.
+                val perLetter = isActive && fx.rotationDegrees > 0.05f
                 if (perLetter) {
                     Letters3DLine(
                         text = line.text.ifBlank { "♪" },
@@ -628,11 +626,10 @@ internal fun KaraokeLyricLine(
     glyphKeyBase: Int = 0,
     fontSizeSp: Float = 23f,
 ) {
-    // Render letters individually while active whenever the 3D wave OR the god
-    // rays are on (rays need per-glyph positions). One frame clock per line.
+    // Render letters individually while active whenever the 3D wave is on.
+    // One frame clock per line.
     val fx = LocalLyricsFx.current
-    val perLetter = isActive &&
-        (fx.rotationDegrees > 0.05f || (fx.bassReact > 0.01f && fx.rayCount > 0))
+    val perLetter = isActive && fx.rotationDegrees > 0.05f
     val time = if (perLetter) rememberFrameSeconds() else null
     // Font + base style are identical for every word — build them ONCE per line
     // instead of per word inside the loop (only the colour varies per word).

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -398,7 +398,7 @@ internal fun SyncedLyricsView(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 28.dp)
-                .liquidGlass(),
+                .liquidGlass(tint = accent),
             contentPadding = PaddingValues(top = halfViewport, bottom = halfViewport),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
@@ -436,13 +436,10 @@ internal fun SyncedLyricsView(
                 // active line at once.
                 val color by animateColorAsState(
                     targetValue = when {
-                        // The playing line is glass: a translucent fill so the
-                        // blurred backdrop reads THROUGH the letters and the
-                        // liquid-glass relight looks like a lit pane, not solid
-                        // paint. It still leads the eye via the accent colour and
-                        // the ExtraBold weight below, so lowering its opacity
-                        // doesn't cost the "which line is active" cue.
-                        isActive -> accent.copy(alpha = 0.72f)
+                        // Full-opacity fill: the glass transparency is applied by
+                        // the liquidGlass() shader (which owns the see-through body
+                        // and the bright rim), so the letter is handed to it solid.
+                        isActive -> accent
                         isPast -> Color.White.copy(alpha = 0.35f)
                         else -> Color.White.copy(alpha = 0.62f)
                     },
@@ -519,14 +516,12 @@ internal fun KaraokeLyricLine(
     ) {
         var letterBase = 0
         line.words.forEach { word ->
-            // The active line is glass: its sung/lighting-up words carry a
-            // translucent fill so the backdrop shows through and the relight
-            // reads as a lit pane rather than solid paint. Colour still tracks
-            // the karaoke progress; only the opacity is pulled off full.
+            // Solid fills: the liquidGlass() shader turns the active line into
+            // see-through glass, so the karaoke colours are handed to it opaque.
             val target = when {
                 !isActive -> if (isPast) Color.White.copy(alpha = 0.32f) else Color.White.copy(alpha = 0.6f)
-                position >= word.endMs -> accent.copy(alpha = 0.66f)  // already sung
-                position >= word.startMs -> accent.copy(alpha = 0.78f) // lighting up now
+                position >= word.endMs -> accent.copy(alpha = 0.9f)   // already sung
+                position >= word.startMs -> accent                    // lighting up now
                 else -> Color.White.copy(alpha = 0.45f)               // not yet reached
             }
             val color by animateColorAsState(targetValue = target, label = "wordColor")

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -436,7 +436,13 @@ internal fun SyncedLyricsView(
                 // active line at once.
                 val color by animateColorAsState(
                     targetValue = when {
-                        isActive -> accent
+                        // The playing line is glass: a translucent fill so the
+                        // blurred backdrop reads THROUGH the letters and the
+                        // liquid-glass relight looks like a lit pane, not solid
+                        // paint. It still leads the eye via the accent colour and
+                        // the ExtraBold weight below, so lowering its opacity
+                        // doesn't cost the "which line is active" cue.
+                        isActive -> accent.copy(alpha = 0.72f)
                         isPast -> Color.White.copy(alpha = 0.35f)
                         else -> Color.White.copy(alpha = 0.62f)
                     },
@@ -513,10 +519,14 @@ internal fun KaraokeLyricLine(
     ) {
         var letterBase = 0
         line.words.forEach { word ->
+            // The active line is glass: its sung/lighting-up words carry a
+            // translucent fill so the backdrop shows through and the relight
+            // reads as a lit pane rather than solid paint. Colour still tracks
+            // the karaoke progress; only the opacity is pulled off full.
             val target = when {
                 !isActive -> if (isPast) Color.White.copy(alpha = 0.32f) else Color.White.copy(alpha = 0.6f)
-                position >= word.endMs -> accent.copy(alpha = 0.9f)   // already sung
-                position >= word.startMs -> accent                    // lighting up now
+                position >= word.endMs -> accent.copy(alpha = 0.66f)  // already sung
+                position >= word.startMs -> accent.copy(alpha = 0.78f) // lighting up now
                 else -> Color.White.copy(alpha = 0.45f)               // not yet reached
             }
             val color by animateColorAsState(targetValue = target, label = "wordColor")

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -464,7 +466,7 @@ internal fun SyncedLyricsView(
                     lineHeight = (fx.fontSizeSp * 1.26f).sp,
                     letterSpacing = fx.letterSpacingSp.sp,
                     fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
-                )
+                ).withLyricFont(rememberLyricFontFamily(fx))
                 val lineModifier = beatModifier
                     .fillMaxWidth()
                     .clickable { onSeekTo(line.timeMs) }
@@ -540,7 +542,7 @@ internal fun KaraokeLyricLine(
                 lineHeight = (fx.fontSizeSp * 1.26f).sp,
                 letterSpacing = fx.letterSpacingSp.sp,
                 fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
-            )
+            ).withLyricFont(rememberLyricFontFamily(fx))
             if (time != null) {
                 val phaseBase = letterBase
                 Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx))) {
@@ -573,6 +575,27 @@ internal fun KaraokeLyricLine(
 }
 
 val LocalLyricsFx = compositionLocalOf { LyricsFxSettings() }
+
+/**
+ * The imported font chosen for the lyrics, or null when the custom-font toggle
+ * is off / the file is missing (callers then keep the app theme typeface). Built
+ * from the same filesDir/custom_fonts store the Appearance settings import into.
+ */
+@Composable
+internal fun rememberLyricFontFamily(fx: LyricsFxSettings): FontFamily? {
+    if (!fx.customFont || fx.customFontPath.isBlank()) return null
+    val path = fx.customFontPath
+    return remember(path) {
+        runCatching {
+            val file = java.io.File(path)
+            if (file.exists()) FontFamily(Font(file)) else null
+        }.getOrNull()
+    }
+}
+
+/** Applies [family] to this style only when non-null, so the theme font stays the default. */
+internal fun TextStyle.withLyricFont(family: FontFamily?): TextStyle =
+    if (family != null) copy(fontFamily = family) else this
 
 // Crisp contact shadow: a tight, dark edge right under the glyph so the
 // letterform reads as solid and sharp. (The previous wide blur — up to ~17px —
@@ -716,7 +739,7 @@ internal fun UnsyncedLyricsView(lines: List<LyricLine>) {
                 style = MaterialTheme.typography.bodyLarge.copy(
                     fontSize = fx.fontSizeSp.sp,
                     lineHeight = (fx.fontSizeSp * 1.26f).sp,
-                ),
+                ).withLyricFont(rememberLyricFontFamily(fx)),
                 color = Color.White.copy(alpha = 0.85f),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -449,6 +449,22 @@ internal fun SyncedLyricsView(
         // clip edge, so edge letters never get corner-cut against the border.
         val sideInset = fx.edgeMarginDp.dp + LYRIC_BEVEL_SAFE_DP
         val lineWidth = (maxWidth - sideInset * 2).coerceAtLeast(0.dp)
+        // Headroom for the active line's bass bounce. The line pumps + pops via a
+        // graphicsLayer scale (bassBeat), but it lives inside the lyric surface's
+        // glass render-layer, which only captures `lineWidth` — so a long line
+        // swelling past that would be clipped. Fit width-constrained lines to a
+        // slightly narrower box that reserves the PEAK bounce scale, so at full
+        // pump they just reach the edge and can never be cut. (The bass pulse
+        // caps at ~1.6 in rememberBassPulse; pop-in adds a small overshoot.)
+        // Short lines aren't width-constrained, so the fitter leaves them as-is.
+        val bounceHeadroom = if (fx.bassReact > 0.01f) {
+            val pumpPeak = 1f + fx.pumpAmount * fx.bassReact * 1.6f
+            val popPeak = 1f + fx.popAmount * 0.25f
+            (pumpPeak * popPeak).coerceIn(1f, 2f)
+        } else {
+            1f
+        }
+        val fitWidth = lineWidth / bounceHeadroom
 
         // Keyed on maxHeight as well so the active line is re-centred while
         // the surface is being resized (the expand/collapse morph animates
@@ -518,7 +534,7 @@ internal fun SyncedLyricsView(
             // height never moves with the fitted size — the list never reflows.
             val fittedSp = rememberFittedLyricSizeSp(
                 text = line.text.ifBlank { "♪" },
-                availableWidth = lineWidth,
+                availableWidth = fitWidth,
                 baseSp = fx.fontSizeSp,
                 style = MaterialTheme.typography.titleMedium.copy(
                     letterSpacing = fx.letterSpacingSp.sp,

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
@@ -528,7 +529,7 @@ internal fun KaraokeLyricLine(
             )
             if (time != null) {
                 val phaseBase = letterBase
-                Row {
+                Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx))) {
                     display.forEachIndexed { j, ch ->
                         val idx = phaseBase + j
                         Letter3DText(
@@ -570,6 +571,23 @@ private fun letter3DShadow(depth: Float) = Shadow(
 )
 
 /**
+ * Horizontal breathing room laid out between adjacent per-letter 3D glyphs so
+ * they can never bleed into one another. Each [Letter3DText] swells toward the
+ * viewer (up to ~9% of its size per unit of ripple intensity) and stamps an
+ * extruded backing a couple of pixels to the right — both inside its own
+ * transform layer. CJK glyphs fill their advance box with no side bearing, so
+ * without a gap that peak swell plus the backing pushed neighbouring characters
+ * on top of each other. The gap is exactly the peak horizontal overflow, so at
+ * rest the line stays tight and at full swing the letters just kiss.
+ */
+private fun letterGapDp(fx: LyricsFxSettings): Dp {
+    val intensity = (fx.rotationDegrees / 9f).coerceAtMost(2.5f)
+    // fontSize * peakSwell = total width the glyph gains at the toward-viewer
+    // peak; +1.5dp covers the extruded backing (offset 1.2dp, scaled by depth).
+    return (fx.fontSizeSp * 0.09f * intensity + 1.5f).dp
+}
+
+/**
  * Active-line treatment: each character is its own Text inside a per-letter
  * 3D transform — a ripple of rotation travelling along the line — with a
  * baked-in drop shadow for depth. Word-wise FlowRow keeps wrapping at word
@@ -595,7 +613,7 @@ internal fun Letters3DLine(
         words.forEachIndexed { index, word ->
             val display = if (index < words.lastIndex) "$word " else word
             val phaseBase = letterBase
-            Row {
+            Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx))) {
                 display.forEachIndexed { j, ch ->
                     val idx = phaseBase + j
                     Letter3DText(

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -45,13 +43,17 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSp
 import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
@@ -68,7 +70,6 @@ import kotlin.math.sin
  * for `NowPlayingScreenKt.NowPlayingScreen` no longer has to inline the
  * synced/karaoke rendering paths.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun LyricsHeroPanel(
     lyrics: Lyrics?,
@@ -419,13 +420,20 @@ internal fun SyncedLyricsView(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 28.dp)
+                // No side margin: the hero is now the full screen width, and each
+                // line is fitted to one row (with built-in slack), so lines reach
+                // the phone's edges instead of being boxed into the padded slot.
                 .fxaa()
                 .liquidGlass(tint = accent),
             contentPadding = PaddingValues(top = halfViewport, bottom = halfViewport),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             itemsIndexed(lines) { index, line ->
+            // Each line gets ONE row: the font is fitted to the available width so
+            // a long line reaches toward the screen edges (shrinking if it must)
+            // instead of wrapping or being cut off inside the compact player.
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            val availWidth = maxWidth
             val isActive = index == currentLineIndex
             val isPast = index < currentLineIndex
             // Bass FX rides only the active line: the line pumps + pops
@@ -440,6 +448,19 @@ internal fun SyncedLyricsView(
             // Line index scopes glyph keys so an advancing active line's glyphs
             // never collide with the outgoing one's during the transition.
             val glyphKeyBase = index * 4096
+            val lyricFont = rememberLyricFontFamily(fx)
+            val weight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium
+            // One-row fit. lineHeight stays pinned to the BASE size so the row
+            // height never moves with the fitted size — the list never reflows.
+            val fittedSp = rememberFittedLyricSizeSp(
+                text = line.text.ifBlank { "♪" },
+                availableWidth = availWidth,
+                baseSp = fx.fontSizeSp,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    letterSpacing = fx.letterSpacingSp.sp,
+                    fontWeight = weight,
+                ).withLyricFont(lyricFont),
+            )
             if (line.words.isNotEmpty()) {
                 // Only sources with real per-word timing (TIDAL enhanced LRC)
                 // illuminate word-by-word.
@@ -454,6 +475,7 @@ internal fun SyncedLyricsView(
                     beatModifier = beatModifier,
                     anchors = lineAnchors,
                     glyphKeyBase = glyphKeyBase,
+                    fontSizeSp = fittedSp,
                 )
             } else {
                 // Line-level sources (LRCLib / Qobuz): illuminate the whole
@@ -469,17 +491,12 @@ internal fun SyncedLyricsView(
                     },
                     label = "lyricColor",
                 )
-                // Fixed size: the active line is marked by colour/weight only.
-                // A size change reflows the list and shifts every line below,
-                // which makes the lyrics impossible to track while reading.
-                // Tracking is identical for active/inactive for the same
-                // reason — only weight may differ between the two states.
                 val lineStyle = MaterialTheme.typography.titleMedium.copy(
-                    fontSize = fx.fontSizeSp.sp,
+                    fontSize = fittedSp.sp,
                     lineHeight = (fx.fontSizeSp * 1.26f).sp,
                     letterSpacing = fx.letterSpacingSp.sp,
-                    fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
-                ).withLyricFont(rememberLyricFontFamily(fx))
+                    fontWeight = weight,
+                ).withLyricFont(lyricFont)
                 val lineModifier = beatModifier
                     .fillMaxWidth()
                     .clickable { onSeekTo(line.timeMs) }
@@ -503,16 +520,19 @@ internal fun SyncedLyricsView(
                         style = lineStyle,
                         color = color,
                         textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Clip,
                         modifier = lineModifier,
                     )
                 }
+            }
             }
         }
         }
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun KaraokeLyricLine(
     line: LyricLine,
@@ -524,6 +544,7 @@ internal fun KaraokeLyricLine(
     beatModifier: Modifier = Modifier,
     anchors: LyricGlyphAnchors? = null,
     glyphKeyBase: Int = 0,
+    fontSizeSp: Float = 23f,
 ) {
     // Render letters individually while active whenever the 3D wave OR the god
     // rays are on (rays need per-glyph positions). One frame clock per line.
@@ -531,7 +552,9 @@ internal fun KaraokeLyricLine(
     val perLetter = isActive &&
         (fx.rotationDegrees > 0.05f || (fx.bassReact > 0.01f && fx.rayCount > 0))
     val time = if (perLetter) rememberFrameSeconds() else null
-    FlowRow(
+    // Single row (no wrap): the whole line stays on one line, fitted to width by
+    // the caller. Overflow (a very long line) simply runs toward the screen edge.
+    Row(
         modifier = beatModifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
@@ -551,14 +574,14 @@ internal fun KaraokeLyricLine(
             val color by animateColorAsState(targetValue = target, label = "wordColor")
             val display = word.text + " "
             val wordStyle = MaterialTheme.typography.titleMedium.copy(
-                fontSize = fx.fontSizeSp.sp,
+                fontSize = fontSizeSp.sp,
                 lineHeight = (fx.fontSizeSp * 1.26f).sp,
                 letterSpacing = fx.letterSpacingSp.sp,
                 fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
             ).withLyricFont(rememberLyricFontFamily(fx))
             if (time != null) {
                 val phaseBase = letterBase
-                Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx))) {
+                Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx, fontSizeSp))) {
                     display.forEachIndexed { j, ch ->
                         val idx = phaseBase + j
                         Letter3DText(
@@ -617,6 +640,42 @@ internal fun rememberLyricFontFamily(fx: LyricsFxSettings): FontFamily? {
 internal fun TextStyle.withLyricFont(family: FontFamily?): TextStyle =
     if (family != null) copy(fontFamily = family) else this
 
+/** Smallest lyric font we'll shrink to before a line is simply allowed to run wide. */
+private const val MIN_LYRIC_SP = 11f
+
+/**
+ * The largest font size (≤ [baseSp], down to [MIN_LYRIC_SP]) at which [text]
+ * still fits on ONE line within [availableWidth] — so every lyric line renders
+ * on a single row and reaches toward the screen edges without being cut, instead
+ * of wrapping inside the compact player. Text width scales ~linearly with size,
+ * so one measurement at the base size is enough to scale down. The slack factor
+ * leaves room for the per-letter 3D swell and inter-letter gaps so the
+ * single-row 3D path fits too.
+ */
+@Composable
+internal fun rememberFittedLyricSizeSp(
+    text: String,
+    availableWidth: Dp,
+    baseSp: Float,
+    style: TextStyle,
+): Float {
+    val measurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    return remember(text, availableWidth, baseSp, style.fontWeight, style.letterSpacing, style.fontFamily) {
+        if (text.isBlank()) return@remember baseSp
+        val maxPx = with(density) { availableWidth.toPx() } * 0.94f
+        if (maxPx <= 0f) return@remember baseSp
+        val measured = measurer.measure(
+            text = text,
+            style = style.copy(fontSize = baseSp.sp),
+            maxLines = 1,
+            softWrap = false,
+        ).size.width.toFloat()
+        if (measured <= maxPx) baseSp
+        else (baseSp * (maxPx / measured)).coerceIn(MIN_LYRIC_SP, baseSp)
+    }
+}
+
 // Crisp contact shadow: a tight, dark edge right under the glyph so the
 // letterform reads as solid and sharp. (The previous wide blur — up to ~17px —
 // hazed the glyph edges and made the whole line look soft; block depth now
@@ -637,21 +696,21 @@ private fun letter3DShadow(depth: Float) = Shadow(
  * on top of each other. The gap is exactly the peak horizontal overflow, so at
  * rest the line stays tight and at full swing the letters just kiss.
  */
-private fun letterGapDp(fx: LyricsFxSettings): Dp {
+private fun letterGapDp(fx: LyricsFxSettings, fontSizeSp: Float = fx.fontSizeSp): Dp {
     val intensity = (fx.rotationDegrees / 9f).coerceAtMost(2.5f)
     // fontSize * peakSwell = total width the glyph gains at the toward-viewer
     // peak; +1.5dp covers the extruded backing (offset 1.2dp, scaled by depth).
-    return (fx.fontSizeSp * 0.09f * intensity + 1.5f).dp
+    // Sized off the ACTUAL (fitted) glyph size so a shrunk line's gaps shrink too.
+    return (fontSizeSp * 0.09f * intensity + 1.5f).dp
 }
 
 /**
  * Active-line treatment: each character is its own Text inside a per-letter
  * 3D transform — a ripple of rotation travelling along the line — with a
- * baked-in drop shadow for depth. Word-wise FlowRow keeps wrapping at word
- * boundaries like the plain Text it replaces, and the transforms are
+ * baked-in drop shadow for depth. The whole line stays on ONE row (no wrap);
+ * the caller fits [style]'s font size to the width. The transforms are
  * draw-only: layout, font size and spacing never change.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun Letters3DLine(
     text: String,
@@ -664,13 +723,14 @@ internal fun Letters3DLine(
     val fx = LocalLyricsFx.current
     val time = rememberFrameSeconds()
     val shadowed = style.copy(shadow = letter3DShadow(fx.shadowDepth))
-    FlowRow(modifier = modifier, horizontalArrangement = Arrangement.Center) {
+    val sizeSp = style.fontSize.takeIf { it.isSp }?.value ?: fx.fontSizeSp
+    Row(modifier = modifier, horizontalArrangement = Arrangement.Center) {
         var letterBase = 0
         val words = text.split(" ")
         words.forEachIndexed { index, word ->
             val display = if (index < words.lastIndex) "$word " else word
             val phaseBase = letterBase
-            Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx))) {
+            Row(horizontalArrangement = Arrangement.spacedBy(letterGapDp(fx, sizeSp))) {
                 display.forEachIndexed { j, ch ->
                     val idx = phaseBase + j
                     Letter3DText(

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsHero.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -385,9 +387,9 @@ internal fun SyncedLyricsView(
         // Half-height padding top and bottom lets any line — including the
         // first and last — settle at the exact vertical centre.
         val halfViewport = maxHeight / 2
-        // The line width is the same for every item (no per-item horizontal
-        // padding), so read it once here instead of a BoxWithConstraints per line.
-        val lineWidth = maxWidth
+        // The line width is the same for every item, so read it once here (minus
+        // the user's edge margin) instead of a BoxWithConstraints per line.
+        val lineWidth = (maxWidth - fx.edgeMarginDp.dp * 2).coerceAtLeast(0.dp)
 
         // Keyed on maxHeight as well so the active line is re-centred while
         // the surface is being resized (the expand/collapse morph animates
@@ -424,9 +426,9 @@ internal fun SyncedLyricsView(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                // No side margin: the hero is now the full screen width, and each
-                // line is fitted to one row (with built-in slack), so lines reach
-                // the phone's edges instead of being boxed into the padded slot.
+                // Side margin between the lyrics and the edges (user setting; 0 by
+                // default so the hero uses the full screen width).
+                .padding(horizontal = fx.edgeMarginDp.dp)
                 .fxaa()
                 .liquidGlass(tint = accent),
             contentPadding = PaddingValues(top = halfViewport, bottom = halfViewport),
@@ -462,6 +464,7 @@ internal fun SyncedLyricsView(
                     letterSpacing = fx.letterSpacingSp.sp,
                     fontWeight = weight,
                 ).withLyricFont(lyricFont),
+                maxRows = fx.maxWrapLines,
             )
             if (line.words.isNotEmpty()) {
                 // Only sources with real per-word timing (TIDAL enhanced LRC)
@@ -523,8 +526,8 @@ internal fun SyncedLyricsView(
                         style = lineStyle,
                         color = color,
                         textAlign = TextAlign.Center,
-                        maxLines = 1,
-                        softWrap = false,
+                        maxLines = fx.maxWrapLines,
+                        softWrap = fx.maxWrapLines > 1,
                         overflow = TextOverflow.Clip,
                         modifier = lineModifier,
                     )
@@ -535,6 +538,7 @@ internal fun SyncedLyricsView(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun KaraokeLyricLine(
     line: LyricLine,
@@ -563,15 +567,12 @@ internal fun KaraokeLyricLine(
         letterSpacing = fx.letterSpacingSp.sp,
         fontWeight = if (isActive) FontWeight.ExtraBold else FontWeight.Medium,
     ).withLyricFont(lyricFont)
-    // Single row (no wrap): the whole line stays on one line, fitted to width by
-    // the caller. Overflow (a very long line) simply runs toward the screen edge.
-    Row(
-        modifier = beatModifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.Center,
-    ) {
+    // One row when maxWrapLines == 1, else a FlowRow that wraps between words.
+    val lineModifier = beatModifier
+        .fillMaxWidth()
+        .clickable(onClick = onClick)
+        .padding(vertical = 2.dp)
+    val content: @Composable () -> Unit = {
         var letterBase = 0
         line.words.forEach { word ->
             // Solid fills: the liquidGlass() shader turns the active line into
@@ -612,6 +613,11 @@ internal fun KaraokeLyricLine(
             }
             letterBase += display.length
         }
+    }
+    if (fx.maxWrapLines > 1) {
+        FlowRow(modifier = lineModifier, horizontalArrangement = Arrangement.Center) { content() }
+    } else {
+        Row(modifier = lineModifier, horizontalArrangement = Arrangement.Center) { content() }
     }
 }
 
@@ -663,21 +669,25 @@ internal fun rememberFittedLyricSizeSp(
     availableWidth: Dp,
     baseSp: Float,
     style: TextStyle,
+    maxRows: Int = 1,
 ): Float {
     val measurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    return remember(text, availableWidth, baseSp, style.fontWeight, style.letterSpacing, style.fontFamily) {
+    return remember(text, availableWidth, baseSp, maxRows, style.fontWeight, style.letterSpacing, style.fontFamily) {
         if (text.isBlank()) return@remember baseSp
-        val maxPx = with(density) { availableWidth.toPx() } * 0.94f
-        if (maxPx <= 0f) return@remember baseSp
+        // Capacity is the total horizontal run the text may occupy across maxRows
+        // rows; if it exceeds that at the base size, shrink to fit (so a line wraps
+        // up to maxRows rows, then shrinks rather than wrapping further or clipping).
+        val capacity = with(density) { availableWidth.toPx() } * maxRows.coerceAtLeast(1) * 0.94f
+        if (capacity <= 0f) return@remember baseSp
         val measured = measurer.measure(
             text = text,
             style = style.copy(fontSize = baseSp.sp),
             maxLines = 1,
             softWrap = false,
         ).size.width.toFloat()
-        if (measured <= maxPx) baseSp
-        else (baseSp * (maxPx / measured)).coerceIn(MIN_LYRIC_SP, baseSp)
+        if (measured <= capacity) baseSp
+        else (baseSp * (capacity / measured)).coerceIn(MIN_LYRIC_SP, baseSp)
     }
 }
 
@@ -716,6 +726,7 @@ private fun letterGapDp(fx: LyricsFxSettings, fontSizeSp: Float = fx.fontSizeSp)
  * the caller fits [style]'s font size to the width. The transforms are
  * draw-only: layout, font size and spacing never change.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun Letters3DLine(
     text: String,
@@ -731,9 +742,12 @@ internal fun Letters3DLine(
     val fx = LocalLyricsFx.current
     val time = rememberFrameSeconds()
     val shadowed = style.copy(shadow = letter3DShadow(fx.shadowDepth))
-    Row(modifier = modifier, horizontalArrangement = Arrangement.Center) {
+    // Word-wise: each word's letters stay together in a Row; the outer container
+    // holds the words. A single row when maxWrapLines == 1, else a FlowRow that
+    // wraps between words up to that many rows (the fit sizes it to that budget).
+    val words = remember(text) { text.split(" ") }
+    val content: @Composable () -> Unit = {
         var letterBase = 0
-        val words = text.split(" ")
         words.forEachIndexed { index, word ->
             val display = if (index < words.lastIndex) "$word " else word
             val phaseBase = letterBase
@@ -753,6 +767,11 @@ internal fun Letters3DLine(
             }
             letterBase += display.length
         }
+    }
+    if (fx.maxWrapLines > 1) {
+        FlowRow(modifier = modifier, horizontalArrangement = Arrangement.Center) { content() }
+    } else {
+        Row(modifier = modifier, horizontalArrangement = Arrangement.Center) { content() }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
@@ -115,6 +115,7 @@ private fun SyncedLyrics(
     // than the reported position over Bluetooth, so rewind the clock we match
     // lyrics against to keep them in step with what's heard.
     val syncDelayMs = LocalLyricsFx.current.bluetoothDelayMs.toLong()
+    val lyricFont = rememberLyricFontFamily(LocalLyricsFx.current)
     val listState = rememberLazyListState()
     var currentLineIndex by remember { mutableIntStateOf(-1) }
 
@@ -171,7 +172,7 @@ private fun SyncedLyrics(
                         fontSize = 23.sp,
                         lineHeight = 29.sp,
                         fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
-                    ),
+                    ).withLyricFont(lyricFont),
                     color = textColor,
                     textAlign = TextAlign.Center,
                     modifier = Modifier
@@ -192,6 +193,7 @@ private fun KaraokeLine(
     position: Long,
     onClick: () -> Unit
 ) {
+    val lyricFont = rememberLyricFontFamily(LocalLyricsFx.current)
     FlowRow(
         modifier = Modifier
             .fillMaxWidth()
@@ -220,7 +222,7 @@ private fun KaraokeLine(
                     fontSize = 23.sp,
                     lineHeight = 29.sp,
                     fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
-                ),
+                ).withLyricFont(lyricFont),
                 color = color
             )
         }
@@ -229,6 +231,7 @@ private fun KaraokeLine(
 
 @Composable
 private fun UnsyncedLyrics(lines: List<LyricLine>) {
+    val lyricFont = rememberLyricFontFamily(LocalLyricsFx.current)
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -238,7 +241,8 @@ private fun UnsyncedLyrics(lines: List<LyricLine>) {
         itemsIndexed(lines) { _, line ->
             Text(
                 text = line.text.ifBlank { "" },
-                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 23.sp, lineHeight = 29.sp),
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 23.sp, lineHeight = 29.sp)
+                    .withLyricFont(lyricFont),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
                 modifier = Modifier

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
@@ -141,6 +141,7 @@ private fun SyncedLyrics(
         state = listState,
         modifier = Modifier
             .fillMaxSize()
+            .fxaa()
             .liquidGlass(),
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
@@ -235,6 +236,7 @@ private fun UnsyncedLyrics(lines: List<LyricLine>) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
+            .fxaa()
             .liquidGlass(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
@@ -111,12 +111,16 @@ private fun SyncedLyrics(
     onSeekTo: (Long) -> Unit
 ) {
     val position by positionMs.collectAsState()
+    // Bluetooth sync delay (tunable in the Lyrics FX Studio): audio lands later
+    // than the reported position over Bluetooth, so rewind the clock we match
+    // lyrics against to keep them in step with what's heard.
+    val syncDelayMs = LocalLyricsFx.current.bluetoothDelayMs.toLong()
     val listState = rememberLazyListState()
     var currentLineIndex by remember { mutableIntStateOf(-1) }
 
-    // Find current line based on playback position
-    LaunchedEffect(position) {
-        val newIndex = lines.indexOfLast { it.timeMs <= position }
+    // Find current line based on the Bluetooth-adjusted playback position.
+    LaunchedEffect(position, syncDelayMs) {
+        val newIndex = lines.indexOfLast { it.timeMs <= position - syncDelayMs }
         if (newIndex != currentLineIndex && newIndex >= 0) {
             currentLineIndex = newIndex
         }
@@ -146,7 +150,7 @@ private fun SyncedLyrics(
                 KaraokeLine(
                     line = line,
                     isActive = isActive,
-                    position = position,
+                    position = position - syncDelayMs,
                     onClick = { onSeekTo(line.timeMs) }
                 )
             } else {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -34,6 +36,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -44,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -340,81 +344,97 @@ fun MainPlayerRoute(
                 )
             },
             hero = { heroModifier ->
-                // Lyrics mode dissolves the album art (or visualizer) and brings the
-                // lyric surface in, sized to exactly the same album slot. Everything
-                // else (square / circular / visualizer) is handled by PlayerHero.
-                androidx.compose.animation.Crossfade(
-                    targetState = viewMode == NowPlayingViewMode.LYRICS,
-                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 500),
-                    label = "lyricsHeroCrossfade",
-                    modifier = heroModifier,
-                ) { lyricsMode ->
-                if (lyricsMode) {
-                    // Fx/spectrum/beat locals are provided once around the
-                    // whole player (see the route-level provider).
-                    LyricsHeroBox(
-                        lyrics = lyrics,
-                        isLoading = isLyricsLoading,
-                        albumColors = albumColors,
-                        positionMs = playerViewModel.positionMs,
-                        // One element, two states: compact taps expand
-                        // (synced lyrics only); expanded line taps seek and
-                        // gap taps collapse.
-                        onSeekTo = { timeMs ->
-                            if (lyricsExpanded) playerViewModel.seekTo(timeMs)
-                            else if (lyricsSynced) lyricsExpanded = true
-                        },
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null,
-                                enabled = lyricsSynced,
-                            ) { lyricsExpanded = !lyricsExpanded },
-                    )
-                } else {
-                val effectiveStyle = if (viewMode == NowPlayingViewMode.VISUALIZER) {
-                    PlayerHeroStyle.Visualizer
-                } else {
-                    heroStyle
-                }
-                PlayerHero(
-                    modifier = Modifier.fillMaxSize(),
-                    style = effectiveStyle,
-                    isFullscreen = isFullscreenActive,
-                    track = currentTrack,
-                    isPlaying = isPlaying,
-                    progress = state.progress,
-                    albumColors = albumColors,
-                    visualizerSensitivity = visualizerSensitivity,
-                    visualizerBrightness = visualizerBrightness,
-                    visualizerEngineStatus = visualizerEngineStatus,
-                    visualizerEngineEnabled = visualizerEngineEnabled,
-                    visualizerShowFps = visualizerShowFps,
-                    visualizerRepository = playerViewModel.visualizerRepository,
-                    visualizerTouchWaveform = visualizerTouchWaveform,
-                    currentVisualizerPreset = currentVisualizerPreset,
-                    visualizerAutoShuffle = visualizerAutoShuffle,
-                    onToggleVisualizerShuffle = playerViewModel::setVisualizerShuffle,
-                    onNextPreset = playerViewModel::nextVisualizerPreset,
-                    onOpenPresetBrowser = { showPresetSheet = true },
-                    isPresetFavorite = currentVisualizerPreset?.id?.let { it in visualizerFavoritePresetIds } ?: false,
-                    onTogglePresetFavorite = {
-                        currentVisualizerPreset?.id?.let { playerViewModel.toggleVisualizerFavoritePreset(it) }
-                    },
-                    visualizerCompact = visualizerCompact,
-                    onToggleCompact = playerViewModel::toggleVisualizerCompact,
-                    onToggleFullscreen = playerViewModel::toggleVisualizerFullscreen,
-                    spectrumBins = spectrumBins,
-                    spectrumColor = spectrumColor,
-                    showSpectrum = showNpSpectrum,
-                    onToggleShowSpectrum = {
-                        playerViewModel.setSpectrumShowOnNowPlaying(!spectrumShowOnNowPlaying)
-                    },
-                    onEnterVisualizer = { playerViewModel.setNowPlayingViewMode(NowPlayingViewMode.VISUALIZER) },
-                    onExitVisualizer = { playerViewModel.setNowPlayingViewMode(NowPlayingViewMode.COVER_ART) },
+                // Manual dissolve between the album art / visualizer and the lyric
+                // surface. The built-in Crossfade snapped here; an explicit alpha
+                // animation is reliable, and it lets the fading art stay a centred
+                // square while the lyrics fill the full-width slot.
+                val lyricsProgress by androidx.compose.animation.core.animateFloatAsState(
+                    targetValue = if (viewMode == NowPlayingViewMode.LYRICS) 1f else 0f,
+                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 450),
+                    label = "lyricsHeroDissolve",
                 )
-                }
+                // Compose each side only while it is at all visible — derivedStateOf
+                // flips at the thresholds, not on every animation frame, so the
+                // (expensive) art/visualizer doesn't recompose mid-dissolve.
+                val showAlbumHero by remember { derivedStateOf { lyricsProgress < 0.999f } }
+                val showLyricsHero by remember { derivedStateOf { lyricsProgress > 0.001f } }
+                Box(modifier = heroModifier, contentAlignment = Alignment.Center) {
+                    if (showAlbumHero) {
+                        val effectiveStyle = if (viewMode == NowPlayingViewMode.VISUALIZER) {
+                            PlayerHeroStyle.Visualizer
+                        } else {
+                            heroStyle
+                        }
+                        // In lyrics mode the slot is full-width, so keep the art a
+                        // centred square while it fades out; otherwise it fills the slot.
+                        val artMod = if (viewMode == NowPlayingViewMode.LYRICS) {
+                            Modifier.fillMaxHeight().aspectRatio(1f)
+                        } else {
+                            Modifier.fillMaxSize()
+                        }
+                        PlayerHero(
+                            modifier = artMod.graphicsLayer { alpha = 1f - lyricsProgress },
+                            style = effectiveStyle,
+                            isFullscreen = isFullscreenActive,
+                            track = currentTrack,
+                            isPlaying = isPlaying,
+                            progress = state.progress,
+                            albumColors = albumColors,
+                            visualizerSensitivity = visualizerSensitivity,
+                            visualizerBrightness = visualizerBrightness,
+                            visualizerEngineStatus = visualizerEngineStatus,
+                            visualizerEngineEnabled = visualizerEngineEnabled,
+                            visualizerShowFps = visualizerShowFps,
+                            visualizerRepository = playerViewModel.visualizerRepository,
+                            visualizerTouchWaveform = visualizerTouchWaveform,
+                            currentVisualizerPreset = currentVisualizerPreset,
+                            visualizerAutoShuffle = visualizerAutoShuffle,
+                            onToggleVisualizerShuffle = playerViewModel::setVisualizerShuffle,
+                            onNextPreset = playerViewModel::nextVisualizerPreset,
+                            onOpenPresetBrowser = { showPresetSheet = true },
+                            isPresetFavorite = currentVisualizerPreset?.id?.let { it in visualizerFavoritePresetIds } ?: false,
+                            onTogglePresetFavorite = {
+                                currentVisualizerPreset?.id?.let { playerViewModel.toggleVisualizerFavoritePreset(it) }
+                            },
+                            visualizerCompact = visualizerCompact,
+                            onToggleCompact = playerViewModel::toggleVisualizerCompact,
+                            onToggleFullscreen = playerViewModel::toggleVisualizerFullscreen,
+                            spectrumBins = spectrumBins,
+                            spectrumColor = spectrumColor,
+                            showSpectrum = showNpSpectrum,
+                            onToggleShowSpectrum = {
+                                playerViewModel.setSpectrumShowOnNowPlaying(!spectrumShowOnNowPlaying)
+                            },
+                            onEnterVisualizer = { playerViewModel.setNowPlayingViewMode(NowPlayingViewMode.VISUALIZER) },
+                            onExitVisualizer = { playerViewModel.setNowPlayingViewMode(NowPlayingViewMode.COVER_ART) },
+                        )
+                    }
+                    if (showLyricsHero) {
+                        // Fx/spectrum/beat locals are provided once around the
+                        // whole player (see the route-level provider). Rendered on
+                        // top of the art so it fades in over it.
+                        LyricsHeroBox(
+                            lyrics = lyrics,
+                            isLoading = isLyricsLoading,
+                            albumColors = albumColors,
+                            positionMs = playerViewModel.positionMs,
+                            // One element, two states: compact taps expand
+                            // (synced lyrics only); expanded line taps seek and
+                            // gap taps collapse.
+                            onSeekTo = { timeMs ->
+                                if (lyricsExpanded) playerViewModel.seekTo(timeMs)
+                                else if (lyricsSynced) lyricsExpanded = true
+                            },
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .graphicsLayer { alpha = lyricsProgress }
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null,
+                                    enabled = lyricsSynced,
+                                ) { lyricsExpanded = !lyricsExpanded },
+                        )
+                    }
                 }
             },
             fxUnderlay = {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -313,9 +313,7 @@ fun MainPlayerRoute(
             },
             onSeekCommit = playerViewModel::seekToFraction,
             onPrevious = playerViewModel::skipToPrevious,
-            onRewind10 = playerViewModel::rewind10,
             onPlayPause = playerViewModel::togglePlayPause,
-            onForward10 = playerViewModel::forward10,
             onNext = playerViewModel::skipToNext,
             onLyrics = {
                 playerViewModel.setNowPlayingViewMode(

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -155,12 +155,16 @@ fun MainPlayerRoute(
 
     val lyricsFx by playerViewModel.lyricsFx.collectAsState()
     val playerDynamicColor by playerViewModel.playerDynamicColor.collectAsState()
+    val dynamicColors by playerViewModel.dynamicColors.collectAsState()
 
     val extractedColors = rememberAlbumColors(currentTrack?.coverUrl)
-    // Player tint follows album art only when the user wants it; otherwise the
-    // theme's primary drives the same pipeline (background, glow, accents).
+    // Player tint follows album art only when BOTH the master "Dynamic Colors"
+    // switch and the player-specific toggle are on — so turning off Dynamic
+    // Colors makes the whole player static (background, glow, accents, rays,
+    // glass), not just the app-wide theme. Otherwise the theme primary drives
+    // the same pipeline.
     val themeAccent = MaterialTheme.colorScheme.primary
-    val albumColors = if (playerDynamicColor) {
+    val albumColors = if (dynamicColors && playerDynamicColor) {
         extractedColors
     } else {
         AlbumColors(dominant = themeAccent, vibrant = themeAccent)

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -384,9 +384,11 @@ fun MainPlayerRoute(
                         }
                         // Keep the art a centred square whenever the slot is the
                         // full-width lyric rectangle (i.e. any time lyrics are on
-                        // screen, including the fade-out); otherwise it fills the slot.
+                        // screen, including the fade-out). Bound it by WIDTH so the
+                        // now-taller lyric slot doesn't stretch the (dissolving) art
+                        // vertically; otherwise it fills the slot.
                         val artMod = if (lyricsSlotWide) {
-                            Modifier.fillMaxHeight().aspectRatio(1f)
+                            Modifier.fillMaxWidth().aspectRatio(1f)
                         } else {
                             Modifier.fillMaxSize()
                         }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -91,6 +91,7 @@ fun MainPlayerRoute(
     val lyrics by playerViewModel.currentLyrics.collectAsState()
     val isLyricsLoading by playerViewModel.isLyricsLoading.collectAsState()
     val viewMode by playerViewModel.nowPlayingViewMode.collectAsState()
+    val blurredBackground by playerViewModel.playerBlurredBackground.collectAsState()
     val playbackSpeed by playerViewModel.playbackSpeed.collectAsState()
     val preservePitch by playerViewModel.preservePitch.collectAsState()
     val compressorEnabled by playerViewModel.compressorEnabled.collectAsState()
@@ -285,6 +286,13 @@ fun MainPlayerRoute(
         LocalLyricsSpectrum provides playerViewModel.spectrumAnalyzer,
         LocalLyricGlyphAnchors provides glyphAnchors.takeIf { lyricsBeatOn },
         LocalBeatPulse provides beatPulse,
+        // Tell the lyric glass what's behind it so it can lens the real album
+        // tones when the blurred album background is on (Apple-OS style).
+        LocalPlayerBackdrop provides PlayerBackdrop(
+            blurredArt = blurredBackground,
+            dominant = albumColors.dominant,
+            secondary = albumColors.vibrant,
+        ),
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
         MainPlayerScreen(
@@ -461,6 +469,7 @@ fun MainPlayerRoute(
             // Slot stays the full-width rectangle for the whole dissolve, not just
             // while viewMode==LYRICS, so leaving lyrics doesn't snap it to square.
             lyricsMode = lyricsSlotWide,
+            blurredBackground = blurredBackground,
         )
     }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -154,6 +154,7 @@ fun MainPlayerRoute(
     LaunchedEffect(isPlaying) { playerViewModel.setVisualizerPlaybackPaused(!isPlaying) }
 
     val lyricsFx by playerViewModel.lyricsFx.collectAsState()
+    val playerGlass by playerViewModel.playerGlass.collectAsState()
     val playerDynamicColor by playerViewModel.playerDynamicColor.collectAsState()
     val dynamicColors by playerViewModel.dynamicColors.collectAsState()
 
@@ -297,6 +298,8 @@ fun MainPlayerRoute(
             dominant = albumColors.dominant,
             secondary = albumColors.vibrant,
         ),
+        // The transport buttons' refractive glass parameters (Studio › Player Glass).
+        LocalPlayerGlass provides playerGlass,
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
         MainPlayerScreen(

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -268,6 +268,18 @@ fun MainPlayerRoute(
         LyricsDebug.log("view mode: ${if (viewMode == NowPlayingViewMode.LYRICS) "LYRICS active" else "lyrics inactive"}")
     }
 
+    // Hero dissolve progress (album/visualizer <-> lyrics), hoisted so the slot
+    // stays full-width for the WHOLE fade — otherwise leaving lyrics snapped the
+    // still-visible lyric surface from full-width back to the square instantly.
+    val lyricsProgress by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = if (viewMode == NowPlayingViewMode.LYRICS) 1f else 0f,
+        animationSpec = androidx.compose.animation.core.tween(durationMillis = 450),
+        label = "lyricsHeroDissolve",
+    )
+    // Slot is the full-width lyric rectangle whenever the lyric surface is at all
+    // visible (dissolving in or out). derivedStateOf flips only at the threshold.
+    val lyricsSlotWide by remember { derivedStateOf { lyricsProgress > 0.001f } }
+
     CompositionLocalProvider(
         LocalLyricsFx provides lyricsFx,
         LocalLyricsSpectrum provides playerViewModel.spectrumAnalyzer,
@@ -345,14 +357,10 @@ fun MainPlayerRoute(
             },
             hero = { heroModifier ->
                 // Manual dissolve between the album art / visualizer and the lyric
-                // surface. The built-in Crossfade snapped here; an explicit alpha
-                // animation is reliable, and it lets the fading art stay a centred
-                // square while the lyrics fill the full-width slot.
-                val lyricsProgress by androidx.compose.animation.core.animateFloatAsState(
-                    targetValue = if (viewMode == NowPlayingViewMode.LYRICS) 1f else 0f,
-                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 450),
-                    label = "lyricsHeroDissolve",
-                )
+                // surface (lyricsProgress is hoisted above). The built-in Crossfade
+                // snapped here; an explicit alpha animation is reliable, and it lets
+                // the fading art stay a centred square while the lyrics fill the
+                // full-width slot.
                 // Compose each side only while it is at all visible — derivedStateOf
                 // flips at the thresholds, not on every animation frame, so the
                 // (expensive) art/visualizer doesn't recompose mid-dissolve.
@@ -365,9 +373,10 @@ fun MainPlayerRoute(
                         } else {
                             heroStyle
                         }
-                        // In lyrics mode the slot is full-width, so keep the art a
-                        // centred square while it fades out; otherwise it fills the slot.
-                        val artMod = if (viewMode == NowPlayingViewMode.LYRICS) {
+                        // Keep the art a centred square whenever the slot is the
+                        // full-width lyric rectangle (i.e. any time lyrics are on
+                        // screen, including the fade-out); otherwise it fills the slot.
+                        val artMod = if (lyricsSlotWide) {
                             Modifier.fillMaxHeight().aspectRatio(1f)
                         } else {
                             Modifier.fillMaxSize()
@@ -448,7 +457,9 @@ fun MainPlayerRoute(
                 }
             },
             lyricsExpanded = lyricsExpanded,
-            lyricsMode = viewMode == NowPlayingViewMode.LYRICS,
+            // Slot stays the full-width rectangle for the whole dissolve, not just
+            // while viewMode==LYRICS, so leaving lyrics doesn't snap it to square.
+            lyricsMode = lyricsSlotWide,
         )
     }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -346,6 +346,7 @@ fun MainPlayerRoute(
                     },
                     onOpenVisualizer = { playerViewModel.setNowPlayingViewMode(NowPlayingViewMode.VISUALIZER) },
                     onOpenEqualizer = { navController.navigate(Screen.Equalizer.route) },
+                    onOpenLyricsStudio = { navController.navigate(Screen.LyricsFxStudio.route) },
                     onOpenSettings = { navController.navigate(Screen.Settings.createRoute()) },
                     onGoToArtist = currentTrack?.artist?.id?.let { artistId ->
                         { navController.navigate(Screen.ArtistDetail.createRoute(artistId)) }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -428,6 +428,7 @@ fun MainPlayerRoute(
                 }
             },
             lyricsExpanded = lyricsExpanded,
+            lyricsMode = viewMode == NowPlayingViewMode.LYRICS,
         )
     }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -253,7 +253,15 @@ fun MainPlayerRoute(
     val beatPulse: androidx.compose.runtime.State<Float>? =
         if (lyricsBeatOn) rememberBassPulse(playerViewModel.spectrumAnalyzer, lyricsFx) else null
     androidx.compose.runtime.LaunchedEffect(lyricsBeatOn) {
+        LyricsDebug.log("beat engine ${if (lyricsBeatOn) "acquired (FFT analyzer staked)" else "released"}")
         if (!lyricsBeatOn) glyphAnchors.reset()
+    }
+    // Log the active lyrics-FX configuration whenever it changes, and when the
+    // lyrics view is entered/left — so the Debug Log shows exactly what the
+    // lyric renderer is running.
+    androidx.compose.runtime.LaunchedEffect(lyricsFx) { LyricsDebug.log(LyricsDebug.summary(lyricsFx)) }
+    androidx.compose.runtime.LaunchedEffect(viewMode == NowPlayingViewMode.LYRICS) {
+        LyricsDebug.log("view mode: ${if (viewMode == NowPlayingViewMode.LYRICS) "LYRICS active" else "lyrics inactive"}")
     }
 
     CompositionLocalProvider(

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -576,7 +576,7 @@ private fun StatusOverlayPanel(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(elevation = 32.dp, shape = shape, clip = false)
-            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f, liquid = true),
+            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f),
         shape = shape,
         color = PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
     ) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -128,9 +128,7 @@ fun MainPlayerScreen(
     onArtistClick: (Long) -> Unit,
     onSeekCommit: (Float) -> Unit,
     onPrevious: () -> Unit,
-    onRewind10: () -> Unit,
     onPlayPause: () -> Unit,
-    onForward10: () -> Unit,
     onNext: () -> Unit,
     onLyrics: () -> Unit,
     onTimer: () -> Unit,
@@ -404,9 +402,7 @@ fun MainPlayerScreen(
                         isPlaying = state.isPlaying,
                         accent = accent,
                         onPrevious = onPrevious,
-                        onRewind10 = onRewind10,
                         onPlayPause = onPlayPause,
-                        onForward10 = onForward10,
                         onNext = onNext,
                     )
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -227,20 +227,31 @@ fun MainPlayerScreen(
                 .background(dynamicPlayerBackground(state.albumColors.dominant)),
         )
         // Full-screen blurred, stretched album art (Apple-Music / Spotify style).
-        // Sits directly over the gradient so the whole player floats over the
-        // artwork; the lyric liquid glass then refracts these album tones.
-        if (blurredBackground) {
+        // Shown whenever the lyrics are on — collapsed OR fullscreen — and only
+        // then (album-art / visualizer views keep the plain gradient). Fades with
+        // the album↔lyrics transition instead of popping.
+        val lyricsOn = lyricsExpanded || lyricsMode
+        val blurBgAlpha by animateFloatAsState(
+            targetValue = if (blurredBackground && lyricsOn) 1f else 0f,
+            animationSpec = androidx.compose.animation.core.tween(durationMillis = 400),
+            label = "blurredBg",
+        )
+        if (blurBgAlpha > 0.001f) {
             PlayerBlurredArtBackground(
                 coverUrl = state.track?.coverUrl,
                 albumColors = state.albumColors,
+                alpha = { blurBgAlpha },
             )
         }
         DynamicAlbumGlow(state.albumColors.dominant)
 
         // Expanded-lyrics backdrop: the artwork as a blurred stain fading in
-        // behind the player content — background only, not a new element.
+        // behind the player content — background only, not a new element. When
+        // the always-on blurred album background is enabled it already covers
+        // this (in every lyrics state), so the stain stands down to avoid
+        // double-darkening.
         val stainAlpha by animateFloatAsState(
-            targetValue = if (lyricsExpanded) 1f else 0f,
+            targetValue = if (lyricsExpanded && !blurredBackground) 1f else 0f,
             animationSpec = androidx.compose.animation.core.tween(durationMillis = 400),
             label = "lyricsStain",
         )

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -152,6 +153,9 @@ fun MainPlayerScreen(
     // full-bleed while the player controls collapse away and the blurred
     // artwork stain fades in behind everything.
     lyricsExpanded: Boolean = false,
+    // Collapsed lyrics render as a full-screen-width rectangle (album height) so
+    // lines can reach the phone's edges; album art stays a padded square.
+    lyricsMode: Boolean = false,
 ) {
     val accent = state.albumColors.vibrant
 
@@ -274,6 +278,9 @@ fun MainPlayerScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 val side = minOf(maxWidth, maxHeight)
+                // Full phone-screen width = the padded slot width plus the side
+                // padding the Column already subtracted.
+                val fullWidth = maxWidth + screenPad * 2
                 val heroW by animateDpAsState(
                     targetValue = if (lyricsExpanded) maxWidth else side,
                     animationSpec = androidx.compose.animation.core.tween(durationMillis = 350),
@@ -284,16 +291,25 @@ fun MainPlayerScreen(
                     animationSpec = androidx.compose.animation.core.tween(durationMillis = 350),
                     label = "heroH",
                 )
+                // Collapsed lyrics: a rectangle the height of the album square but
+                // the FULL screen width (requiredWidth overrides the padded slot's
+                // constraint; the centred Box lets it overflow to both edges), so
+                // lines reach the borders. Album art keeps its padded square.
+                val heroMod = if (lyricsMode && !lyricsExpanded) {
+                    Modifier.requiredWidth(fullWidth).height(heroH)
+                } else {
+                    Modifier.size(heroW, heroH)
+                }
                 // Wrap only the square art (not the full-width slot) so the DevEdit
                 // highlight hugs the album-art ratio instead of a tall rectangle.
                 // The saved DevEdit offset/scale are tuned for the compact square;
-                // applied to the expanded lyric surface they push text past the
-                // screen borders — so expanded renders 1:1, bypassing the override.
-                if (lyricsExpanded) {
-                    hero(Modifier.size(heroW, heroH))
+                // applied to the expanded/full-width lyric surface they push text
+                // past the screen borders — so those render 1:1, bypassing it.
+                if (lyricsExpanded || lyricsMode) {
+                    hero(heroMod)
                 } else {
                     DevEditable("hero", Modifier) {
-                        hero(Modifier.size(heroW, heroH))
+                        hero(heroMod)
                     }
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -156,6 +156,8 @@ fun MainPlayerScreen(
     // Collapsed lyrics render as a full-screen-width rectangle (album height) so
     // lines can reach the phone's edges; album art stays a padded square.
     lyricsMode: Boolean = false,
+    // Full-screen blurred, stretched album-art background (Appearance setting).
+    blurredBackground: Boolean = false,
 ) {
     val accent = state.albumColors.vibrant
 
@@ -224,6 +226,15 @@ fun MainPlayerScreen(
                 .dithered()
                 .background(dynamicPlayerBackground(state.albumColors.dominant)),
         )
+        // Full-screen blurred, stretched album art (Apple-Music / Spotify style).
+        // Sits directly over the gradient so the whole player floats over the
+        // artwork; the lyric liquid glass then refracts these album tones.
+        if (blurredBackground) {
+            PlayerBlurredArtBackground(
+                coverUrl = state.track?.coverUrl,
+                albumColors = state.albumColors,
+            )
+        }
         DynamicAlbumGlow(state.albumColors.dominant)
 
         // Expanded-lyrics backdrop: the artwork as a blurred stain fading in

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -225,12 +225,11 @@ fun MainPlayerScreen(
                 .background(dynamicPlayerBackground(state.albumColors.dominant)),
         )
         // Full-screen blurred, stretched album art (Apple-Music / Spotify style).
-        // Shown whenever the lyrics are on — collapsed OR fullscreen — and only
-        // then (album-art / visualizer views keep the plain gradient). Fades with
-        // the album↔lyrics transition instead of popping.
-        val lyricsOn = lyricsExpanded || lyricsMode
+        // Shown whenever the toggle is on — in EVERY view (album art, visualizer,
+        // and lyrics, collapsed or fullscreen), not just the lyrics views. Fades
+        // in/out instead of popping.
         val blurBgAlpha by animateFloatAsState(
-            targetValue = if (blurredBackground && lyricsOn) 1f else 0f,
+            targetValue = if (blurredBackground) 1f else 0f,
             animationSpec = androidx.compose.animation.core.tween(durationMillis = 400),
             label = "blurredBg",
         )

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -297,15 +297,19 @@ fun MainPlayerScreen(
                     animationSpec = androidx.compose.animation.core.tween(durationMillis = 350),
                     label = "heroW",
                 )
+                // Lyrics get the FULL hero region height (decoupled from the album
+                // square), so the 3D letters, their glass bevels and the per-letter
+                // god rays have vertical room instead of being corner-cut in a short
+                // album-height band. Album art alone stays the compact square.
                 val heroH by animateDpAsState(
-                    targetValue = if (lyricsExpanded) maxHeight else side,
+                    targetValue = if (lyricsExpanded || lyricsMode) maxHeight else side,
                     animationSpec = androidx.compose.animation.core.tween(durationMillis = 350),
                     label = "heroH",
                 )
-                // Collapsed lyrics: a rectangle the height of the album square but
-                // the FULL screen width (requiredWidth overrides the padded slot's
-                // constraint; the centred Box lets it overflow to both edges), so
-                // lines reach the borders. Album art keeps its padded square.
+                // Collapsed lyrics: a full-width rectangle spanning the whole hero
+                // region (requiredWidth overrides the padded slot; the centred Box
+                // lets it overflow to both edges), so lines reach the borders and
+                // have vertical breathing room. Album art keeps its padded square.
                 val heroMod = if (lyricsMode && !lyricsExpanded) {
                     Modifier.requiredWidth(fullWidth).height(heroH)
                 } else {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -576,7 +576,7 @@ private fun StatusOverlayPanel(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(elevation = 32.dp, shape = shape, clip = false)
-            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f),
+            .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f, liquid = true),
         shape = shape,
         color = PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
     ) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -54,6 +54,7 @@ fun PlayerActionDock(
                 shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge),
                 tintAlpha = PlayerDesignTokens.GlassTintMedium,
                 borderAlpha = PlayerDesignTokens.GlassTintSoft,
+                liquid = true,
             )
             .padding(vertical = 6.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -93,12 +93,15 @@ fun PlayerActionDock(
     )
     val bulgeCenter = Offset((bulgeSlot.intValue + 0.5f) / icons.size, 0.42f)
     Box(modifier = modifier.fillMaxWidth()) {
+        // Button glass tint: a custom colour chosen in the Studio, or the album
+        // accent when none is set (tintColor == 0).
+        val g = LocalPlayerGlass.current
+        val glassTint = if (g.tintColor != 0) Color(g.tintColor) else accent
         // Soft rounded-rect drop shadow lifting the whole glass slab off the
         // player, matching the play button + transport icons (Studio-tunable).
-        val g = LocalPlayerGlass.current
         if (g.enabled) {
             GlassDropShadow(
-                color = androidx.compose.ui.graphics.lerp(Color.Black, accent, g.shadowTint)
+                color = androidx.compose.ui.graphics.lerp(Color.Black, glassTint, g.shadowTint)
                     .copy(alpha = 0.26f + 0.5f * g.shadowDepth),
                 softness = g.shadowSoftness,
                 depth = g.shadowDepth,
@@ -111,15 +114,15 @@ fun PlayerActionDock(
         Canvas(
             modifier = Modifier
                 .matchParentSize()
-                .playerGlass(tint = accent, bulgeCenter = bulgeCenter, bulgeAmount = { bulgeAmt })
+                .playerGlass(tint = glassTint, bulgeCenter = bulgeCenter, bulgeAmount = { bulgeAmt })
                 .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
         ) {
             val cornerPx = PlayerDesignTokens.GlassCornerLarge.toPx()
-            // Same solid [accent] fill as the play-button disc, so the slab reads
+            // Same solid glass-tint fill as the play-button disc, so the slab reads
             // as the same coloured glass — the shader's body opacity makes it
             // see-through, matching the transport buttons exactly.
             drawRoundRect(
-                color = accent,
+                color = glassTint,
                 cornerRadius = CornerRadius(cornerPx, cornerPx),
             )
             val iconPx = PlayerDesignTokens.ActionIconSize.toPx()

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -3,15 +3,18 @@ package tf.monochrome.android.ui.player
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
@@ -31,8 +34,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import tf.monochrome.android.ui.components.liquidGlass
-
 /**
  * Compact tool row beneath the transport controls: Lyrics · Timer · Mixer/FX · Playlist.
  * (Monitoring + effect controls live in the pull-up "Audio tools" panel.)
@@ -47,22 +48,29 @@ fun PlayerActionDock(
     onPlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .liquidGlass(
-                shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge),
-                tintAlpha = PlayerDesignTokens.GlassTintMedium,
-                borderAlpha = PlayerDesignTokens.GlassTintSoft,
-                liquid = true,
-            )
-            .padding(vertical = 6.dp),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-    ) {
-        DockAction(Icons.Default.Lyrics, "Lyrics", accent, lyricsActive, onLyrics)
-        DockAction(Icons.Default.Timer, "Timer", accent, false, onTimer)
-        DockAction(Icons.Default.Tune, "Mixer/FX", accent, false, onMixer)
-        DockAction(Icons.AutoMirrored.Filled.QueueMusic, "Playlist", accent, false, onPlaylist)
+    val shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge)
+    Box(modifier = modifier.fillMaxWidth()) {
+        // The SAME refractive lyric glass, on the dock panel — a translucent
+        // fill the shader bevels into a lit, tilt-reactive glass rim. It sits
+        // behind the tool row, so the icons and labels on it stay crisp.
+        Box(
+            Modifier
+                .matchParentSize()
+                .clip(shape)
+                .background(Color.White.copy(alpha = 0.20f))
+                .liquidGlassPanel(tint = accent),
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 6.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            DockAction(Icons.Default.Lyrics, "Lyrics", accent, lyricsActive, onLyrics)
+            DockAction(Icons.Default.Timer, "Timer", accent, false, onTimer)
+            DockAction(Icons.Default.Tune, "Mixer/FX", accent, false, onMixer)
+            DockAction(Icons.AutoMirrored.Filled.QueueMusic, "Playlist", accent, false, onPlaylist)
+        }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -96,17 +95,10 @@ fun PlayerActionDock(
         // accent when none is set (tintColor == 0).
         val g = LocalPlayerGlass.current
         val glassTint = if (g.tintColor != 0) Color(g.tintColor) else accent
-        // Soft rounded-rect drop shadow lifting the whole glass slab off the
-        // player, matching the play button + transport icons (Studio-tunable).
-        if (g.enabled) {
-            GlassDropShadow(
-                color = androidx.compose.ui.graphics.lerp(Color.Black, glassTint, g.shadowTint)
-                    .copy(alpha = 0.26f + 0.5f * g.shadowDepth),
-                softness = g.shadowSoftness,
-                depth = g.shadowDepth,
-                shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge),
-            )
-        }
+        // NOTE: no drop shadow behind the slab — a shadow there would sit BEHIND
+        // the punched icon holes and show through them (making the holes read as
+        // dark shapes instead of true cut-outs). The slab's own beveled rim + the
+        // button/dock-icon depth carry the glass without it.
         // The glass slab with the four icons carved out of it. Drawn in one
         // offscreen layer so the DstOut punch clears only the glyph shapes (not
         // the whole rectangle) and can't clear the player behind the dock.

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -3,7 +3,7 @@ package tf.monochrome.android.ui.player
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -11,12 +11,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,16 +22,35 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
+
+// Vertical paddings shared between the label overlay and the punch geometry, so
+// the hollow icons stay centred over their labels regardless of DPI.
+private val DockRowVerticalPadding = 6.dp
+private val DockItemVerticalPadding = 10.dp
+
 /**
  * Compact tool row beneath the transport controls: Lyrics · Timer · Mixer/FX · Playlist.
- * (Monitoring + effect controls live in the pull-up "Audio tools" panel.)
+ *
+ * The whole rectangle is one liquid-glass slab with the four icons *hollowed out*
+ * of it — exactly like the play button: a solid translucent slab, the icon shapes
+ * punched to transparent (so the backdrop shows through the glyphs), and the
+ * player-glass shader bevels the slab rim and every cut-out edge into refractive
+ * 3D glass. The labels and tap targets sit as a transparent overlay aligned to
+ * the holes. (Monitoring + effect controls live in the pull-up "Audio tools" panel.)
  */
 @Composable
 fun PlayerActionDock(
@@ -45,35 +62,55 @@ fun PlayerActionDock(
     onPlaylist: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge)
+    val icons = listOf(
+        painterResource(R.drawable.ic_glass_lyrics),
+        painterResource(R.drawable.ic_glass_timer),
+        painterResource(R.drawable.ic_glass_mixer),
+        painterResource(R.drawable.ic_glass_playlist),
+    )
     Box(modifier = modifier.fillMaxWidth()) {
-        // The SAME refractive lyric glass, on the dock panel — a translucent
-        // fill the shader bevels into a lit, tilt-reactive glass rim. It sits
-        // behind the tool row, so the icons and labels on it stay crisp.
-        Box(
-            Modifier
-                .matchParentSize()
-                .clip(shape)
-                .background(Color.White.copy(alpha = 0.20f))
-                .liquidGlassPanel(tint = accent),
-        )
-        Row(
+        // The glass slab with the four icons carved out of it. Drawn in one
+        // offscreen layer so the DstOut punch clears only the glyph shapes (not
+        // the whole rectangle) and can't clear the player behind the dock.
+        Canvas(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 6.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+                .matchParentSize()
+                .playerGlass(tint = accent)
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
         ) {
-            DockAction(painterResource(R.drawable.ic_glass_lyrics), "Lyrics", accent, lyricsActive, onLyrics)
-            DockAction(painterResource(R.drawable.ic_glass_timer), "Timer", accent, false, onTimer)
-            DockAction(painterResource(R.drawable.ic_glass_mixer), "Mixer/FX", accent, false, onMixer)
-            DockAction(painterResource(R.drawable.ic_glass_playlist), "Playlist", accent, false, onPlaylist)
+            val cornerPx = PlayerDesignTokens.GlassCornerLarge.toPx()
+            drawRoundRect(
+                color = Color.White.copy(alpha = 0.20f),
+                cornerRadius = CornerRadius(cornerPx, cornerPx),
+            )
+            val iconPx = PlayerDesignTokens.ActionIconSize.toPx()
+            val cy = (DockRowVerticalPadding + DockItemVerticalPadding).toPx() + iconPx / 2f
+            // DstOut: dest * (1 - src.alpha) → the opaque icon pixels erase the
+            // slab, leaving an icon-shaped hole; everything else is untouched.
+            val punch = Paint().apply { blendMode = BlendMode.DstOut }
+            val canvas = drawContext.canvas
+            canvas.saveLayer(Rect(0f, 0f, size.width, size.height), punch)
+            icons.forEachIndexed { i, painter ->
+                val cx = size.width * (i + 0.5f) / icons.size
+                translate(cx - iconPx / 2f, cy - iconPx / 2f) {
+                    with(painter) { draw(Size(iconPx, iconPx)) }
+                }
+            }
+            canvas.restore()
+        }
+        // Transparent overlay: labels + tap targets, one weighted slot per hole.
+        Row(modifier = Modifier.fillMaxWidth().padding(vertical = DockRowVerticalPadding)) {
+            DockLabel(Modifier.weight(1f), "Lyrics", accent, lyricsActive, onLyrics)
+            DockLabel(Modifier.weight(1f), "Timer", accent, false, onTimer)
+            DockLabel(Modifier.weight(1f), "Mixer/FX", accent, false, onMixer)
+            DockLabel(Modifier.weight(1f), "Playlist", accent, false, onPlaylist)
         }
     }
 }
 
 @Composable
-private fun DockAction(
-    icon: Painter,
+private fun DockLabel(
+    modifier: Modifier,
     label: String,
     accent: Color,
     selected: Boolean,
@@ -84,27 +121,20 @@ private fun DockAction(
     val scale by animateFloatAsState(
         targetValue = if (isPressed) 0.92f else 1f,
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-        label = "dockActionScale",
+        label = "dockLabelScale",
     )
-    val iconTint = accent
     val labelTint = if (selected) accent else Color.White.copy(alpha = 0.7f)
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .graphicsLayer { scaleX = scale; scaleY = scale }
             .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
-            .padding(horizontal = 10.dp, vertical = 10.dp),
+            .padding(vertical = DockItemVerticalPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        Icon(
-            painter = icon,
-            contentDescription = label,
-            modifier = Modifier
-                .size(PlayerDesignTokens.ActionIconSize)
-                .playerGlass(tint = iconTint),
-            tint = iconTint,
-        )
+        // Reserves the slot where the glass slab carries the hollow icon above.
+        Spacer(Modifier.size(PlayerDesignTokens.ActionIconSize))
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,8 +16,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,7 +35,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
 
@@ -91,7 +87,7 @@ fun PlayerActionDock(
         },
         label = "dockBulge",
     )
-    val bulgeCenter = Offset((bulgeSlot.intValue + 0.5f) / icons.size, 0.42f)
+    val bulgeCenter = Offset((bulgeSlot.intValue + 0.5f) / icons.size, 0.5f)
     Box(modifier = modifier.fillMaxWidth()) {
         // Button glass tint: a custom colour chosen in the Studio, or the album
         // accent when none is set (tintColor == 0).
@@ -125,7 +121,7 @@ fun PlayerActionDock(
                 color = glassTint,
                 cornerRadius = CornerRadius(cornerPx, cornerPx),
             )
-            val iconPx = PlayerDesignTokens.ActionIconSize.toPx()
+            val iconPx = PlayerDesignTokens.DockIconSize.toPx()
             val cy = (DockRowVerticalPadding + DockItemVerticalPadding).toPx() + iconPx / 2f
             // DstOut: dest * (1 - src.alpha) → the opaque icon pixels erase the
             // slab, leaving an icon-shaped hole; everything else is untouched.
@@ -142,10 +138,10 @@ fun PlayerActionDock(
         }
         // Transparent overlay: labels + tap targets, one weighted slot per hole.
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = DockRowVerticalPadding)) {
-            DockLabel(Modifier.weight(1f), "Lyrics", accent, lyricsActive, sources[0], onLyrics)
-            DockLabel(Modifier.weight(1f), "Timer", accent, false, sources[1], onTimer)
-            DockLabel(Modifier.weight(1f), "Mixer/FX", accent, false, sources[2], onMixer)
-            DockLabel(Modifier.weight(1f), "Playlist", accent, false, sources[3], onPlaylist)
+            DockLabel(Modifier.weight(1f), "Lyrics", sources[0], onLyrics)
+            DockLabel(Modifier.weight(1f), "Timer", sources[1], onTimer)
+            DockLabel(Modifier.weight(1f), "Mixer/FX", sources[2], onMixer)
+            DockLabel(Modifier.weight(1f), "Playlist", sources[3], onPlaylist)
         }
     }
 }
@@ -154,8 +150,6 @@ fun PlayerActionDock(
 private fun DockLabel(
     modifier: Modifier,
     label: String,
-    accent: Color,
-    selected: Boolean,
     interactionSource: MutableInteractionSource,
     onClick: () -> Unit,
 ) {
@@ -165,24 +159,22 @@ private fun DockLabel(
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
         label = "dockLabelScale",
     )
-    val labelTint = if (selected) accent else Color.White.copy(alpha = 0.7f)
 
+    // No text label: the tap target is the whole slot, and the (bigger) hollow
+    // icon carved into the glass slab above fills the space the label used to take.
     Column(
         modifier = modifier
             .graphicsLayer { scaleX = scale; scaleY = scale }
-            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClickLabel = label,
+                onClick = onClick,
+            )
             .padding(vertical = DockItemVerticalPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // Reserves the slot where the glass slab carries the hollow icon above.
-        Spacer(Modifier.size(PlayerDesignTokens.ActionIconSize))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = labelTint,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        // Reserves the slot the glass slab's hollow icon is punched into.
+        Spacer(Modifier.size(PlayerDesignTokens.DockIconSize))
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -23,6 +24,8 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -138,10 +141,10 @@ fun PlayerActionDock(
         }
         // Transparent overlay: labels + tap targets, one weighted slot per hole.
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = DockRowVerticalPadding)) {
-            DockLabel(Modifier.weight(1f), "Lyrics", sources[0], onLyrics)
-            DockLabel(Modifier.weight(1f), "Timer", sources[1], onTimer)
-            DockLabel(Modifier.weight(1f), "Mixer/FX", sources[2], onMixer)
-            DockLabel(Modifier.weight(1f), "Playlist", sources[3], onPlaylist)
+            DockLabel(Modifier.weight(1f), "Lyrics", icons[0], glassTint, lyricsActive, sources[0], onLyrics)
+            DockLabel(Modifier.weight(1f), "Timer", icons[1], glassTint, false, sources[1], onTimer)
+            DockLabel(Modifier.weight(1f), "Mixer/FX", icons[2], glassTint, false, sources[2], onMixer)
+            DockLabel(Modifier.weight(1f), "Playlist", icons[3], glassTint, false, sources[3], onPlaylist)
         }
     }
 }
@@ -150,6 +153,9 @@ fun PlayerActionDock(
 private fun DockLabel(
     modifier: Modifier,
     label: String,
+    painter: Painter,
+    litColor: Color,
+    active: Boolean,
     interactionSource: MutableInteractionSource,
     onClick: () -> Unit,
 ) {
@@ -159,9 +165,17 @@ private fun DockLabel(
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
         label = "dockLabelScale",
     )
+    // Fade the "lit" glyph in/out so toggling active glows on smoothly.
+    val lit by animateFloatAsState(
+        targetValue = if (active) 1f else 0f,
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "dockLit",
+    )
 
     // No text label: the tap target is the whole slot, and the (bigger) hollow
     // icon carved into the glass slab above fills the space the label used to take.
+    // When active, a bright glyph + soft glow lights up over the hole — the way
+    // the Lyrics label used to light up when lyrics were on.
     Column(
         modifier = modifier
             .graphicsLayer { scaleX = scale; scaleY = scale }
@@ -174,7 +188,30 @@ private fun DockLabel(
             .padding(vertical = DockItemVerticalPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Reserves the slot the glass slab's hollow icon is punched into.
-        Spacer(Modifier.size(PlayerDesignTokens.DockIconSize))
+        Box(contentAlignment = Alignment.Center) {
+            // Reserves the slot the glass slab's hollow icon is punched into.
+            Spacer(Modifier.size(PlayerDesignTokens.DockIconSize))
+            if (lit > 0.004f) {
+                // Soft bloom behind the lit glyph.
+                Icon(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(PlayerDesignTokens.DockIconSize)
+                        .graphicsLayer { alpha = lit }
+                        .blur(radius = 11.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
+                    tint = litColor.copy(alpha = 0.6f),
+                )
+                // Crisp lit glyph filling the hole.
+                Icon(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(PlayerDesignTokens.DockIconSize)
+                        .graphicsLayer { alpha = lit },
+                    tint = litColor,
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -69,6 +70,18 @@ fun PlayerActionDock(
         painterResource(R.drawable.ic_glass_playlist),
     )
     Box(modifier = modifier.fillMaxWidth()) {
+        // Soft rounded-rect drop shadow lifting the whole glass slab off the
+        // player, matching the play button + transport icons (Studio-tunable).
+        val g = LocalPlayerGlass.current
+        if (g.enabled) {
+            GlassDropShadow(
+                color = androidx.compose.ui.graphics.lerp(Color.Black, accent, g.shadowTint)
+                    .copy(alpha = 0.26f + 0.5f * g.shadowDepth),
+                softness = g.shadowSoftness,
+                depth = g.shadowDepth,
+                shape = RoundedCornerShape(PlayerDesignTokens.GlassCornerLarge),
+            )
+        }
         // The glass slab with the four icons carved out of it. Drawn in one
         // offscreen layer so the DstOut punch clears only the glyph shapes (not
         // the whole rectangle) and can't clear the player behind the dock.

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -16,11 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Lyrics
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,9 +26,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import tf.monochrome.android.R
 /**
  * Compact tool row beneath the transport controls: Lyrics · Timer · Mixer/FX · Playlist.
  * (Monitoring + effect controls live in the pull-up "Audio tools" panel.)
@@ -66,17 +63,17 @@ fun PlayerActionDock(
                 .padding(vertical = 6.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
-            DockAction(Icons.Default.Lyrics, "Lyrics", accent, lyricsActive, onLyrics)
-            DockAction(Icons.Default.Timer, "Timer", accent, false, onTimer)
-            DockAction(Icons.Default.Tune, "Mixer/FX", accent, false, onMixer)
-            DockAction(Icons.AutoMirrored.Filled.QueueMusic, "Playlist", accent, false, onPlaylist)
+            DockAction(painterResource(R.drawable.ic_glass_lyrics), "Lyrics", accent, lyricsActive, onLyrics)
+            DockAction(painterResource(R.drawable.ic_glass_timer), "Timer", accent, false, onTimer)
+            DockAction(painterResource(R.drawable.ic_glass_mixer), "Mixer/FX", accent, false, onMixer)
+            DockAction(painterResource(R.drawable.ic_glass_playlist), "Playlist", accent, false, onPlaylist)
         }
     }
 }
 
 @Composable
 private fun DockAction(
-    icon: ImageVector,
+    icon: Painter,
     label: String,
     accent: Color,
     selected: Boolean,
@@ -101,9 +98,11 @@ private fun DockAction(
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         Icon(
-            imageVector = icon,
+            painter = icon,
             contentDescription = label,
-            modifier = Modifier.size(PlayerDesignTokens.ActionIconSize),
+            modifier = Modifier
+                .size(PlayerDesignTokens.ActionIconSize)
+                .playerGlass(tint = iconTint),
             tint = iconTint,
         )
         Text(

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -79,8 +79,11 @@ fun PlayerActionDock(
                 .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
         ) {
             val cornerPx = PlayerDesignTokens.GlassCornerLarge.toPx()
+            // Same solid [accent] fill as the play-button disc, so the slab reads
+            // as the same coloured glass — the shader's body opacity makes it
+            // see-through, matching the transport buttons exactly.
             drawRoundRect(
-                color = Color.White.copy(alpha = 0.20f),
+                color = accent,
                 cornerRadius = CornerRadius(cornerPx, cornerPx),
             )
             val iconPx = PlayerDesignTokens.ActionIconSize.toPx()

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -3,6 +3,7 @@ package tf.monochrome.android.ui.player
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -19,11 +20,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
@@ -69,6 +73,25 @@ fun PlayerActionDock(
         painterResource(R.drawable.ic_glass_mixer),
         painterResource(R.drawable.ic_glass_playlist),
     )
+    // Press-bulge: one shared interaction source per slot so the parent knows
+    // which button is held and can swell the glass under it. The bulge grows on
+    // press (spring) and recedes on release (tween); its centre follows the last
+    // pressed slot.
+    val sources = remember { List(icons.size) { MutableInteractionSource() } }
+    val pressed = sources.map { it.collectIsPressedAsState() }
+    val pressedIndex = pressed.indexOfFirst { it.value }
+    val bulgeSlot = remember { mutableIntStateOf(0) }
+    LaunchedEffect(pressedIndex) { if (pressedIndex >= 0) bulgeSlot.intValue = pressedIndex }
+    val bulgeAmt by animateFloatAsState(
+        targetValue = if (pressedIndex >= 0) 1f else 0f,
+        animationSpec = if (pressedIndex >= 0) {
+            spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessMediumLow)
+        } else {
+            tween(durationMillis = 260)
+        },
+        label = "dockBulge",
+    )
+    val bulgeCenter = Offset((bulgeSlot.intValue + 0.5f) / icons.size, 0.42f)
     Box(modifier = modifier.fillMaxWidth()) {
         // Soft rounded-rect drop shadow lifting the whole glass slab off the
         // player, matching the play button + transport icons (Studio-tunable).
@@ -88,7 +111,7 @@ fun PlayerActionDock(
         Canvas(
             modifier = Modifier
                 .matchParentSize()
-                .playerGlass(tint = accent)
+                .playerGlass(tint = accent, bulgeCenter = bulgeCenter, bulgeAmount = { bulgeAmt })
                 .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
         ) {
             val cornerPx = PlayerDesignTokens.GlassCornerLarge.toPx()
@@ -116,10 +139,10 @@ fun PlayerActionDock(
         }
         // Transparent overlay: labels + tap targets, one weighted slot per hole.
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = DockRowVerticalPadding)) {
-            DockLabel(Modifier.weight(1f), "Lyrics", accent, lyricsActive, onLyrics)
-            DockLabel(Modifier.weight(1f), "Timer", accent, false, onTimer)
-            DockLabel(Modifier.weight(1f), "Mixer/FX", accent, false, onMixer)
-            DockLabel(Modifier.weight(1f), "Playlist", accent, false, onPlaylist)
+            DockLabel(Modifier.weight(1f), "Lyrics", accent, lyricsActive, sources[0], onLyrics)
+            DockLabel(Modifier.weight(1f), "Timer", accent, false, sources[1], onTimer)
+            DockLabel(Modifier.weight(1f), "Mixer/FX", accent, false, sources[2], onMixer)
+            DockLabel(Modifier.weight(1f), "Playlist", accent, false, sources[3], onPlaylist)
         }
     }
 }
@@ -130,9 +153,9 @@ private fun DockLabel(
     label: String,
     accent: Color,
     selected: Boolean,
+    interactionSource: MutableInteractionSource,
     onClick: () -> Unit,
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
         targetValue = if (isPressed) 0.92f else 1f,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
@@ -47,6 +47,8 @@ object PlayerDesignTokens {
     // Skip previous/next read 50% larger than the other transport glyphs.
     val SkipIconSize = 51.dp
     val ActionIconSize = 24.dp
+    // Dock glyphs are label-less, so the icon fills the freed vertical space.
+    val DockIconSize = 48.dp
 
     val ProgressHeight = 4.dp
     val ProgressThumbSize = 14.dp

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
@@ -44,6 +44,8 @@ object PlayerDesignTokens {
 
     val PlayButtonSize = 72.dp
     val TransportIconSize = 34.dp
+    // Skip previous/next read 50% larger than the other transport glyphs.
+    val SkipIconSize = 51.dp
     val ActionIconSize = 24.dp
 
     val ProgressHeight = 4.dp

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
@@ -48,7 +48,7 @@ object PlayerDesignTokens {
     val SkipIconSize = 51.dp
     val ActionIconSize = 24.dp
     // Dock glyphs are label-less, so the icon fills the freed vertical space.
-    val DockIconSize = 48.dp
+    val DockIconSize = 38.dp
 
     val ProgressHeight = 4.dp
     val ProgressThumbSize = 14.dp

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
@@ -438,7 +438,7 @@ private fun VisualizerHeroOverlay(
 ) {
     Surface(
         modifier = modifier.padding(10.dp)
-            .liquidGlass(shape = RoundedCornerShape(18.dp), tintAlpha = 0.26f, liquid = true),
+            .liquidGlass(shape = RoundedCornerShape(18.dp), tintAlpha = 0.26f),
         shape = RoundedCornerShape(18.dp),
         color = Color.Transparent,
         contentColor = Color.White,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
@@ -438,7 +438,7 @@ private fun VisualizerHeroOverlay(
 ) {
     Surface(
         modifier = modifier.padding(10.dp)
-            .liquidGlass(shape = RoundedCornerShape(18.dp), tintAlpha = 0.26f),
+            .liquidGlass(shape = RoundedCornerShape(18.dp), tintAlpha = 0.26f, liquid = true),
         shape = RoundedCornerShape(18.dp),
         color = Color.Transparent,
         contentColor = Color.White,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
@@ -1,6 +1,12 @@
 package tf.monochrome.android.ui.player
 
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -16,16 +22,32 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
 
 /**
  * Scrubber plus elapsed / center-label / total time. The center label carries
  * the quality or queue-position context from the generated design.
+ *
+ * When the player glass is on with the "Glass progress bar" setting, the
+ * scrubber is a thin liquid-glass tube (a thermometer) that fills up, with a
+ * playhead dot that swells the tube into a smooth sine-wave bulge. Otherwise it
+ * falls back to a plain Material slider.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,43 +61,21 @@ fun PlayerProgress(
     onSeekFinished: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val interaction = remember { MutableInteractionSource() }
-    val dragged by interaction.collectIsDraggedAsState()
-    val thumbSize by animateDpAsState(
-        targetValue = if (dragged) 18.dp else PlayerDesignTokens.ProgressThumbSize,
-        label = "progressThumb",
-    )
-    val colors = SliderDefaults.colors(
-        thumbColor = accent,
-        activeTrackColor = accent,
-        inactiveTrackColor = Color.White.copy(alpha = 0.20f),
-    )
+    val glass = LocalPlayerGlass.current
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
 
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Slider(
-            value = fraction.coerceIn(0f, 1f),
-            onValueChange = onSeek,
-            onValueChangeFinished = { onSeekFinished(fraction) },
-            modifier = Modifier.fillMaxWidth(),
-            interactionSource = interaction,
-            colors = colors,
-            thumb = {
-                SliderDefaults.Thumb(
-                    interactionSource = interaction,
-                    colors = colors,
-                    thumbSize = DpSize(thumbSize, thumbSize),
-                )
-            },
-            track = { sliderState ->
-                SliderDefaults.Track(
-                    sliderState = sliderState,
-                    modifier = Modifier.height(PlayerDesignTokens.ProgressHeight),
-                    colors = colors,
-                    drawStopIndicator = null,
-                    thumbTrackGapSize = 0.dp,
-                )
-            },
-        )
+        if (glass.enabled && glass.progressGlass) {
+            GlassProgressTube(
+                fraction = fraction,
+                tint = tint,
+                onSeek = onSeek,
+                onSeekFinished = onSeekFinished,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        } else {
+            PlainSlider(fraction, tint, onSeek, onSeekFinished)
+        }
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -100,4 +100,139 @@ fun PlayerProgress(
             )
         }
     }
+}
+
+/**
+ * The liquid-glass "thermometer" scrubber: a thin tube whose vertical thickness
+ * follows a raised-cosine (sine-wave) bump centred on the playhead, so the dot
+ * reads as a smooth bulge in the tube. The played portion is filled with [tint];
+ * the whole thing is handed to the [playerGlass] shader, which bevels the tube
+ * and the bulge into refractive glass. Drag or tap to seek.
+ */
+@Composable
+internal fun GlassProgressTube(
+    fraction: Float,
+    tint: Color,
+    onSeek: (Float) -> Unit,
+    onSeekFinished: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var dragging by remember { mutableStateOf(false) }
+    // The dot always shows a bulge; it swells further while dragging.
+    val bulge by animateFloatAsState(
+        targetValue = if (dragging) 1f else 0.6f,
+        animationSpec = spring(dampingRatio = 0.6f, stiffness = Spring.StiffnessMedium),
+        label = "progressBulge",
+    )
+    val frac = fraction.coerceIn(0f, 1f)
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(34.dp)
+            .pointerInput(Unit) {
+                detectTapGestures { pos ->
+                    val f = (pos.x / size.width).coerceIn(0f, 1f)
+                    onSeek(f)
+                    onSeekFinished(f)
+                }
+            }
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragStart = { pos ->
+                        dragging = true
+                        onSeek((pos.x / size.width).coerceIn(0f, 1f))
+                    },
+                    onDragEnd = { dragging = false; onSeekFinished(frac) },
+                    onDragCancel = { dragging = false },
+                    onHorizontalDrag = { change, _ ->
+                        onSeek((change.position.x / size.width).coerceIn(0f, 1f))
+                    },
+                )
+            }
+            .playerGlass(tint = tint)
+            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+    ) {
+        val w = size.width
+        val cy = size.height / 2f
+        val baseHalf = 2.6.dp.toPx()                          // thin tube half-thickness
+        val bulgeHalf = 7.dp.toPx() + 5.dp.toPx() * bulge     // dot half-thickness
+        val sigma = 26.dp.toPx()                              // bulge half-width
+        val inset = bulgeHalf                                 // keep the dot on-screen
+        val thumbX = inset + frac * (w - 2f * inset)
+
+        // Raised-cosine (sine-wave) contour: fat at the dot, thin along the tube.
+        fun halfAt(x: Float): Float {
+            val d = abs(x - thumbX)
+            val bump = if (d < sigma) 0.5f * (1f + cos(PI.toFloat() * d / sigma)) else 0f
+            return baseHalf + (bulgeHalf - baseHalf) * bump
+        }
+
+        val path = Path()
+        val step = 3f
+        path.moveTo(0f, cy - halfAt(0f))
+        var x = step
+        while (x < w) { path.lineTo(x, cy - halfAt(x)); x += step }
+        path.lineTo(w, cy - halfAt(w))
+        x = w - step
+        while (x > 0f) { path.lineTo(x, cy + halfAt(x)); x -= step }
+        path.lineTo(0f, cy + halfAt(0f))
+        path.close()
+
+        // Inactive glass tube.
+        drawPath(path, color = Color.White.copy(alpha = 0.22f))
+        // Filled (played) portion up to the dot.
+        clipRect(right = thumbX) { drawPath(path, color = tint) }
+        // A defined dot core at the playhead so the bulge reads as the thumb.
+        drawCircle(
+            color = tint,
+            radius = baseHalf + (bulgeHalf - baseHalf) * 0.6f,
+            center = Offset(thumbX, cy),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PlainSlider(
+    fraction: Float,
+    tint: Color,
+    onSeek: (Float) -> Unit,
+    onSeekFinished: (Float) -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val dragged by interaction.collectIsDraggedAsState()
+    val thumbSize by animateDpAsState(
+        targetValue = if (dragged) 18.dp else PlayerDesignTokens.ProgressThumbSize,
+        label = "progressThumb",
+    )
+    val colors = SliderDefaults.colors(
+        thumbColor = tint,
+        activeTrackColor = tint,
+        inactiveTrackColor = Color.White.copy(alpha = 0.20f),
+    )
+    Slider(
+        value = fraction.coerceIn(0f, 1f),
+        onValueChange = onSeek,
+        onValueChangeFinished = { onSeekFinished(fraction) },
+        modifier = Modifier.fillMaxWidth(),
+        interactionSource = interaction,
+        colors = colors,
+        thumb = {
+            SliderDefaults.Thumb(
+                interactionSource = interaction,
+                colors = colors,
+                thumbSize = DpSize(thumbSize, thumbSize),
+            )
+        },
+        track = { sliderState ->
+            SliderDefaults.Track(
+                sliderState = sliderState,
+                modifier = Modifier.height(PlayerDesignTokens.ProgressHeight),
+                colors = colors,
+                drawStopIndicator = null,
+                thumbTrackGapSize = 0.dp,
+            )
+        },
+    )
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -118,6 +119,10 @@ internal fun GlassProgressTube(
     modifier: Modifier = Modifier,
 ) {
     var dragging by remember { mutableStateOf(false) }
+    // The position the finger is currently over, committed on release. Held in a
+    // MutableState so the pointerInput(Unit) closures (created once) read/write
+    // the live value instead of a stale captured fraction.
+    var seekTarget by remember { mutableFloatStateOf(0f) }
     // The dot always shows a bulge; it swells further while dragging.
     val bulge by animateFloatAsState(
         targetValue = if (dragging) 1f else 0.6f,
@@ -141,12 +146,16 @@ internal fun GlassProgressTube(
                 detectHorizontalDragGestures(
                     onDragStart = { pos ->
                         dragging = true
-                        onSeek((pos.x / size.width).coerceIn(0f, 1f))
+                        val f = (pos.x / size.width).coerceIn(0f, 1f)
+                        seekTarget = f
+                        onSeek(f)
                     },
-                    onDragEnd = { dragging = false; onSeekFinished(frac) },
+                    onDragEnd = { dragging = false; onSeekFinished(seekTarget) },
                     onDragCancel = { dragging = false },
                     onHorizontalDrag = { change, _ ->
-                        onSeek((change.position.x / size.width).coerceIn(0f, 1f))
+                        val f = (change.position.x / size.width).coerceIn(0f, 1f)
+                        seekTarget = f
+                        onSeek(f)
                     },
                 )
             }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTopBar.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTopBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material3.DropdownMenu
@@ -68,6 +69,7 @@ fun PlayerTopBar(
     onCycleHeroStyle: () -> Unit,
     onOpenVisualizer: () -> Unit,
     onOpenEqualizer: () -> Unit,
+    onOpenLyricsStudio: () -> Unit,
     onOpenSettings: () -> Unit,
     onGoToArtist: (() -> Unit)? = null,
     onGoToAlbum: (() -> Unit)? = null,
@@ -210,6 +212,11 @@ fun PlayerTopBar(
                         text = { Text("Equalizer") },
                         onClick = { onOpenEqualizer(); menuExpanded = false },
                         leadingIcon = { Icon(Icons.Default.Equalizer, contentDescription = null) },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Lyrics FX Studio") },
+                        onClick = { onOpenLyricsStudio(); menuExpanded = false },
+                        leadingIcon = { Icon(Icons.Default.AutoAwesome, contentDescription = null) },
                     )
                     DropdownMenuItem(
                         text = { Text("Settings") },

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -33,10 +34,12 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
 
@@ -63,7 +66,10 @@ fun PlayerTransportControls(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        TransportIcon(painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious)
+        TransportIcon(
+            painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious,
+            size = PlayerDesignTokens.SkipIconSize,
+        )
         TransportIcon(painterResource(R.drawable.ic_glass_replay_10), "Rewind 10 seconds", accent, onRewind10)
 
         val interactionSource = remember { MutableInteractionSource() }
@@ -119,7 +125,10 @@ fun PlayerTransportControls(
         }
 
         TransportIcon(painterResource(R.drawable.ic_glass_forward_10), "Forward 10 seconds", accent, onForward10)
-        TransportIcon(painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext)
+        TransportIcon(
+            painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext,
+            size = PlayerDesignTokens.SkipIconSize,
+        )
     }
 }
 
@@ -184,14 +193,19 @@ private fun DrawScope.drawPlayPauseSymbol(
 }
 
 /**
- * A soft, perfectly ROUND drop shadow for the play button — a blurred, tinted
- * circle we draw ourselves instead of the platform elevation shadow (which
- * facets a CircleShape into a visible octagon on some GPUs). [depth] offsets +
- * darkens it, [softness] sets the blur radius. Below API 31 blur is a no-op, so
- * it degrades to a hard (still round) circle rather than an octagon.
+ * A soft drop shadow for a [shape] surface (the play disc, the dock slab) — a
+ * blurred, tinted shape we draw ourselves instead of the platform elevation
+ * shadow (which facets a CircleShape into a visible octagon on some GPUs).
+ * [depth] offsets + darkens it, [softness] sets the blur radius. Below API 31
+ * blur is a no-op, so it degrades to a hard (still true-shaped) fill.
  */
 @Composable
-internal fun BoxScope.GlassDropShadow(color: Color, softness: Float, depth: Float) {
+internal fun BoxScope.GlassDropShadow(
+    color: Color,
+    softness: Float,
+    depth: Float,
+    shape: Shape = CircleShape,
+) {
     Box(
         modifier = Modifier
             .matchParentSize()
@@ -200,20 +214,49 @@ internal fun BoxScope.GlassDropShadow(color: Color, softness: Float, depth: Floa
                 radius = (5f + softness * 22f).dp,
                 edgeTreatment = BlurredEdgeTreatment.Unbounded,
             )
-            .background(color, CircleShape),
+            .background(color, shape),
     )
 }
 
 @Composable
-private fun TransportIcon(painter: Painter, description: String, tint: Color, onClick: () -> Unit) {
+private fun TransportIcon(
+    painter: Painter,
+    description: String,
+    tint: Color,
+    onClick: () -> Unit,
+    size: Dp = PlayerDesignTokens.TransportIconSize,
+) {
+    val glass = LocalPlayerGlass.current
     IconButton(onClick = onClick) {
-        Icon(
-            painter = painter,
-            contentDescription = description,
-            modifier = Modifier
-                .size(PlayerDesignTokens.TransportIconSize)
-                .playerGlass(tint = tint),
-            tint = tint,
-        )
+        Box(contentAlignment = Alignment.Center) {
+            // Shape-accurate drop shadow: a blurred, tinted copy of the SAME glyph
+            // behind the glass icon, so the shadow traces the icon's real outline
+            // (a circle shadow can't fit a triangle/arrow). Tracks the Studio's
+            // shadow depth / softness / tint, matching the play button.
+            if (glass.enabled) {
+                val shadowColor = androidx.compose.ui.graphics.lerp(Color.Black, tint, glass.shadowTint)
+                    .copy(alpha = 0.30f + 0.5f * glass.shadowDepth)
+                Icon(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .requiredSize(size)
+                        .graphicsLayer { translationY = (1.5f + glass.shadowDepth * 4f).dp.toPx() }
+                        .blur(
+                            radius = (2f + glass.shadowSoftness * 12f).dp,
+                            edgeTreatment = BlurredEdgeTreatment.Unbounded,
+                        ),
+                    tint = shadowColor,
+                )
+            }
+            Icon(
+                painter = painter,
+                contentDescription = description,
+                modifier = Modifier
+                    .requiredSize(size)
+                    .playerGlass(tint = tint),
+                tint = tint,
+            )
+        }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -226,36 +225,42 @@ internal fun TransportIcon(
     size: Dp = PlayerDesignTokens.TransportIconSize,
 ) {
     val glass = LocalPlayerGlass.current
-    IconButton(onClick = onClick) {
-        Box(contentAlignment = Alignment.Center) {
-            // Shape-accurate drop shadow: a blurred, tinted copy of the SAME glyph
-            // behind the glass icon, so the shadow traces the icon's real outline
-            // (a circle shadow can't fit a triangle/arrow). Tracks the Studio's
-            // shadow depth / softness / tint, matching the play button.
-            if (glass.enabled) {
-                val shadowColor = androidx.compose.ui.graphics.lerp(Color.Black, tint, glass.shadowTint)
-                    .copy(alpha = 0.30f + 0.5f * glass.shadowDepth)
-                Icon(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .requiredSize(size)
-                        .graphicsLayer { translationY = (1.5f + glass.shadowDepth * 4f).dp.toPx() }
-                        .blur(
-                            radius = (2f + glass.shadowSoftness * 12f).dp,
-                            edgeTreatment = BlurredEdgeTreatment.Unbounded,
-                        ),
-                    tint = shadowColor,
-                )
-            }
+    // A generously-sized clickable box (instead of the fixed 48dp IconButton) so
+    // the offset + blurred drop shadow has canvas room and isn't clipped by the
+    // transport row. The visible glyph stays `size`, centred in the box.
+    Box(
+        modifier = Modifier
+            .size(size + 40.dp)
+            .clickable(onClickLabel = description, onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Shape-accurate drop shadow: a blurred, tinted copy of the SAME glyph
+        // behind the glass icon, so the shadow traces the icon's real outline
+        // (a circle shadow can't fit a triangle/arrow). Tracks the Studio's
+        // shadow depth / softness / tint, matching the play button.
+        if (glass.enabled) {
+            val shadowColor = androidx.compose.ui.graphics.lerp(Color.Black, tint, glass.shadowTint)
+                .copy(alpha = 0.30f + 0.5f * glass.shadowDepth)
             Icon(
                 painter = painter,
-                contentDescription = description,
+                contentDescription = null,
                 modifier = Modifier
                     .requiredSize(size)
-                    .playerGlass(tint = tint),
-                tint = tint,
+                    .graphicsLayer { translationY = (1.5f + glass.shadowDepth * 4f).dp.toPx() }
+                    .blur(
+                        radius = (2f + glass.shadowSoftness * 12f).dp,
+                        edgeTreatment = BlurredEdgeTreatment.Unbounded,
+                    ),
+                tint = shadowColor,
             )
         }
+        Icon(
+            painter = painter,
+            contentDescription = description,
+            modifier = Modifier
+                .requiredSize(size)
+                .playerGlass(tint = tint),
+            tint = tint,
+        )
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -4,11 +4,13 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,8 +23,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -72,40 +75,46 @@ fun PlayerTransportControls(
         )
         // Play/pause is a SOLID round glass disc with the play/pause symbol
         // punched out (hollow), so the backdrop shows through the glyph and the
-        // shader bevels both the disc rim and the cut-out edges. A drop shadow
-        // lifts it off the surface: shadow depth = darkness, softness = blur,
-        // tint = black -> accent-tinted glow (all tunable in the Studio).
-        val shadowColor = androidx.compose.ui.graphics.lerp(Color.Black, accent, glass.shadowTint)
-            .copy(alpha = 0.25f + 0.6f * glass.shadowDepth)
+        // shader bevels both the disc rim and the cut-out edges.
         Box(
             modifier = Modifier
                 .size(PlayerDesignTokens.PlayButtonSize)
-                .graphicsLayer { scaleX = scale; scaleY = scale }
-                .shadow(
-                    elevation = (4f + glass.shadowSoftness * 26f).dp,
-                    shape = CircleShape,
-                    clip = false,
-                    ambientColor = shadowColor,
-                    spotColor = shadowColor,
-                )
-                .clip(CircleShape)
-                .clickable(
-                    interactionSource = interactionSource,
-                    indication = null,
-                    onClick = onPlayPause,
-                ),
+                .graphicsLayer { scaleX = scale; scaleY = scale },
             contentAlignment = Alignment.Center,
         ) {
-            Canvas(
+            // Drop shadow drawn by us as a blurred, tinted circle — a TRUE round
+            // shadow. The platform elevation shadow facets CircleShape into an
+            // octagon on some GPUs; a blurred circle stays perfectly round.
+            // Depth = darkness, softness = blur radius + offset, tint = black ->
+            // accent glow (all tunable in the Studio).
+            GlassDropShadow(
+                color = androidx.compose.ui.graphics.lerp(Color.Black, accent, glass.shadowTint)
+                    .copy(alpha = 0.28f + 0.55f * glass.shadowDepth),
+                softness = glass.shadowSoftness,
+                depth = glass.shadowDepth,
+            )
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .playerGlass(tint = accent)
-                    // Own offscreen layer so the punch-out (BlendMode.Clear) is
-                    // contained here and can't clear the player behind it — needed
-                    // when the glass effect is off or below API 33.
-                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                    .clip(CircleShape)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = onPlayPause,
+                    ),
+                contentAlignment = Alignment.Center,
             ) {
-                drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = accent)
+                Canvas(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .playerGlass(tint = accent)
+                        // Own offscreen layer so the punch-out (BlendMode.Clear) is
+                        // contained here and can't clear the player behind it — needed
+                        // when the glass effect is off or below API 33.
+                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                ) {
+                    drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = accent)
+                }
             }
         }
 
@@ -172,6 +181,27 @@ private fun DrawScope.drawPlayPauseSymbol(
         }
         drawPath(tri, color = color, blendMode = blend)
     }
+}
+
+/**
+ * A soft, perfectly ROUND drop shadow for the play button — a blurred, tinted
+ * circle we draw ourselves instead of the platform elevation shadow (which
+ * facets a CircleShape into a visible octagon on some GPUs). [depth] offsets +
+ * darkens it, [softness] sets the blur radius. Below API 31 blur is a no-op, so
+ * it degrades to a hard (still round) circle rather than an octagon.
+ */
+@Composable
+internal fun BoxScope.GlassDropShadow(color: Color, softness: Float, depth: Float) {
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .graphicsLayer { translationY = (2f + depth * 6f).dp.toPx() }
+            .blur(
+                radius = (5f + softness * 22f).dp,
+                edgeTreatment = BlurredEdgeTreatment.Unbounded,
+            )
+            .background(color, CircleShape),
+    )
 }
 
 @Composable

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -59,13 +59,16 @@ fun PlayerTransportControls(
     modifier: Modifier = Modifier,
 ) {
     val glass = LocalPlayerGlass.current
+    // Button glass tint: a custom colour chosen in the Studio, or the album
+    // accent when none is set (tintColor == 0).
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TransportIcon(
-            painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious,
+            painterResource(R.drawable.ic_glass_skip_previous), "Previous", tint, onPrevious,
             size = PlayerDesignTokens.SkipIconSize,
         )
 
@@ -91,7 +94,7 @@ fun PlayerTransportControls(
             // Depth = darkness, softness = blur radius + offset, tint = black ->
             // accent glow (all tunable in the Studio).
             GlassDropShadow(
-                color = androidx.compose.ui.graphics.lerp(Color.Black, accent, glass.shadowTint)
+                color = androidx.compose.ui.graphics.lerp(Color.Black, tint, glass.shadowTint)
                     .copy(alpha = 0.28f + 0.55f * glass.shadowDepth),
                 softness = glass.shadowSoftness,
                 depth = glass.shadowDepth,
@@ -110,19 +113,19 @@ fun PlayerTransportControls(
                 Canvas(
                     modifier = Modifier
                         .fillMaxSize()
-                        .playerGlass(tint = accent)
+                        .playerGlass(tint = tint)
                         // Own offscreen layer so the punch-out (BlendMode.Clear) is
                         // contained here and can't clear the player behind it — needed
                         // when the glass effect is off or below API 33.
                         .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
                 ) {
-                    drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = accent)
+                    drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = tint)
                 }
             }
         }
 
         TransportIcon(
-            painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext,
+            painterResource(R.drawable.ic_glass_skip_next), "Next", tint, onNext,
             size = PlayerDesignTokens.SkipIconSize,
         )
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -3,25 +3,30 @@ package tf.monochrome.android.ui.player
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forward10
 import androidx.compose.material.icons.filled.Replay10
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -61,25 +66,42 @@ fun PlayerTransportControls(
             animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
             label = "playScale",
         )
-        FilledIconButton(
-            onClick = onPlayPause,
-            interactionSource = interactionSource,
+        // Play/pause is a HOLLOW glass ring: the circular band carries the glass
+        // treatment and the interior is empty (the reverse of a solid disc), with
+        // the play/pause glyph floating glass in the centre.
+        Box(
             modifier = Modifier
                 .size(PlayerDesignTokens.PlayButtonSize)
-                .graphicsLayer { scaleX = scale; scaleY = scale },
-            colors = IconButtonDefaults.filledIconButtonColors(
-                containerColor = accent,
-                contentColor = Color.Black,
-            ),
+                .graphicsLayer { scaleX = scale; scaleY = scale }
+                .clip(CircleShape)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onPlayPause,
+                ),
+            contentAlignment = Alignment.Center,
         ) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .playerGlass(tint = accent),
+            ) {
+                val stroke = size.minDimension * 0.12f
+                drawCircle(
+                    color = accent,
+                    radius = (size.minDimension - stroke) / 2f,
+                    style = Stroke(width = stroke),
+                )
+            }
             Icon(
                 painter = painterResource(
                     if (isPlaying) R.drawable.ic_glass_pause else R.drawable.ic_glass_play
                 ),
                 contentDescription = if (isPlaying) "Pause" else "Play",
                 modifier = Modifier
-                    .size(38.dp)
+                    .size(30.dp)
                     .playerGlass(tint = accent),
+                tint = accent,
             )
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -3,6 +3,7 @@ package tf.monochrome.android.ui.player
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -78,6 +79,17 @@ fun PlayerTransportControls(
             animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
             label = "playScale",
         )
+        // Press-bulge: swell the glass under the disc while it's held, matching
+        // the dock and the other glass buttons.
+        val bulge by animateFloatAsState(
+            targetValue = if (isPressed) 1f else 0f,
+            animationSpec = if (isPressed) {
+                spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessMediumLow)
+            } else {
+                tween(durationMillis = 260)
+            },
+            label = "playBulge",
+        )
         // Play/pause is a SOLID round glass disc with the play/pause symbol
         // punched out (hollow), so the backdrop shows through the glyph and the
         // shader bevels both the disc rim and the cut-out edges.
@@ -112,7 +124,7 @@ fun PlayerTransportControls(
                 Canvas(
                     modifier = Modifier
                         .fillMaxSize()
-                        .playerGlass(tint = tint)
+                        .playerGlass(tint = tint, bulgeAmount = { bulge })
                         // Own offscreen layer so the punch-out (BlendMode.Clear) is
                         // contained here and can't clear the player behind it — needed
                         // when the glass effect is off or below API 33.
@@ -225,13 +237,32 @@ internal fun TransportIcon(
     size: Dp = PlayerDesignTokens.TransportIconSize,
 ) {
     val glass = LocalPlayerGlass.current
+    // Press-bulge: swell the glass glyph while it's held (spring in, tween out),
+    // matching the play disc and the dock — the bulge is the tap feedback, so no
+    // ripple indication.
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val bulge by animateFloatAsState(
+        targetValue = if (isPressed) 1f else 0f,
+        animationSpec = if (isPressed) {
+            spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessMediumLow)
+        } else {
+            tween(durationMillis = 260)
+        },
+        label = "transportBulge",
+    )
     // A generously-sized clickable box (instead of the fixed 48dp IconButton) so
     // the offset + blurred drop shadow has canvas room and isn't clipped by the
     // transport row. The visible glyph stays `size`, centred in the box.
     Box(
         modifier = Modifier
             .size(size + 40.dp)
-            .clickable(onClickLabel = description, onClick = onClick),
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClickLabel = description,
+                onClick = onClick,
+            ),
         contentAlignment = Alignment.Center,
     ) {
         // Shape-accurate drop shadow: a blurred, tinted copy of the SAME glyph
@@ -259,7 +290,7 @@ internal fun TransportIcon(
             contentDescription = description,
             modifier = Modifier
                 .requiredSize(size)
-                .playerGlass(tint = tint),
+                .playerGlass(tint = tint, bulgeAmount = { bulge }),
             tint = tint,
         )
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -14,9 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Forward10
-import androidx.compose.material.icons.filled.Replay10
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -25,11 +22,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
@@ -51,13 +54,14 @@ fun PlayerTransportControls(
     onNext: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val glass = LocalPlayerGlass.current
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TransportIcon(painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious)
-        TransportIcon(rememberVectorPainter(Icons.Default.Replay10), "Rewind 10 seconds", accent, onRewind10)
+        TransportIcon(painterResource(R.drawable.ic_glass_replay_10), "Rewind 10 seconds", accent, onRewind10)
 
         val interactionSource = remember { MutableInteractionSource() }
         val isPressed by interactionSource.collectIsPressedAsState()
@@ -66,13 +70,19 @@ fun PlayerTransportControls(
             animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
             label = "playScale",
         )
-        // Play/pause is a HOLLOW glass ring: the circular band carries the glass
-        // treatment and the interior is empty (the reverse of a solid disc), with
-        // the play/pause glyph floating glass in the centre.
+        // Play/pause is a SOLID round glass disc with the play/pause symbol
+        // punched out (hollow), so the backdrop shows through the glyph and the
+        // shader bevels both the disc rim and the cut-out edges. A soft drop
+        // shadow (tunable "shadow depth") lifts it off the surface for 3D depth.
         Box(
             modifier = Modifier
                 .size(PlayerDesignTokens.PlayButtonSize)
                 .graphicsLayer { scaleX = scale; scaleY = scale }
+                .shadow(
+                    elevation = (glass.shadowDepth * 22f).dp,
+                    shape = CircleShape,
+                    clip = false,
+                )
                 .clip(CircleShape)
                 .clickable(
                     interactionSource = interactionSource,
@@ -84,29 +94,62 @@ fun PlayerTransportControls(
             Canvas(
                 modifier = Modifier
                     .fillMaxSize()
-                    .playerGlass(tint = accent),
+                    .playerGlass(tint = accent)
+                    // Own offscreen layer so the punch-out (BlendMode.Clear) is
+                    // contained here and can't clear the player behind it — needed
+                    // when the glass effect is off or below API 33.
+                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
             ) {
-                val stroke = size.minDimension * 0.12f
-                drawCircle(
-                    color = accent,
-                    radius = (size.minDimension - stroke) / 2f,
-                    style = Stroke(width = stroke),
-                )
+                drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = accent)
             }
-            Icon(
-                painter = painterResource(
-                    if (isPlaying) R.drawable.ic_glass_pause else R.drawable.ic_glass_play
-                ),
-                contentDescription = if (isPlaying) "Pause" else "Play",
-                modifier = Modifier
-                    .size(30.dp)
-                    .playerGlass(tint = accent),
-                tint = accent,
-            )
         }
 
-        TransportIcon(rememberVectorPainter(Icons.Default.Forward10), "Forward 10 seconds", accent, onForward10)
+        TransportIcon(painterResource(R.drawable.ic_glass_forward_10), "Forward 10 seconds", accent, onForward10)
         TransportIcon(painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext)
+    }
+}
+
+/**
+ * Draws the play/pause round button: a solid [fill] disc with the play triangle
+ * or pause bars *punched out* (cleared to transparent) so the glyph reads as a
+ * hollow cut-out of the glass. Meant to be drawn inside a layer carrying the
+ * [playerGlass] render effect, which bevels the disc edge and the cut-out edges
+ * into refractive 3D glass.
+ */
+internal fun DrawScope.drawGlassPlayPauseDisc(isPlaying: Boolean, fill: Color) {
+    val d = size.minDimension
+    val cx = size.width / 2f
+    val cy = size.height / 2f
+    drawCircle(color = fill, radius = d / 2f)
+    if (isPlaying) {
+        val barW = d * 0.11f
+        val barH = d * 0.34f
+        val gap = d * 0.10f
+        val corner = CornerRadius(barW * 0.42f, barW * 0.42f)
+        drawRoundRect(
+            color = fill,
+            topLeft = Offset(cx - gap / 2f - barW, cy - barH / 2f),
+            size = Size(barW, barH),
+            cornerRadius = corner,
+            blendMode = BlendMode.Clear,
+        )
+        drawRoundRect(
+            color = fill,
+            topLeft = Offset(cx + gap / 2f, cy - barH / 2f),
+            size = Size(barW, barH),
+            cornerRadius = corner,
+            blendMode = BlendMode.Clear,
+        )
+    } else {
+        val w = d * 0.32f
+        val h = d * 0.34f
+        val tri = Path().apply {
+            moveTo(cx - w * 0.40f, cy - h / 2f)
+            lineTo(cx - w * 0.40f, cy + h / 2f)
+            lineTo(cx + w * 0.60f, cy)
+            close()
+        }
+        drawPath(tri, color = fill, blendMode = BlendMode.Clear)
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -11,11 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forward10
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay10
-import androidx.compose.material.icons.filled.SkipNext
-import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,12 +23,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import tf.monochrome.android.R
 
 /**
  * Primary transport row: previous · rewind 10s · play/pause · forward 10s ·
- * next. Shuffle and repeat moved to the overflow menu per the redesign.
+ * next. The icons are solid glyph shapes and carry the refractive [playerGlass]
+ * treatment (tunable in the Studio's Player Glass tab), so the buttons read as
+ * 3D liquid glass like the lyrics.
  */
 @Composable
 fun PlayerTransportControls(
@@ -50,8 +51,8 @@ fun PlayerTransportControls(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        TransportIcon(Icons.Default.SkipPrevious, "Previous", accent, onPrevious)
-        TransportIcon(Icons.Default.Replay10, "Rewind 10 seconds", accent, onRewind10)
+        TransportIcon(painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious)
+        TransportIcon(rememberVectorPainter(Icons.Default.Replay10), "Rewind 10 seconds", accent, onRewind10)
 
         val interactionSource = remember { MutableInteractionSource() }
         val isPressed by interactionSource.collectIsPressedAsState()
@@ -72,24 +73,30 @@ fun PlayerTransportControls(
             ),
         ) {
             Icon(
-                imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                painter = painterResource(
+                    if (isPlaying) R.drawable.ic_glass_pause else R.drawable.ic_glass_play
+                ),
                 contentDescription = if (isPlaying) "Pause" else "Play",
-                modifier = Modifier.size(38.dp),
+                modifier = Modifier
+                    .size(38.dp)
+                    .playerGlass(tint = accent),
             )
         }
 
-        TransportIcon(Icons.Default.Forward10, "Forward 10 seconds", accent, onForward10)
-        TransportIcon(Icons.Default.SkipNext, "Next", accent, onNext)
+        TransportIcon(rememberVectorPainter(Icons.Default.Forward10), "Forward 10 seconds", accent, onForward10)
+        TransportIcon(painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext)
     }
 }
 
 @Composable
-private fun TransportIcon(icon: ImageVector, description: String, tint: Color, onClick: () -> Unit) {
+private fun TransportIcon(painter: Painter, description: String, tint: Color, onClick: () -> Unit) {
     IconButton(onClick = onClick) {
         Icon(
-            imageVector = icon,
+            painter = painter,
             contentDescription = description,
-            modifier = Modifier.size(PlayerDesignTokens.TransportIconSize),
+            modifier = Modifier
+                .size(PlayerDesignTokens.TransportIconSize)
+                .playerGlass(tint = tint),
             tint = tint,
         )
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -72,16 +72,21 @@ fun PlayerTransportControls(
         )
         // Play/pause is a SOLID round glass disc with the play/pause symbol
         // punched out (hollow), so the backdrop shows through the glyph and the
-        // shader bevels both the disc rim and the cut-out edges. A soft drop
-        // shadow (tunable "shadow depth") lifts it off the surface for 3D depth.
+        // shader bevels both the disc rim and the cut-out edges. A drop shadow
+        // lifts it off the surface: shadow depth = darkness, softness = blur,
+        // tint = black -> accent-tinted glow (all tunable in the Studio).
+        val shadowColor = androidx.compose.ui.graphics.lerp(Color.Black, accent, glass.shadowTint)
+            .copy(alpha = 0.25f + 0.6f * glass.shadowDepth)
         Box(
             modifier = Modifier
                 .size(PlayerDesignTokens.PlayButtonSize)
                 .graphicsLayer { scaleX = scale; scaleY = scale }
                 .shadow(
-                    elevation = (glass.shadowDepth * 22f).dp,
+                    elevation = (4f + glass.shadowSoftness * 26f).dp,
                     shape = CircleShape,
                     clip = false,
+                    ambientColor = shadowColor,
+                    spotColor = shadowColor,
                 )
                 .clip(CircleShape)
                 .clickable(

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -112,44 +112,64 @@ fun PlayerTransportControls(
 /**
  * Draws the play/pause round button: a solid [fill] disc with the play triangle
  * or pause bars *punched out* (cleared to transparent) so the glyph reads as a
- * hollow cut-out of the glass. Meant to be drawn inside a layer carrying the
- * [playerGlass] render effect, which bevels the disc edge and the cut-out edges
- * into refractive 3D glass.
+ * hollow cut-out of the glass. A dark, slightly larger copy is laid under the
+ * cut first, so a recessed shadow rim rings the hole and the hollow stays
+ * legible even over a bright backdrop. Meant to be drawn inside a layer carrying
+ * the [playerGlass] render effect, which bevels the disc edge and the cut-out
+ * edges into refractive 3D glass.
  */
 internal fun DrawScope.drawGlassPlayPauseDisc(isPlaying: Boolean, fill: Color) {
     val d = size.minDimension
     val cx = size.width / 2f
     val cy = size.height / 2f
     drawCircle(color = fill, radius = d / 2f)
+    // 1) A dark symbol at full size darkens the region around the cut.
+    drawPlayPauseSymbol(isPlaying, cx, cy, d, scale = 1f, color = Color.Black.copy(alpha = 0.55f), blend = BlendMode.SrcOver)
+    // 2) A smaller punch clears the hole, leaving that dark ring as a recessed
+    //    glass edge around the hollow glyph.
+    drawPlayPauseSymbol(isPlaying, cx, cy, d, scale = 0.78f, color = fill, blend = BlendMode.Clear)
+}
+
+/** One play/pause glyph, scaled about the button centre, for the layered cut. */
+private fun DrawScope.drawPlayPauseSymbol(
+    isPlaying: Boolean,
+    cx: Float,
+    cy: Float,
+    d: Float,
+    scale: Float,
+    color: Color,
+    blend: BlendMode,
+) {
     if (isPlaying) {
-        val barW = d * 0.11f
-        val barH = d * 0.34f
-        val gap = d * 0.10f
-        val corner = CornerRadius(barW * 0.42f, barW * 0.42f)
+        val barW = d * 0.11f * scale
+        val barH = d * 0.34f * scale
+        val gap = d * 0.10f * scale
+        val corner = CornerRadius(d * 0.046f * scale, d * 0.046f * scale)
         drawRoundRect(
-            color = fill,
+            color = color,
             topLeft = Offset(cx - gap / 2f - barW, cy - barH / 2f),
             size = Size(barW, barH),
             cornerRadius = corner,
-            blendMode = BlendMode.Clear,
+            blendMode = blend,
         )
         drawRoundRect(
-            color = fill,
+            color = color,
             topLeft = Offset(cx + gap / 2f, cy - barH / 2f),
             size = Size(barW, barH),
             cornerRadius = corner,
-            blendMode = BlendMode.Clear,
+            blendMode = blend,
         )
     } else {
-        val w = d * 0.32f
-        val h = d * 0.34f
+        val w = d * 0.32f * scale
+        val h = d * 0.34f * scale
+        val tcx = cx - d * 0.32f * 0.06f // optical-centre (scale-independent so passes stay concentric)
         val tri = Path().apply {
-            moveTo(cx - w * 0.40f, cy - h / 2f)
-            lineTo(cx - w * 0.40f, cy + h / 2f)
-            lineTo(cx + w * 0.60f, cy)
+            moveTo(tcx - w * 0.40f, cy - h / 2f)
+            lineTo(tcx - w * 0.40f, cy + h / 2f)
+            lineTo(tcx + w * 0.60f, cy)
             close()
         }
-        drawPath(tri, color = fill, blendMode = BlendMode.Clear)
+        drawPath(tri, color = color, blendMode = blend)
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -44,19 +44,17 @@ import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
 
 /**
- * Primary transport row: previous · rewind 10s · play/pause · forward 10s ·
- * next. The icons are solid glyph shapes and carry the refractive [playerGlass]
- * treatment (tunable in the Studio's Player Glass tab), so the buttons read as
- * 3D liquid glass like the lyrics.
+ * Primary transport row: previous · play/pause · next. The icons are solid glyph
+ * shapes and carry the refractive [playerGlass] treatment (tunable in the
+ * Studio's Player Glass tab), so the buttons read as 3D liquid glass like the
+ * lyrics.
  */
 @Composable
 fun PlayerTransportControls(
     isPlaying: Boolean,
     accent: Color,
     onPrevious: () -> Unit,
-    onRewind10: () -> Unit,
     onPlayPause: () -> Unit,
-    onForward10: () -> Unit,
     onNext: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -70,7 +68,6 @@ fun PlayerTransportControls(
             painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, onPrevious,
             size = PlayerDesignTokens.SkipIconSize,
         )
-        TransportIcon(painterResource(R.drawable.ic_glass_replay_10), "Rewind 10 seconds", accent, onRewind10)
 
         val interactionSource = remember { MutableInteractionSource() }
         val isPressed by interactionSource.collectIsPressedAsState()
@@ -124,7 +121,6 @@ fun PlayerTransportControls(
             }
         }
 
-        TransportIcon(painterResource(R.drawable.ic_glass_forward_10), "Forward 10 seconds", accent, onForward10)
         TransportIcon(
             painterResource(R.drawable.ic_glass_skip_next), "Next", accent, onNext,
             size = PlayerDesignTokens.SkipIconSize,
@@ -219,7 +215,7 @@ internal fun BoxScope.GlassDropShadow(
 }
 
 @Composable
-private fun TransportIcon(
+internal fun TransportIcon(
     painter: Painter,
     description: String,
     tint: Color,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -112,22 +112,18 @@ fun PlayerTransportControls(
 /**
  * Draws the play/pause round button: a solid [fill] disc with the play triangle
  * or pause bars *punched out* (cleared to transparent) so the glyph reads as a
- * hollow cut-out of the glass. A dark, slightly larger copy is laid under the
- * cut first, so a recessed shadow rim rings the hole and the hollow stays
- * legible even over a bright backdrop. Meant to be drawn inside a layer carrying
- * the [playerGlass] render effect, which bevels the disc edge and the cut-out
- * edges into refractive 3D glass.
+ * clean hollow cut-out of the glass — a single beveled glass edge, no double
+ * outline. Meant to be drawn inside a layer carrying the [playerGlass] render
+ * effect, which bevels the disc edge and the cut-out edges into refractive 3D
+ * glass.
  */
 internal fun DrawScope.drawGlassPlayPauseDisc(isPlaying: Boolean, fill: Color) {
     val d = size.minDimension
     val cx = size.width / 2f
     val cy = size.height / 2f
     drawCircle(color = fill, radius = d / 2f)
-    // 1) A dark symbol at full size darkens the region around the cut.
-    drawPlayPauseSymbol(isPlaying, cx, cy, d, scale = 1f, color = Color.Black.copy(alpha = 0.55f), blend = BlendMode.SrcOver)
-    // 2) A smaller punch clears the hole, leaving that dark ring as a recessed
-    //    glass edge around the hollow glyph.
-    drawPlayPauseSymbol(isPlaying, cx, cy, d, scale = 0.78f, color = fill, blend = BlendMode.Clear)
+    // One clean punch → the shader bevels a single glass edge around the hollow.
+    drawPlayPauseSymbol(isPlaying, cx, cy, d, scale = 1f, color = fill, blend = BlendMode.Clear)
 }
 
 /** One play/pause glyph, scaled about the button centre, for the layered cut. */

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -133,6 +133,8 @@ class PlayerViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val playerBlurredBackground: StateFlow<Boolean> = preferences.playerBlurredBackground
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+    val playerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = preferences.playerGlass
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
     val lyricsFx: StateFlow<LyricsFxSettings> = preferences.lyricsFx
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LyricsFxSettings())
     val nowPlayingViewMode: StateFlow<NowPlayingViewMode> = preferences.nowPlayingViewMode

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -135,6 +135,8 @@ class PlayerViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val playerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = preferences.playerGlass
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
+    val miniPlayerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = preferences.miniPlayerGlass
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
     val lyricsFx: StateFlow<LyricsFxSettings> = preferences.lyricsFx
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LyricsFxSettings())
     val nowPlayingViewMode: StateFlow<NowPlayingViewMode> = preferences.nowPlayingViewMode

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -126,6 +126,8 @@ class PlayerViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 80)
     val playerDynamicColor: StateFlow<Boolean> = preferences.playerDynamicColor
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+    val playerBlurredBackground: StateFlow<Boolean> = preferences.playerBlurredBackground
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val lyricsFx: StateFlow<LyricsFxSettings> = preferences.lyricsFx
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LyricsFxSettings())
     val nowPlayingViewMode: StateFlow<NowPlayingViewMode> = preferences.nowPlayingViewMode

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -64,6 +64,7 @@ class PlayerViewModel @Inject constructor(
     private val bypassVolumeController: tf.monochrome.android.audio.usb.BypassVolumeController,
     private val inflatorEffect: tf.monochrome.android.audio.dsp.oxford.InflatorEffect,
     private val compressorEffect: tf.monochrome.android.audio.dsp.oxford.CompressorEffect,
+    private val nowPlayingLyrics: tf.monochrome.android.player.NowPlayingLyricsHolder,
 ) : ViewModel() {
 
     /**
@@ -222,6 +223,10 @@ class PlayerViewModel @Inject constructor(
         connectToService()
         startPositionPolling()
         observeCurrentTrackMeta()
+        // Mirror the now-playing lyrics + position into the app-scoped holder so
+        // other screens (the Lyrics FX Studio preview) can show the real lyrics.
+        viewModelScope.launch { _currentLyrics.collect { nowPlayingLyrics.setLyrics(it) } }
+        viewModelScope.launch { _positionMs.collect { nowPlayingLyrics.setPosition(it) } }
         viewModelScope.launch {
             downloadManager.observeAllActiveDownloads().collectLatest { active ->
                 _activeDownloads.value = active

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -126,6 +126,11 @@ class PlayerViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 80)
     val playerDynamicColor: StateFlow<Boolean> = preferences.playerDynamicColor
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+    // Master album-colour switch (Appearance › Dynamic Colors). When off, NO
+    // surface tints from album art — including the player — so turning it off
+    // makes everything static, not just the app-wide theme.
+    val dynamicColors: StateFlow<Boolean> = preferences.dynamicColors
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val playerBlurredBackground: StateFlow<Boolean> = preferences.playerBlurredBackground
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val lyricsFx: StateFlow<LyricsFxSettings> = preferences.lyricsFx

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
@@ -38,9 +38,15 @@ class ProfileViewModel @Inject constructor(
             _isSyncing.value = true
             _syncStatus.value = null
             try {
-                supabaseSyncRepository.pushAll()
-                supabaseSyncRepository.pullAll()
-                _syncStatus.value = "Sync complete"
+                // Each section swallows its own error, so a failure is only
+                // visible via these returned section names — don't report
+                // success unless both came back clean.
+                val failed = (supabaseSyncRepository.pushAll() + supabaseSyncRepository.pullAll()).distinct()
+                _syncStatus.value = if (failed.isEmpty()) {
+                    "Sync complete"
+                } else {
+                    "Sync finished with issues: ${failed.joinToString(", ")}"
+                }
             } catch (e: Exception) {
                 _syncStatus.value = "Sync failed: ${e.message ?: "unknown error"}"
             } finally {

--- a/app/src/main/java/tf/monochrome/android/ui/settings/DirectionDial.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/DirectionDial.kt
@@ -1,0 +1,89 @@
+package tf.monochrome.android.ui.settings
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * A full-360° direction joystick: drag anywhere on the dial to aim it. 0° = up,
+ * increasing clockwise — the same convention the god-ray shader uses. Unlike the
+ * bounded [tf.monochrome.android.ui.mixer.PanKnob], the touch angle is read
+ * absolutely with no clamp so it spins the whole way round.
+ */
+@Composable
+internal fun DirectionDial(
+    angleDeg: Float,
+    onAngleChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary,
+) {
+    val trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.16f)
+    val dotColor = if (accentColor.luminance() > 0.55f) Color.Black else Color.White
+
+    Canvas(
+        modifier = modifier
+            .size(64.dp)
+            .pointerInput(Unit) {
+                val cx = size.width / 2f
+                val cy = size.height / 2f
+                fun emit(pos: Offset) {
+                    // atan2(x, -y): 0 = up (12 o'clock), increasing clockwise.
+                    val deg = (Math.toDegrees(
+                        atan2((pos.x - cx).toDouble(), -(pos.y - cy).toDouble())
+                    ).toFloat() + 360f) % 360f
+                    onAngleChange(deg)
+                }
+                detectDragGestures(onDragStart = { emit(it) }) { change, _ ->
+                    change.consume()
+                    emit(change.position)
+                }
+            },
+    ) {
+        val cx = size.width / 2f
+        val cy = size.height / 2f
+        val radius = size.minDimension / 2f - 5.dp.toPx()
+
+        // Full-circle track.
+        drawCircle(
+            color = trackColor,
+            radius = radius,
+            center = Offset(cx, cy),
+            style = Stroke(width = 2.5.dp.toPx()),
+        )
+
+        // Direction: 0° = up, clockwise → (sin, -cos).
+        val rad = Math.toRadians(angleDeg.toDouble()).toFloat()
+        val dx = sin(rad)
+        val dy = -cos(rad)
+
+        // Needle from centre to the rim.
+        drawLine(
+            color = accentColor,
+            start = Offset(cx, cy),
+            end = Offset(cx + dx * radius, cy + dy * radius),
+            strokeWidth = 3.dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+
+        // Handle dot at the rim.
+        val handle = Offset(cx + dx * radius, cy + dy * radius)
+        drawCircle(color = accentColor, radius = 7.dp.toPx(), center = handle)
+        drawCircle(color = dotColor, radius = 4.dp.toPx(), center = handle)
+
+        // Small hub.
+        drawCircle(color = accentColor, radius = 3.dp.toPx(), center = Offset(cx, cy))
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1,6 +1,7 @@
 package tf.monochrome.android.ui.settings
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -61,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -748,10 +750,21 @@ private fun PlayerGlassTab(
                         painterResource(R.drawable.ic_glass_skip_previous), null,
                         Modifier.size(34.dp).playerGlass(accent), tint = accent,
                     )
-                    Icon(
-                        painterResource(R.drawable.ic_glass_play), null,
-                        Modifier.size(58.dp).playerGlass(accent), tint = accent,
-                    )
+                    // Hollow glass ring + centred glyph, matching the real button.
+                    Box(Modifier.size(64.dp), contentAlignment = Alignment.Center) {
+                        Canvas(Modifier.fillMaxSize().playerGlass(accent)) {
+                            val stroke = size.minDimension * 0.12f
+                            drawCircle(
+                                color = accent,
+                                radius = (size.minDimension - stroke) / 2f,
+                                style = Stroke(width = stroke),
+                            )
+                        }
+                        Icon(
+                            painterResource(R.drawable.ic_glass_play), null,
+                            Modifier.size(30.dp).playerGlass(accent), tint = accent,
+                        )
+                    }
                     Icon(
                         painterResource(R.drawable.ic_glass_skip_next), null,
                         Modifier.size(34.dp).playerGlass(accent), tint = accent,
@@ -787,6 +800,14 @@ private fun PlayerGlassTab(
             "Chromatic aberration", "${(glass.dispersion * 100).toInt()}%", glass.dispersion, 0f..2f,
             description = "Colour fringing at the refracting edges.",
         ) { onUpdate { g -> g.copy(dispersion = it) } }
+        FxSlider(
+            "Roundness", "%.2f".format(glass.roundness), glass.roundness, 0.5f..2f,
+            description = "Rolls the glass edge from a sharp bevel to a round, pillowy shoulder.",
+        ) { onUpdate { g -> g.copy(roundness = it) } }
+        FxSlider(
+            "Depth (profondeur)", "%.2f".format(glass.depth), glass.depth, 0.5f..2f,
+            description = "How thick and deep the relief reads — higher pops the buttons more in 3D.",
+        ) { onUpdate { g -> g.copy(depth = it) } }
         FxSlider(
             "Per-pixel samples",
             "${glass.sampleRings} (${when (glass.sampleRings) { 1 -> 5; 2 -> 9; else -> 13 }} taps)",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -59,6 +59,7 @@ import androidx.navigation.NavController
 import android.content.Context
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -113,12 +114,14 @@ class LyricsFxStudioViewModel @Inject constructor(
         refreshFonts()
     }
 
-    /** Re-list the imported font files (call when the Font section is shown). */
+    /** Re-list the imported font files off the main thread (directory I/O). */
     fun refreshFonts() {
-        _availableFonts.value = File(context.filesDir, "custom_fonts").listFiles()
-            ?.filter { it.isFile && (it.extension.equals("ttf", true) || it.extension.equals("otf", true)) }
-            ?.sortedBy { it.name.lowercase(java.util.Locale.US) }
-            ?: emptyList()
+        viewModelScope.launch(Dispatchers.IO) {
+            _availableFonts.value = File(context.filesDir, "custom_fonts").listFiles()
+                ?.filter { it.isFile && (it.extension.equals("ttf", true) || it.extension.equals("otf", true)) }
+                ?.sortedBy { it.name.lowercase(java.util.Locale.US) }
+                ?: emptyList()
+        }
     }
 
     fun update(transform: (LyricsFxSettings) -> LyricsFxSettings) {
@@ -160,6 +163,10 @@ fun LyricsFxStudioScreen(
 ) {
     val fx by viewModel.fx.collectAsState()
     val fonts by viewModel.availableFonts.collectAsState()
+
+    // Re-list imported fonts whenever the custom-font toggle turns on, so a font
+    // imported in Settings › Appearance since this screen opened shows up.
+    LaunchedEffect(fx.customFont) { if (fx.customFont) viewModel.refreshFonts() }
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -63,9 +63,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -729,20 +731,18 @@ private fun PlayerGlassTab(
     onUpdate: ((PlayerGlassSettings) -> PlayerGlassSettings) -> Unit,
 ) {
     val accent = MaterialTheme.colorScheme.primary
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Pinned preview — stays locked in view while you tune the sliders,
+        // just like the Lyrics editor.
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
         Spacer(Modifier.height(12.dp))
-        // Live preview: the real transport icons under the current button glass.
+        // Live preview: the real transport buttons under the current button glass.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(150.dp)
                 .clip(RoundedCornerShape(16.dp))
-                .background(Color(0xFF121016)),
+                .background(previewBackground(accent)),
             contentAlignment = Alignment.Center,
         ) {
             CompositionLocalProvider(LocalPlayerGlass provides glass) {
@@ -789,7 +789,16 @@ private fun PlayerGlassTab(
                 modifier = Modifier.align(Alignment.TopStart).padding(10.dp),
             )
         }
+        }
 
+        // Controls scroll below the pinned preview.
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+        ) {
         StudioSection("Player Glass")
         FxToggle(
             "Button liquid glass", glass.enabled,
@@ -830,8 +839,22 @@ private fun PlayerGlassTab(
             description = "Bevel quality vs GPU cost.",
         ) { onUpdate { g -> g.copy(sampleRings = it.toInt()) } }
         Spacer(Modifier.height(48.dp))
+        }
     }
 }
+
+/**
+ * Preview backdrop tinted with the CURRENT theme/album [accent] — a dark
+ * vertical wash of the live colour, so the Studio previews sit on the same
+ * colour the player does instead of a fixed near-black.
+ */
+private fun previewBackground(accent: Color): Brush =
+    Brush.verticalGradient(
+        listOf(
+            lerp(Color.Black, accent, 0.34f),
+            lerp(Color.Black, accent, 0.10f),
+        ),
+    )
 
 @Composable
 private fun StudioPreview(
@@ -851,7 +874,7 @@ private fun StudioPreview(
             .fillMaxWidth()
             .height(190.dp)
             .clip(RoundedCornerShape(16.dp))
-            .background(Color(0xFF121016)),
+            .background(previewBackground(accent)),
         contentAlignment = Alignment.Center,
     ) {
         CompositionLocalProvider(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -148,6 +148,12 @@ class LyricsFxStudioViewModel @Inject constructor(
     private var playerGlassTouched = false
     private var playerGlassPersistJob: Job? = null
 
+    /** Mini-player glass settings — the "Mini Player" tab (its own blob, same shape). */
+    private val _miniPlayerGlass = MutableStateFlow(tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
+    val miniPlayerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = _miniPlayerGlass.asStateFlow()
+    private var miniPlayerGlassTouched = false
+    private var miniPlayerGlassPersistJob: Job? = null
+
     /** Fonts the user has imported (Settings › Appearance copies them here). */
     private val _availableFonts = MutableStateFlow<List<File>>(emptyList())
     val availableFonts: StateFlow<List<File>> = _availableFonts.asStateFlow()
@@ -174,6 +180,10 @@ class LyricsFxStudioViewModel @Inject constructor(
         viewModelScope.launch {
             val pg = preferences.playerGlass.first()
             if (!playerGlassTouched) _playerGlass.value = pg
+        }
+        viewModelScope.launch {
+            val mpg = preferences.miniPlayerGlass.first()
+            if (!miniPlayerGlassTouched) _miniPlayerGlass.value = mpg
         }
         refreshFonts()
     }
@@ -244,6 +254,38 @@ class LyricsFxStudioViewModel @Inject constructor(
         val toAdd = decoded.copy(name = name)
         viewModelScope.launch { preferences.setCustomPlayerGlassPresets(customPlayerGlassPresets.value + toAdd) }
         return name
+    }
+
+    // ── Mini-player glass (same controls + shared theme pool as Player Glass) ──
+
+    fun updateMiniPlayerGlass(transform: (tf.monochrome.android.domain.model.PlayerGlassSettings) -> tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        miniPlayerGlassTouched = true
+        _miniPlayerGlass.value = transform(_miniPlayerGlass.value).clamped()
+        miniPlayerGlassPersistJob?.cancel()
+        miniPlayerGlassPersistJob = viewModelScope.launch {
+            delay(200)
+            preferences.setMiniPlayerGlass(_miniPlayerGlass.value)
+        }
+    }
+
+    /** Apply a theme to the mini player — changes the material, keeps colour/perf. */
+    fun applyMiniPlayerGlassPreset(preset: tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        miniPlayerGlassTouched = true
+        val next = preset.withPersonalFrom(_miniPlayerGlass.value).clamped()
+        _miniPlayerGlass.value = next
+        miniPlayerGlassPersistJob?.cancel()
+        viewModelScope.launch { preferences.setMiniPlayerGlass(next) }
+    }
+
+    /** Save the current mini-player glass as a named theme (into the shared pool). */
+    fun saveMiniPlayerGlassPreset(name: String) {
+        val clean = name.trim()
+        if (clean.isEmpty()) return
+        val preset = tf.monochrome.android.domain.model.PlayerGlassPreset(clean, _miniPlayerGlass.value.clamped())
+        viewModelScope.launch {
+            val current = customPlayerGlassPresets.value.filterNot { it.name.equals(clean, ignoreCase = true) }
+            preferences.setCustomPlayerGlassPresets(current + preset)
+        }
     }
 
     fun applyPreset(preset: LyricsFxSettings) {
@@ -322,9 +364,10 @@ fun LyricsFxStudioScreen(
     val currentLyrics by viewModel.currentLyrics.collectAsState()
     val customPresets by viewModel.customPresets.collectAsState()
     val playerGlass by viewModel.playerGlass.collectAsState()
+    val miniPlayerGlass by viewModel.miniPlayerGlass.collectAsState()
     val context = LocalContext.current
 
-    // Which studio tab: 0 = Lyrics, 1 = Player Glass.
+    // Which studio tab: 0 = Lyrics, 1 = Player Glass, 2 = Mini Player.
     var selectedTab by remember { mutableStateOf(0) }
 
     // Preset save / import / share dialog state.
@@ -353,20 +396,36 @@ fun LyricsFxStudioScreen(
         ) {
             Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text("Lyrics") })
             Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text("Player Glass") })
+            Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }, text = { Text("Mini Player") })
         }
 
-        if (selectedTab == 1) {
+        if (selectedTab == 1 || selectedTab == 2) {
+            // Both glass tabs share the same controls, preview, and theme pool;
+            // only which settings blob they edit differs.
             val customGlassPresets by viewModel.customPlayerGlassPresets.collectAsState()
-            PlayerGlassTab(
-                glass = playerGlass,
-                customPresets = customGlassPresets,
-                onUpdate = { viewModel.updatePlayerGlass(it) },
-                onApplyPreset = { viewModel.applyPlayerGlassPreset(it) },
-                onSavePreset = { viewModel.savePlayerGlassPreset(it) },
-                onDeletePreset = { viewModel.deletePlayerGlassPreset(it) },
-                onExportPreset = { viewModel.exportPlayerGlassPreset(it) },
-                onImportPreset = { viewModel.importPlayerGlassPresetCode(it) },
-            )
+            if (selectedTab == 1) {
+                PlayerGlassTab(
+                    glass = playerGlass,
+                    customPresets = customGlassPresets,
+                    onUpdate = { viewModel.updatePlayerGlass(it) },
+                    onApplyPreset = { viewModel.applyPlayerGlassPreset(it) },
+                    onSavePreset = { viewModel.savePlayerGlassPreset(it) },
+                    onDeletePreset = { viewModel.deletePlayerGlassPreset(it) },
+                    onExportPreset = { viewModel.exportPlayerGlassPreset(it) },
+                    onImportPreset = { viewModel.importPlayerGlassPresetCode(it) },
+                )
+            } else {
+                PlayerGlassTab(
+                    glass = miniPlayerGlass,
+                    customPresets = customGlassPresets,
+                    onUpdate = { viewModel.updateMiniPlayerGlass(it) },
+                    onApplyPreset = { viewModel.applyMiniPlayerGlassPreset(it) },
+                    onSavePreset = { viewModel.saveMiniPlayerGlassPreset(it) },
+                    onDeletePreset = { viewModel.deletePlayerGlassPreset(it) },
+                    onExportPreset = { viewModel.exportPlayerGlassPreset(it) },
+                    onImportPreset = { viewModel.importPlayerGlassPresetCode(it) },
+                )
+            }
             return@Column
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -61,6 +62,7 @@ import tf.monochrome.android.ui.player.LocalLyricsFx
 import tf.monochrome.android.ui.player.LyricGlyphAnchors
 import tf.monochrome.android.ui.player.LyricsFxLayer
 import tf.monochrome.android.ui.player.bassBeat
+import tf.monochrome.android.ui.player.liquidGlass
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.exp
@@ -223,6 +225,33 @@ fun LyricsFxStudioScreen(
             }
 
             item {
+                StudioSection("Liquid Glass")
+                FxToggle(
+                    "Liquid glass", fx.liquidGlass,
+                    description = "Refractive glass relight of the lyric surface (needs Android 13+).",
+                ) { viewModel.update { s -> s.copy(liquidGlass = it) } }
+                FxSlider(
+                    "Glass opacity", "${(fx.glassBodyOpacity * 100).toInt()}%",
+                    fx.glassBodyOpacity, 0.2f..1f,
+                    description = "Lower lets more of the backdrop read through the letters.",
+                ) { viewModel.update { s -> s.copy(glassBodyOpacity = it) } }
+                FxSlider(
+                    "Refraction", "%.2f".format(fx.glassRefraction), fx.glassRefraction, 0f..0.4f,
+                    description = "How hard the beveled edges lens the backdrop behind them.",
+                ) { viewModel.update { s -> s.copy(glassRefraction = it) } }
+                FxSlider(
+                    "Edge highlight", "${(fx.glassRimBrightness * 100).toInt()}%",
+                    fx.glassRimBrightness, 0f..2f,
+                    description = "Brightness of the specular glass rim.",
+                ) { viewModel.update { s -> s.copy(glassRimBrightness = it) } }
+                FxSlider(
+                    "Chromatic aberration", "${(fx.glassDispersion * 100).toInt()}%",
+                    fx.glassDispersion, 0f..2f,
+                    description = "Colour fringing where the edges refract.",
+                ) { viewModel.update { s -> s.copy(glassDispersion = it) } }
+            }
+
+            item {
                 Spacer(Modifier.height(20.dp))
                 OutlinedButton(
                     onClick = { viewModel.applyPreset(LyricsFxSettings.DEFAULT) },
@@ -271,7 +300,9 @@ private fun StudioPreview(fx: LyricsFxSettings) {
                     fontWeight = FontWeight.ExtraBold,
                 ),
                 color = accent,
-                modifier = Modifier.bassBeat(pulse, { 1f }, fx, anchors),
+                modifier = Modifier
+                    .liquidGlass(tint = accent)
+                    .bassBeat(pulse, { 1f }, fx, anchors),
                 anchors = anchors,
             )
         }
@@ -335,6 +366,33 @@ private fun StudioSection(title: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(bottom = 4.dp),
     )
+}
+
+@Composable
+private fun FxToggle(
+    label: String,
+    checked: Boolean,
+    description: String? = null,
+    onChange: (Boolean) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            Switch(checked = checked, onCheckedChange = onChange)
+        }
+        description?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -69,12 +69,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 import tf.monochrome.android.data.preferences.PreferencesManager
+import tf.monochrome.android.domain.model.Lyrics
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.ui.player.Letters3DLine
+import tf.monochrome.android.ui.player.LocalBeatPulse
 import tf.monochrome.android.ui.player.LocalLyricGlyphAnchors
 import tf.monochrome.android.ui.player.LocalLyricsFx
 import tf.monochrome.android.ui.player.LyricGlyphAnchors
 import tf.monochrome.android.ui.player.LyricsFxLayer
+import tf.monochrome.android.ui.player.SyncedLyricsView
 import tf.monochrome.android.ui.player.bassBeat
 import tf.monochrome.android.ui.player.fxaa
 import tf.monochrome.android.ui.player.liquidGlass
@@ -88,7 +91,11 @@ import kotlin.math.exp
 class LyricsFxStudioViewModel @Inject constructor(
     private val preferences: PreferencesManager,
     @ApplicationContext private val context: Context,
+    nowPlayingLyrics: tf.monochrome.android.player.NowPlayingLyricsHolder,
 ) : ViewModel() {
+    /** The currently-playing lyrics + position, so the preview can show them live. */
+    val currentLyrics: StateFlow<tf.monochrome.android.domain.model.Lyrics?> = nowPlayingLyrics.lyrics
+    val currentPositionMs: StateFlow<Long> = nowPlayingLyrics.positionMs
     // An in-memory working copy is the source of truth for the Studio UI and the
     // live preview, so every slider frame updates instantly with no I/O. A slider
     // drag fires dozens of times a second; persisting each frame — JSON-encode +
@@ -163,6 +170,7 @@ fun LyricsFxStudioScreen(
 ) {
     val fx by viewModel.fx.collectAsState()
     val fonts by viewModel.availableFonts.collectAsState()
+    val currentLyrics by viewModel.currentLyrics.collectAsState()
 
     // Re-list imported fonts whenever the custom-font toggle turns on, so a font
     // imported in Settings › Appearance since this screen opened shows up.
@@ -182,7 +190,7 @@ fun LyricsFxStudioScreen(
         // Preview + presets are pinned above the scrolling sliders, so the
         // live example stays locked in view while you tune every parameter.
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            StudioPreview(fx)
+            StudioPreview(fx, currentLyrics, viewModel.currentPositionMs)
             Spacer(Modifier.height(12.dp))
             Row(
                 modifier = Modifier
@@ -216,6 +224,15 @@ fun LyricsFxStudioScreen(
                 FxSlider("Letter spacing", "%.2f sp".format(fx.letterSpacingSp), fx.letterSpacingSp, -1f..1f) {
                     viewModel.update { s -> s.copy(letterSpacingSp = it) }
                 }
+                FxSlider(
+                    "Edge margin", "%.0f dp".format(fx.edgeMarginDp), fx.edgeMarginDp, 0f..48f,
+                    description = "Side spacing between the lyrics and the screen edges.",
+                ) { viewModel.update { s -> s.copy(edgeMarginDp = it) } }
+                FxSlider(
+                    "Lines per block", "${fx.maxWrapLines}" + if (fx.maxWrapLines == 1) " (no wrap)" else "",
+                    fx.maxWrapLines.toFloat(), 1f..3f, steps = 1,
+                    description = "How many rows a long line may wrap to before it shrinks to fit.",
+                ) { viewModel.update { s -> s.copy(maxWrapLines = it.toInt()) } }
             }
 
             item {
@@ -436,10 +453,17 @@ fun LyricsFxStudioScreen(
  * the font element via [bassBeat] — exactly as it is on the active lyric line.
  */
 @Composable
-private fun StudioPreview(fx: LyricsFxSettings) {
+private fun StudioPreview(
+    fx: LyricsFxSettings,
+    lyrics: Lyrics?,
+    positionMs: kotlinx.coroutines.flow.StateFlow<Long>,
+) {
     val pulse = rememberSyntheticKickPulse(fx)
     val anchors = remember { LyricGlyphAnchors() }
     val accent = MaterialTheme.colorScheme.primary
+    // Show the real currently-playing lyrics when there are synced lines; else a
+    // synthetic sample so the preview is never empty.
+    val playing = lyrics?.takeIf { it.isSynced && it.lines.isNotEmpty() }
 
     Box(
         modifier = Modifier
@@ -452,30 +476,41 @@ private fun StudioPreview(fx: LyricsFxSettings) {
         CompositionLocalProvider(
             LocalLyricsFx provides fx,
             LocalLyricGlyphAnchors provides anchors,
+            // Drive the beat FX from the synthetic kick even for real lyrics
+            // (there's no live audio analyzer on this screen).
+            LocalBeatPulse provides pulse,
         ) {
-            // Same pipeline as the player: the ray/glow FX layer fills the
-            // frame and draws at each glyph's reported position, while the
-            // text element pumps and publishes its glyphs.
+            // The ray/glow FX layer draws at each active glyph's reported position.
             LyricsFxLayer(anchors = anchors, pulse = pulse, accent = accent, fx = fx)
-            Letters3DLine(
-                text = "Feel the beat tonight",
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontSize = fx.fontSizeSp.sp,
-                    lineHeight = (fx.fontSizeSp * 1.26f).sp,
-                    letterSpacing = fx.letterSpacingSp.sp,
-                    fontWeight = FontWeight.ExtraBold,
-                ).withLyricFont(rememberLyricFontFamily(fx)),
-                color = accent,
-                modifier = Modifier
-                    .fxaa()
-                    .liquidGlass(tint = accent)
-                    .bassBeat(pulse, { 1f }, fx, anchors),
-                anchors = anchors,
-                fontSizeSp = fx.fontSizeSp,
-            )
+            if (playing != null) {
+                // Exactly the production renderer, on the real lyric lines.
+                SyncedLyricsView(
+                    lines = playing.lines,
+                    positionMs = positionMs,
+                    accent = accent,
+                    onSeekTo = {},
+                )
+            } else {
+                Letters3DLine(
+                    text = "Feel the beat tonight",
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = fx.fontSizeSp.sp,
+                        lineHeight = (fx.fontSizeSp * 1.26f).sp,
+                        letterSpacing = fx.letterSpacingSp.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                    ).withLyricFont(rememberLyricFontFamily(fx)),
+                    color = accent,
+                    modifier = Modifier
+                        .fxaa()
+                        .liquidGlass(tint = accent)
+                        .bassBeat(pulse, { 1f }, fx, anchors),
+                    anchors = anchors,
+                    fontSizeSp = fx.fontSizeSp,
+                )
+            }
         }
         Text(
-            text = "PREVIEW · 120 BPM",
+            text = if (playing != null) "PREVIEW · now playing" else "PREVIEW · 120 BPM",
             style = MaterialTheme.typography.labelSmall,
             color = Color.White.copy(alpha = 0.35f),
             modifier = Modifier

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -14,14 +14,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -29,9 +36,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -49,6 +58,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -66,10 +76,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.io.File
 import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.domain.model.Lyrics
+import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.ui.player.Letters3DLine
 import tf.monochrome.android.ui.player.LocalBeatPulse
@@ -111,6 +123,12 @@ class LyricsFxStudioViewModel @Inject constructor(
     private val _availableFonts = MutableStateFlow<List<File>>(emptyList())
     val availableFonts: StateFlow<List<File>> = _availableFonts.asStateFlow()
 
+    /** The user's own saved presets, alongside the built-in ones. */
+    val customPresets: StateFlow<List<tf.monochrome.android.domain.model.LyricsFxPreset>> =
+        preferences.customLyricsFxPresets.stateIn(
+            viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList(),
+        )
+
     init {
         viewModelScope.launch {
             // Seed once from the persisted settings; after the user starts tuning,
@@ -147,6 +165,46 @@ class LyricsFxStudioViewModel @Inject constructor(
         viewModelScope.launch { preferences.setLyricsFx(next) }
     }
 
+    /**
+     * Save the current settings as a named preset. A blank name is ignored; an
+     * existing name is overwritten so re-saving updates in place.
+     */
+    fun saveCurrentAsPreset(name: String) {
+        val clean = name.trim()
+        if (clean.isEmpty()) return
+        val preset = tf.monochrome.android.domain.model.LyricsFxPreset(clean, _fx.value.clamped())
+        viewModelScope.launch {
+            val current = customPresets.value.filterNot { it.name.equals(clean, ignoreCase = true) }
+            preferences.setCustomLyricsFxPresets(current + preset)
+        }
+    }
+
+    fun deletePreset(name: String) {
+        viewModelScope.launch {
+            preferences.setCustomLyricsFxPresets(customPresets.value.filterNot { it.name == name })
+        }
+    }
+
+    /** The shareable code for a preset (prefix + compact JSON). */
+    fun exportPreset(preset: tf.monochrome.android.domain.model.LyricsFxPreset): String =
+        tf.monochrome.android.domain.model.LyricsFxPreset.encode(preset)
+
+    /**
+     * Import a preset from a shared code. Returns the imported name on success,
+     * or null if the text wasn't a valid preset. A clashing name is de-duped
+     * with a numeric suffix so an import never silently overwrites.
+     */
+    fun importPresetCode(code: String): String? {
+        val decoded = tf.monochrome.android.domain.model.LyricsFxPreset.decode(code) ?: return null
+        val existing = customPresets.value.map { it.name }.toSet()
+        var name = decoded.name
+        var n = 2
+        while (name in existing) { name = "${decoded.name} ($n)"; n++ }
+        val toAdd = decoded.copy(name = name)
+        viewModelScope.launch { preferences.setCustomLyricsFxPresets(customPresets.value + toAdd) }
+        return name
+    }
+
     private fun schedulePersist() {
         persistJob?.cancel()
         persistJob = viewModelScope.launch {
@@ -171,6 +229,13 @@ fun LyricsFxStudioScreen(
     val fx by viewModel.fx.collectAsState()
     val fonts by viewModel.availableFonts.collectAsState()
     val currentLyrics by viewModel.currentLyrics.collectAsState()
+    val customPresets by viewModel.customPresets.collectAsState()
+    val context = LocalContext.current
+
+    // Preset save / import / share dialog state.
+    var showSaveDialog by remember { mutableStateOf(false) }
+    var showImportDialog by remember { mutableStateOf(false) }
+    var presetAction by remember { mutableStateOf<LyricsFxPreset?>(null) }
 
     // Re-list imported fonts whenever the custom-font toggle turns on, so a font
     // imported in Settings › Appearance since this screen opened shows up.
@@ -192,6 +257,32 @@ fun LyricsFxStudioScreen(
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             StudioPreview(fx, currentLyrics, viewModel.currentPositionMs)
             Spacer(Modifier.height(12.dp))
+
+            // Preset bar header: a Save button (store the current look) and an
+            // Import button (paste a shared preset code) beside the "Presets" label.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Presets",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { showSaveDialog = true }) {
+                    Icon(Icons.Default.Save, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Save")
+                }
+                TextButton(onClick = { showImportDialog = true }) {
+                    Icon(Icons.Default.FileDownload, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Import")
+                }
+            }
+            Spacer(Modifier.height(6.dp))
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -209,7 +300,142 @@ fun LyricsFxStudioScreen(
                         ),
                     )
                 }
+                // The user's own saved presets. Tapping applies; the trailing
+                // icon opens a Share / Delete sheet for that preset.
+                customPresets.forEach { saved ->
+                    FilterChip(
+                        selected = fx.matchesPreset(saved.settings),
+                        onClick = { viewModel.applyPreset(saved.settings) },
+                        label = { Text(saved.name) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Share,
+                                contentDescription = "Manage ${saved.name}",
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .clickable { presetAction = saved },
+                            )
+                        },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                    )
+                }
             }
+        }
+
+        // ── Save current settings as a named preset ─────────────────────────
+        if (showSaveDialog) {
+            var name by remember { mutableStateOf("") }
+            AlertDialog(
+                onDismissRequest = { showSaveDialog = false },
+                title = { Text("Save preset") },
+                text = {
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        singleLine = true,
+                        label = { Text("Preset name") },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        enabled = name.isNotBlank(),
+                        onClick = {
+                            viewModel.saveCurrentAsPreset(name)
+                            showSaveDialog = false
+                            android.widget.Toast.makeText(context, "Saved \"${name.trim()}\"", android.widget.Toast.LENGTH_SHORT).show()
+                        },
+                    ) { Text("Save") }
+                },
+                dismissButton = { TextButton(onClick = { showSaveDialog = false }) { Text("Cancel") } },
+            )
+        }
+
+        // ── Import a shared preset code ──────────────────────────────────────
+        if (showImportDialog) {
+            var code by remember { mutableStateOf("") }
+            AlertDialog(
+                onDismissRequest = { showImportDialog = false },
+                title = { Text("Import preset") },
+                text = {
+                    Column {
+                        Text(
+                            "Paste a preset code someone shared with you.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedTextField(
+                            value = code,
+                            onValueChange = { code = it },
+                            label = { Text("Preset code") },
+                            modifier = Modifier.fillMaxWidth().height(140.dp),
+                        )
+                        TextButton(onClick = {
+                            val clip = context.getSystemService(android.content.ClipboardManager::class.java)
+                            val primary = clip?.primaryClip
+                            if (primary != null && primary.itemCount > 0) {
+                                primary.getItemAt(0).coerceToText(context)?.let { code = it.toString() }
+                            }
+                        }) { Text("Paste from clipboard") }
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        enabled = code.isNotBlank(),
+                        onClick = {
+                            val imported = viewModel.importPresetCode(code)
+                            showImportDialog = false
+                            android.widget.Toast.makeText(
+                                context,
+                                if (imported != null) "Imported \"$imported\"" else "That doesn't look like a valid preset code",
+                                android.widget.Toast.LENGTH_SHORT,
+                            ).show()
+                        },
+                    ) { Text("Import") }
+                },
+                dismissButton = { TextButton(onClick = { showImportDialog = false }) { Text("Cancel") } },
+            )
+        }
+
+        // ── Share / delete a saved preset ────────────────────────────────────
+        presetAction?.let { target ->
+            AlertDialog(
+                onDismissRequest = { presetAction = null },
+                title = { Text(target.name) },
+                text = { Text("Share this preset or remove it from your list.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(android.content.Intent.EXTRA_SUBJECT, "Lyrics FX preset: ${target.name}")
+                            putExtra(android.content.Intent.EXTRA_TEXT, viewModel.exportPreset(target))
+                        }
+                        context.startActivity(android.content.Intent.createChooser(send, "Share preset"))
+                        presetAction = null
+                    }) {
+                        Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("Share")
+                    }
+                },
+                dismissButton = {
+                    Row {
+                        TextButton(onClick = {
+                            viewModel.deletePreset(target.name)
+                            presetAction = null
+                        }) {
+                            Icon(Icons.Default.DeleteOutline, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("Delete")
+                        }
+                        TextButton(onClick = { presetAction = null }) { Text("Close") }
+                    }
+                },
+            )
         }
 
         LazyColumn(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -93,11 +93,14 @@ import java.io.File
 import tf.monochrome.android.data.preferences.PreferencesManager
 import androidx.compose.ui.res.painterResource
 import tf.monochrome.android.R
+import tf.monochrome.android.domain.model.Artist
 import tf.monochrome.android.domain.model.Lyrics
 import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.domain.model.PlayerGlassPreset
 import tf.monochrome.android.domain.model.PlayerGlassSettings
+import tf.monochrome.android.domain.model.Track
+import tf.monochrome.android.ui.components.MiniPlayer
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
 import tf.monochrome.android.ui.player.GlassDropShadow
@@ -424,6 +427,7 @@ fun LyricsFxStudioScreen(
                     onDeletePreset = { viewModel.deletePlayerGlassPreset(it) },
                     onExportPreset = { viewModel.exportPlayerGlassPreset(it) },
                     onImportPreset = { viewModel.importPlayerGlassPresetCode(it) },
+                    previewMini = true,
                 )
             }
             return@Column
@@ -795,6 +799,7 @@ private fun PlayerGlassTab(
     onDeletePreset: (String) -> Unit,
     onExportPreset: (PlayerGlassPreset) -> String,
     onImportPreset: (String) -> String?,
+    previewMini: Boolean = false,
 ) {
     val context = LocalContext.current
     val accent = MaterialTheme.colorScheme.primary
@@ -824,6 +829,27 @@ private fun PlayerGlassTab(
             contentAlignment = Alignment.Center,
         ) {
             CompositionLocalProvider(LocalPlayerGlass provides glass) {
+                if (previewMini) {
+                    // The real mini player bar under the current glass — the exact
+                    // component the nav host shows, so tuning is what-you-see.
+                    val sampleTrack = remember {
+                        Track(
+                            id = 0L,
+                            title = "The Business",
+                            artist = Artist(id = 0L, name = "Tiësto"),
+                        )
+                    }
+                    MiniPlayer(
+                        track = sampleTrack,
+                        isPlaying = false,
+                        progressProvider = { 0.4f },
+                        onPlayPauseClick = {},
+                        onSkipNextClick = {},
+                        onSkipPreviousClick = {},
+                        onClick = {},
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                } else {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -887,6 +913,7 @@ private fun PlayerGlassTab(
                         onSeekFinished = {},
                         modifier = Modifier.fillMaxWidth(),
                     )
+                }
                 }
             }
             Text(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -100,6 +100,7 @@ import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
 import tf.monochrome.android.ui.player.GlassDropShadow
+import tf.monochrome.android.ui.player.GlassProgressTube
 import tf.monochrome.android.ui.player.PlayerDesignTokens
 import tf.monochrome.android.ui.player.TransportIcon
 import tf.monochrome.android.ui.player.drawGlassPlayPauseDisc
@@ -688,7 +689,7 @@ private fun PlayerGlassTab(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(232.dp)
+                .height(288.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(previewBgBrush),
             contentAlignment = Alignment.Center,
@@ -749,6 +750,14 @@ private fun PlayerGlassTab(
                         onMixer = {},
                         onPlaylist = {},
                     )
+                    // The glass thermometer scrubber, previewed at ~40%.
+                    GlassProgressTube(
+                        fraction = 0.4f,
+                        tint = previewTint,
+                        onSeek = {},
+                        onSeekFinished = {},
+                        modifier = Modifier.fillMaxWidth(),
+                    )
                 }
             }
             Text(
@@ -791,6 +800,10 @@ private fun PlayerGlassTab(
             "Button liquid glass", glass.enabled,
             description = "3D refractive glass on the transport buttons (needs Android 13+).",
         ) { onUpdate { g -> g.copy(enabled = it) } }
+        FxToggle(
+            "Glass progress bar", glass.progressGlass,
+            description = "Thin glass tube scrubber that fills up, with a sine-wave bulge at the playhead dot.",
+        ) { onUpdate { g -> g.copy(progressGlass = it) } }
         FxSlider(
             "Glass opacity", "${(glass.bodyOpacity * 100).toInt()}%", glass.bodyOpacity, 0.2f..1f,
             description = "Lower makes the buttons more see-through.",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -3,6 +3,7 @@ package tf.monochrome.android.ui.settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -734,6 +736,11 @@ private fun PlayerGlassTab(
     onUpdate: ((PlayerGlassSettings) -> PlayerGlassSettings) -> Unit,
 ) {
     val accent = MaterialTheme.colorScheme.primary
+    // Custom preview colours (0 = use the current album colour).
+    val previewTint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
+    val previewBgBrush = if (glass.previewBg != 0) SolidColor(Color(glass.previewBg)) else previewBackground(accent)
+    var showBgPicker by remember { mutableStateOf(false) }
+    var showTintPicker by remember { mutableStateOf(false) }
     Column(modifier = Modifier.fillMaxSize()) {
         // Pinned preview — stays locked in view while you tune the sliders,
         // just like the Lyrics editor.
@@ -747,7 +754,7 @@ private fun PlayerGlassTab(
                 .fillMaxWidth()
                 .height(232.dp)
                 .clip(RoundedCornerShape(16.dp))
-                .background(previewBackground(accent)),
+                .background(previewBgBrush),
             contentAlignment = Alignment.Center,
         ) {
             CompositionLocalProvider(LocalPlayerGlass provides glass) {
@@ -763,7 +770,7 @@ private fun PlayerGlassTab(
                         // Real transport icon: bigger skip + shape-accurate shadow,
                         // exactly like the player.
                         TransportIcon(
-                            painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, {},
+                            painterResource(R.drawable.ic_glass_skip_previous), "Previous", previewTint, {},
                             size = PlayerDesignTokens.SkipIconSize,
                         )
                         // Solid glass disc with the play symbol punched out, plus the
@@ -773,7 +780,7 @@ private fun PlayerGlassTab(
                             contentAlignment = Alignment.Center,
                         ) {
                             GlassDropShadow(
-                                color = lerp(Color.Black, accent, glass.shadowTint)
+                                color = lerp(Color.Black, previewTint, glass.shadowTint)
                                     .copy(alpha = 0.28f + 0.55f * glass.shadowDepth),
                                 softness = glass.shadowSoftness,
                                 depth = glass.shadowDepth,
@@ -785,15 +792,15 @@ private fun PlayerGlassTab(
                                 Canvas(
                                     Modifier
                                         .fillMaxSize()
-                                        .playerGlass(accent)
+                                        .playerGlass(previewTint)
                                         .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
                                 ) {
-                                    drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
+                                    drawGlassPlayPauseDisc(isPlaying = false, fill = previewTint)
                                 }
                             }
                         }
                         TransportIcon(
-                            painterResource(R.drawable.ic_glass_skip_next), "Next", accent, {},
+                            painterResource(R.drawable.ic_glass_skip_next), "Next", previewTint, {},
                             size = PlayerDesignTokens.SkipIconSize,
                         )
                     }
@@ -825,6 +832,24 @@ private fun PlayerGlassTab(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
+        // Colour swatches: preview background + button glass tint, each "current"
+        // (album) or a custom colour picked from the bubble.
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(28.dp)) {
+            ColorSwatch(
+                label = "Background",
+                color = if (glass.previewBg != 0) Color(glass.previewBg) else lerp(Color.Black, accent, 0.34f),
+                isCustom = glass.previewBg != 0,
+                onClick = { showBgPicker = true },
+            )
+            ColorSwatch(
+                label = "Button tint",
+                color = previewTint,
+                isCustom = glass.tintColor != 0,
+                onClick = { showTintPicker = true },
+            )
+        }
+        Spacer(Modifier.height(14.dp))
         StudioSection("Player Glass")
         FxToggle(
             "Button liquid glass", glass.enabled,
@@ -905,6 +930,98 @@ private fun PlayerGlassTab(
         Spacer(Modifier.height(48.dp))
         }
     }
+
+    if (showBgPicker) {
+        GlassColorPickerDialog(
+            title = "Preview background",
+            initial = glass.previewBg,
+            onPick = { c -> onUpdate { it.copy(previewBg = c) }; showBgPicker = false },
+            onDismiss = { showBgPicker = false },
+        )
+    }
+    if (showTintPicker) {
+        GlassColorPickerDialog(
+            title = "Button glass tint",
+            initial = glass.tintColor,
+            onPick = { c -> onUpdate { it.copy(tintColor = c) }; showTintPicker = false },
+            onDismiss = { showTintPicker = false },
+        )
+    }
+}
+
+/** A round colour bubble + label, showing "Current" (album) or "Custom". */
+@Composable
+private fun ColorSwatch(label: String, color: Color, isCustom: Boolean, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(
+            Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(color)
+                .border(2.dp, Color.White.copy(alpha = 0.55f), CircleShape)
+                .clickable(onClick = onClick),
+        )
+        Text(label, style = MaterialTheme.typography.labelMedium, color = Color.White.copy(alpha = 0.85f))
+        Text(
+            if (isCustom) "Custom" else "Current",
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.45f),
+        )
+    }
+}
+
+/**
+ * A compact HSV colour picker dialog. [initial] is an ARGB int (0 = current
+ * album colour); [onPick] returns the chosen ARGB int, or 0 for "use current".
+ */
+@Composable
+private fun GlassColorPickerDialog(
+    title: String,
+    initial: Int,
+    onPick: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val hsv = remember {
+        FloatArray(3).also { a ->
+            if (initial != 0) android.graphics.Color.colorToHSV(initial, a)
+            else { a[0] = 210f; a[1] = 0.55f; a[2] = 0.95f }
+        }
+    }
+    var h by remember { mutableFloatStateOf(hsv[0]) }
+    var s by remember { mutableFloatStateOf(hsv[1]) }
+    var v by remember { mutableFloatStateOf(hsv[2]) }
+    val preview = Color(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v)))
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(44.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(preview),
+                )
+                Text("Hue", style = MaterialTheme.typography.labelSmall)
+                Slider(value = h, onValueChange = { h = it }, valueRange = 0f..360f)
+                Text("Saturation", style = MaterialTheme.typography.labelSmall)
+                Slider(value = s, onValueChange = { s = it }, valueRange = 0f..1f)
+                Text("Brightness", style = MaterialTheme.typography.labelSmall)
+                Slider(value = v, onValueChange = { v = it }, valueRange = 0f..1f)
+                TextButton(onClick = { onPick(0) }) { Text("Use current album colour") }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onPick(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v))) }) {
+                Text("Select")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 /**

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -50,9 +50,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.domain.model.LyricsFxSettings
@@ -71,16 +74,45 @@ import kotlin.math.exp
 class LyricsFxStudioViewModel @Inject constructor(
     private val preferences: PreferencesManager,
 ) : ViewModel() {
-    val fx: StateFlow<LyricsFxSettings> = preferences.lyricsFx
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LyricsFxSettings.DEFAULT)
+    // An in-memory working copy is the source of truth for the Studio UI and the
+    // live preview, so every slider frame updates instantly with no I/O. A slider
+    // drag fires dozens of times a second; persisting each frame — JSON-encode +
+    // DataStore write, then reading the value back through the flow — was the
+    // studio's performance cliff. Persistence is debounced to the drag's tail.
+    private val _fx = MutableStateFlow(LyricsFxSettings.DEFAULT)
+    val fx: StateFlow<LyricsFxSettings> = _fx.asStateFlow()
+
+    private var userTouched = false
+    private var persistJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            // Seed once from the persisted settings; after the user starts tuning,
+            // the in-memory copy leads so our own debounced writes never echo back.
+            val persisted = preferences.lyricsFx.first()
+            if (!userTouched) _fx.value = persisted
+        }
+    }
 
     fun update(transform: (LyricsFxSettings) -> LyricsFxSettings) {
-        val next = transform(fx.value).clamped()
-        viewModelScope.launch { preferences.setLyricsFx(next) }
+        userTouched = true
+        _fx.value = transform(_fx.value).clamped()
+        schedulePersist()
     }
 
     fun applyPreset(preset: LyricsFxSettings) {
+        userTouched = true
+        _fx.value = preset.clamped()
+        persistJob?.cancel()
         viewModelScope.launch { preferences.setLyricsFx(preset) }
+    }
+
+    private fun schedulePersist() {
+        persistJob?.cancel()
+        persistJob = viewModelScope.launch {
+            delay(200)
+            preferences.setLyricsFx(_fx.value)
+        }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -572,7 +572,7 @@ fun LyricsFxStudioScreen(
                 FxSlider(
                     "Bass reaction", "${(fx.bassReact * 100).toInt()}%" + if (fx.bassReact < 0.01f) " (off)" else "",
                     fx.bassReact, 0f..1f,
-                    description = "Master intensity for pump, pop-in, glow, and rays.",
+                    description = "Master intensity for pump, pop-in, and glow.",
                 ) { viewModel.update { s -> s.copy(bassReact = it) } }
                 FxSlider("Pump amount", "+${(fx.pumpAmount * 100).toInt()}%", fx.pumpAmount, 0f..0.25f) {
                     viewModel.update { s -> s.copy(pumpAmount = it) }
@@ -595,77 +595,13 @@ fun LyricsFxStudioScreen(
             }
 
             item {
-                StudioSection("God Rays & Glow")
-                FxSlider(
-                    "Rays per letter", "${fx.rayCount}" + if (fx.rayCount == 0) " (off)" else "",
-                    fx.rayCount.toFloat(), 0f..24f, steps = 23,
-                    description = "How many light shafts each letter throws (split up and down).",
-                ) { viewModel.update { s -> s.copy(rayCount = it.toInt()) } }
-                FxSlider("Ray length", "${(fx.rayLength * 100).toInt()}%", fx.rayLength, 0.1f..1f,
-                    description = "How far each shaft reaches from its letter.",
-                ) { viewModel.update { s -> s.copy(rayLength = it) } }
-                FxSlider("Ray width", "%.0f dp".format(fx.rayWidthDp), fx.rayWidthDp, 1f..16f) {
-                    viewModel.update { s -> s.copy(rayWidthDp = it) }
-                }
-                FxSlider("Ray brightness", "${(fx.rayBrightness * 100).toInt()}%", fx.rayBrightness, 0f..0.6f) {
-                    viewModel.update { s -> s.copy(rayBrightness = it) }
-                }
-                FxSlider(
-                    "Ray drift", "%.0f°/s".format(fx.raySpinDegPerSec), fx.raySpinDegPerSec, -60f..60f,
-                    description = "Slow sway of each letter's shafts; negative drifts the other way.",
-                ) { viewModel.update { s -> s.copy(raySpinDegPerSec = it) } }
+                StudioSection("Glow")
                 FxSlider("Glow radius", "+%.0f dp".format(fx.glowRadiusDp), fx.glowRadiusDp, 0f..160f) {
                     viewModel.update { s -> s.copy(glowRadiusDp = it) }
                 }
                 FxSlider("Glow brightness", "${(fx.glowBrightness * 100).toInt()}%", fx.glowBrightness, 0f..0.6f) {
                     viewModel.update { s -> s.copy(glowBrightness = it) }
                 }
-                Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            "Ray direction",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            "%.0f°".format(fx.rayAngleDeg),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    Box(Modifier.fillMaxWidth().padding(top = 8.dp), contentAlignment = Alignment.Center) {
-                        DirectionDial(
-                            angleDeg = fx.rayAngleDeg,
-                            onAngleChange = { viewModel.update { s -> s.copy(rayAngleDeg = it) } },
-                        )
-                    }
-                }
-                FxSlider(
-                    "Spread", "%.0f°".format(fx.raySpreadDeg), fx.raySpreadDeg, 0f..180f,
-                    description = "Fan of each letter's shafts. Tight = a vertical column; wide = a burst.",
-                ) { viewModel.update { s -> s.copy(raySpreadDeg = it) } }
-                FxSlider(
-                    "Decay", "${(fx.rayDecay * 100).toInt()}%", fx.rayDecay, 0f..1f,
-                    description = "Where each shaft fades out along its length.",
-                ) { viewModel.update { s -> s.copy(rayDecay = it) } }
-                FxSlider("Taper", "${(fx.rayTaper * 100).toInt()}%", fx.rayTaper, 0f..1f,
-                    description = "How much the shafts widen toward their tips.",
-                ) { viewModel.update { s -> s.copy(rayTaper = it) } }
-                FxSlider(
-                    "Hue shift", "%+.0f°".format(fx.rayHueShift), fx.rayHueShift, -180f..180f,
-                    description = "Recolour the rays off the album accent.",
-                ) { viewModel.update { s -> s.copy(rayHueShift = it) } }
-                FxSlider("Flicker", "${(fx.rayFlicker * 100).toInt()}%", fx.rayFlicker, 0f..1f,
-                    description = "Twinkle/shimmer the beams over time.",
-                ) { viewModel.update { s -> s.copy(rayFlicker = it) } }
-                FxSlider("Length jitter", "${(fx.rayLengthJitter * 100).toInt()}%", fx.rayLengthJitter, 0f..1f,
-                    description = "Randomise each beam's length for an organic burst.",
-                ) { viewModel.update { s -> s.copy(rayLengthJitter = it) } }
-                FxSlider(
-                    "Pulse reactivity", "${(fx.rayPulseAmount * 100).toInt()}%", fx.rayPulseAmount, 0f..1f,
-                    description = "How much the beams grow/brighten on the bass. 0 = steady.",
-                ) { viewModel.update { s -> s.copy(rayPulseAmount = it) } }
             }
 
             item {

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -98,6 +98,8 @@ import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
 import tf.monochrome.android.ui.player.GlassDropShadow
+import tf.monochrome.android.ui.player.PlayerDesignTokens
+import tf.monochrome.android.ui.player.TransportIcon
 import tf.monochrome.android.ui.player.drawGlassPlayPauseDisc
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.Letters3DLine
@@ -755,12 +757,14 @@ private fun PlayerGlassTab(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(22.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Icon(
-                            painterResource(R.drawable.ic_glass_skip_previous), null,
-                            Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                        // Real transport icon: bigger skip + shape-accurate shadow,
+                        // exactly like the player.
+                        TransportIcon(
+                            painterResource(R.drawable.ic_glass_skip_previous), "Previous", accent, {},
+                            size = PlayerDesignTokens.SkipIconSize,
                         )
                         // Solid glass disc with the play symbol punched out, plus the
                         // same custom round drop shadow as the real play button.
@@ -788,9 +792,9 @@ private fun PlayerGlassTab(
                                 }
                             }
                         }
-                        Icon(
-                            painterResource(R.drawable.ic_glass_skip_next), null,
-                            Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                        TransportIcon(
+                            painterResource(R.drawable.ic_glass_skip_next), "Next", accent, {},
+                            size = PlayerDesignTokens.SkipIconSize,
                         )
                     }
                     // The real hollowed-slab dock, previewed under the same glass.

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -97,6 +97,7 @@ import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.PlayerActionDock
 import tf.monochrome.android.ui.player.drawGlassPlayPauseDisc
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.Letters3DLine
@@ -736,49 +737,66 @@ private fun PlayerGlassTab(
         // just like the Lyrics editor.
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
         Spacer(Modifier.height(12.dp))
-        // Live preview: the real transport buttons under the current button glass.
+        // Live preview: the real transport buttons AND the action dock under the
+        // current button glass — the dock is the same hollowed-slab glass, so it
+        // tunes with these sliders exactly like the play button.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(150.dp)
+                .height(232.dp)
                 .clip(RoundedCornerShape(16.dp))
                 .background(previewBackground(accent)),
             contentAlignment = Alignment.Center,
         ) {
             CompositionLocalProvider(LocalPlayerGlass provides glass) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(22.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
-                    Icon(
-                        painterResource(R.drawable.ic_glass_skip_previous), null,
-                        Modifier.size(34.dp).playerGlass(accent), tint = accent,
-                    )
-                    // Solid glass disc with the play symbol punched out, plus the
-                    // drop shadow — matching the real play button.
-                    Box(
-                        Modifier
-                            .size(64.dp)
-                            .shadow(
-                                elevation = (glass.shadowDepth * 22f).dp,
-                                shape = CircleShape,
-                                clip = false,
-                            )
-                            .clip(CircleShape),
-                        contentAlignment = Alignment.Center,
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(22.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Canvas(
+                        Icon(
+                            painterResource(R.drawable.ic_glass_skip_previous), null,
+                            Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                        )
+                        // Solid glass disc with the play symbol punched out, plus the
+                        // drop shadow — matching the real play button.
+                        Box(
                             Modifier
-                                .fillMaxSize()
-                                .playerGlass(accent)
-                                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                                .size(64.dp)
+                                .shadow(
+                                    elevation = (glass.shadowDepth * 22f).dp,
+                                    shape = CircleShape,
+                                    clip = false,
+                                )
+                                .clip(CircleShape),
+                            contentAlignment = Alignment.Center,
                         ) {
-                            drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
+                            Canvas(
+                                Modifier
+                                    .fillMaxSize()
+                                    .playerGlass(accent)
+                                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                            ) {
+                                drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
+                            }
                         }
+                        Icon(
+                            painterResource(R.drawable.ic_glass_skip_next), null,
+                            Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                        )
                     }
-                    Icon(
-                        painterResource(R.drawable.ic_glass_skip_next), null,
-                        Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                    // The real hollowed-slab dock, previewed under the same glass.
+                    PlayerActionDock(
+                        accent = accent,
+                        lyricsActive = false,
+                        onLyrics = {},
+                        onTimer = {},
+                        onMixer = {},
+                        onPlaylist = {},
                     )
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -764,13 +764,17 @@ private fun PlayerGlassTab(
                         )
                         // Solid glass disc with the play symbol punched out, plus the
                         // drop shadow — matching the real play button.
+                        val discShadow = lerp(Color.Black, accent, glass.shadowTint)
+                            .copy(alpha = 0.25f + 0.6f * glass.shadowDepth)
                         Box(
                             Modifier
                                 .size(64.dp)
                                 .shadow(
-                                    elevation = (glass.shadowDepth * 22f).dp,
+                                    elevation = (4f + glass.shadowSoftness * 26f).dp,
                                     shape = CircleShape,
                                     clip = false,
+                                    ambientColor = discShadow,
+                                    spotColor = discShadow,
                                 )
                                 .clip(CircleShape),
                             contentAlignment = Alignment.Center,
@@ -856,6 +860,44 @@ private fun PlayerGlassTab(
             glass.sampleRings.toFloat(), 1f..3f, steps = 1,
             description = "Bevel quality vs GPU cost.",
         ) { onUpdate { g -> g.copy(sampleRings = it.toInt()) } }
+        FxSlider(
+            "Reflection", "${(glass.reflection * 100).toInt()}%", glass.reflection, 0f..2f,
+            description = "How much of the room/environment reflection shows on the glass.",
+        ) { onUpdate { g -> g.copy(reflection = it) } }
+        FxSlider(
+            "Gloss", "${(glass.gloss * 100).toInt()}%", glass.gloss, 0f..1f,
+            description = "Highlight polish: soft frosted-wide glint to a tight mirror.",
+        ) { onUpdate { g -> g.copy(gloss = it) } }
+        FxSlider(
+            "Surface motion", "${(glass.surfaceMotion * 100).toInt()}%", glass.surfaceMotion, 0f..1f,
+            description = "Living-liquid shimmer on the glass surface (0 = still).",
+        ) { onUpdate { g -> g.copy(surfaceMotion = it) } }
+        FxSlider(
+            "Frosted blur", "${(glass.frost * 100).toInt()}%", glass.frost, 0f..1f,
+            description = "Frosts the glass, from clear to misted.",
+        ) { onUpdate { g -> g.copy(frost = it) } }
+
+        StudioSection("Light & shadow")
+        FxSlider(
+            "Tilt reactivity", "${(glass.tiltReactivity * 100).toInt()}%", glass.tiltReactivity, 0f..1.5f,
+            description = "How strongly tilting the phone moves the light and reflection.",
+        ) { onUpdate { g -> g.copy(tiltReactivity = it) } }
+        FxSlider(
+            "Light angle", "${glass.lightAngleDeg.toInt()}°", glass.lightAngleDeg, 0f..360f,
+            description = "Direction the key light comes from — where the highlights sit.",
+        ) { onUpdate { g -> g.copy(lightAngleDeg = it) } }
+        FxSlider(
+            "Edge width", "${(glass.edgeWidth * 100).toInt()}%", glass.edgeWidth, 0f..1f,
+            description = "Reflective rim: thin crisp edge to a broad glassy shoulder.",
+        ) { onUpdate { g -> g.copy(edgeWidth = it) } }
+        FxSlider(
+            "Shadow softness", "${(glass.shadowSoftness * 100).toInt()}%", glass.shadowSoftness, 0f..1f,
+            description = "Blur / spread of the drop shadow under the play button.",
+        ) { onUpdate { g -> g.copy(shadowSoftness = it) } }
+        FxSlider(
+            "Shadow tint", "${(glass.shadowTint * 100).toInt()}%", glass.shadowTint, 0f..1f,
+            description = "Colour of the drop shadow: neutral black to accent glow.",
+        ) { onUpdate { g -> g.copy(shadowTint = it) } }
         Spacer(Modifier.height(48.dp))
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -96,6 +96,7 @@ import tf.monochrome.android.R
 import tf.monochrome.android.domain.model.Lyrics
 import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
+import tf.monochrome.android.domain.model.PlayerGlassPreset
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
@@ -157,6 +158,12 @@ class LyricsFxStudioViewModel @Inject constructor(
             viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList(),
         )
 
+    /** The user's own saved Player Glass themes, alongside the built-in ones. */
+    val customPlayerGlassPresets: StateFlow<List<tf.monochrome.android.domain.model.PlayerGlassPreset>> =
+        preferences.customPlayerGlassPresets.stateIn(
+            viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList(),
+        )
+
     init {
         viewModelScope.launch {
             // Seed once from the persisted settings; after the user starts tuning,
@@ -195,6 +202,48 @@ class LyricsFxStudioViewModel @Inject constructor(
             delay(200)
             preferences.setPlayerGlass(_playerGlass.value)
         }
+    }
+
+    /** Apply a Player Glass theme — changes the material, keeps the user's colour/perf. */
+    fun applyPlayerGlassPreset(preset: tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        playerGlassTouched = true
+        val next = preset.withPersonalFrom(_playerGlass.value).clamped()
+        _playerGlass.value = next
+        playerGlassPersistJob?.cancel()
+        viewModelScope.launch { preferences.setPlayerGlass(next) }
+    }
+
+    /** Save the current Player Glass as a named theme (blank ignored, same name overwrites). */
+    fun savePlayerGlassPreset(name: String) {
+        val clean = name.trim()
+        if (clean.isEmpty()) return
+        val preset = tf.monochrome.android.domain.model.PlayerGlassPreset(clean, _playerGlass.value.clamped())
+        viewModelScope.launch {
+            val current = customPlayerGlassPresets.value.filterNot { it.name.equals(clean, ignoreCase = true) }
+            preferences.setCustomPlayerGlassPresets(current + preset)
+        }
+    }
+
+    fun deletePlayerGlassPreset(name: String) {
+        viewModelScope.launch {
+            preferences.setCustomPlayerGlassPresets(customPlayerGlassPresets.value.filterNot { it.name == name })
+        }
+    }
+
+    /** The shareable code for a Player Glass theme (prefix + compact JSON). */
+    fun exportPlayerGlassPreset(preset: tf.monochrome.android.domain.model.PlayerGlassPreset): String =
+        tf.monochrome.android.domain.model.PlayerGlassPreset.encode(preset)
+
+    /** Import a Player Glass theme from a shared code; returns the name or null. */
+    fun importPlayerGlassPresetCode(code: String): String? {
+        val decoded = tf.monochrome.android.domain.model.PlayerGlassPreset.decode(code) ?: return null
+        val existing = customPlayerGlassPresets.value.map { it.name }.toSet()
+        var name = decoded.name
+        var n = 2
+        while (name in existing) { name = "${decoded.name} ($n)"; n++ }
+        val toAdd = decoded.copy(name = name)
+        viewModelScope.launch { preferences.setCustomPlayerGlassPresets(customPlayerGlassPresets.value + toAdd) }
+        return name
     }
 
     fun applyPreset(preset: LyricsFxSettings) {
@@ -307,7 +356,17 @@ fun LyricsFxStudioScreen(
         }
 
         if (selectedTab == 1) {
-            PlayerGlassTab(playerGlass) { viewModel.updatePlayerGlass(it) }
+            val customGlassPresets by viewModel.customPlayerGlassPresets.collectAsState()
+            PlayerGlassTab(
+                glass = playerGlass,
+                customPresets = customGlassPresets,
+                onUpdate = { viewModel.updatePlayerGlass(it) },
+                onApplyPreset = { viewModel.applyPlayerGlassPreset(it) },
+                onSavePreset = { viewModel.savePlayerGlassPreset(it) },
+                onDeletePreset = { viewModel.deletePlayerGlassPreset(it) },
+                onExportPreset = { viewModel.exportPlayerGlassPreset(it) },
+                onImportPreset = { viewModel.importPlayerGlassPresetCode(it) },
+            )
             return@Column
         }
 
@@ -670,14 +729,25 @@ fun LyricsFxStudioScreen(
 @Composable
 private fun PlayerGlassTab(
     glass: PlayerGlassSettings,
+    customPresets: List<PlayerGlassPreset>,
     onUpdate: ((PlayerGlassSettings) -> PlayerGlassSettings) -> Unit,
+    onApplyPreset: (PlayerGlassSettings) -> Unit,
+    onSavePreset: (String) -> Unit,
+    onDeletePreset: (String) -> Unit,
+    onExportPreset: (PlayerGlassPreset) -> String,
+    onImportPreset: (String) -> String?,
 ) {
+    val context = LocalContext.current
     val accent = MaterialTheme.colorScheme.primary
     // Custom preview colours (0 = use the current album colour).
     val previewTint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
     val previewBgBrush = if (glass.previewBg != 0) SolidColor(Color(glass.previewBg)) else previewBackground(accent)
     var showBgPicker by remember { mutableStateOf(false) }
     var showTintPicker by remember { mutableStateOf(false) }
+    // Theme save / import / share dialog state (mirrors the Lyrics preset system).
+    var showGlassSaveDialog by remember { mutableStateOf(false) }
+    var showGlassImportDialog by remember { mutableStateOf(false) }
+    var glassPresetAction by remember { mutableStateOf<PlayerGlassPreset?>(null) }
     Column(modifier = Modifier.fillMaxSize()) {
         // Pinned preview — stays locked in view while you tune the sliders,
         // just like the Lyrics editor.
@@ -777,9 +847,75 @@ private fun PlayerGlassTab(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
+        // ── Themes: built-in glass materials + the user's saved ones ─────────
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                "Themes",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = { showGlassSaveDialog = true }) {
+                Icon(Icons.Default.Save, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("Save")
+            }
+            TextButton(onClick = { showGlassImportDialog = true }) {
+                Icon(Icons.Default.FileDownload, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("Import")
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PlayerGlassSettings.PRESETS.forEach { (name, preset) ->
+                FilterChip(
+                    selected = glass.matchesPreset(preset),
+                    onClick = { onApplyPreset(preset) },
+                    label = { Text(name) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                )
+            }
+            // The user's own saved themes. Tapping applies; the trailing icon
+            // opens a Share / Delete sheet for that theme.
+            customPresets.forEach { saved ->
+                FilterChip(
+                    selected = glass.matchesPreset(saved.settings),
+                    onClick = { onApplyPreset(saved.settings) },
+                    label = { Text(saved.name) },
+                    trailingIcon = {
+                        Icon(
+                            Icons.Default.Share,
+                            contentDescription = "Manage ${saved.name}",
+                            modifier = Modifier
+                                .size(16.dp)
+                                .clickable { glassPresetAction = saved },
+                        )
+                    },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+                )
+            }
+        }
+
         // Colour swatches: preview background + button glass tint, each "current"
         // (album) or a custom colour picked from the bubble.
-        Spacer(Modifier.height(10.dp))
+        Spacer(Modifier.height(14.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(28.dp)) {
             ColorSwatch(
                 label = "Background",
@@ -876,6 +1012,11 @@ private fun PlayerGlassTab(
             "Shadow tint", "${(glass.shadowTint * 100).toInt()}%", glass.shadowTint, 0f..1f,
             description = "Colour of the drop shadow: neutral black to accent glow.",
         ) { onUpdate { g -> g.copy(shadowTint = it) } }
+        Spacer(Modifier.height(20.dp))
+        OutlinedButton(
+            onClick = { onApplyPreset(PlayerGlassSettings.DEFAULT) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Reset to defaults") }
         Spacer(Modifier.height(48.dp))
         }
     }
@@ -894,6 +1035,119 @@ private fun PlayerGlassTab(
             initial = glass.tintColor,
             onPick = { c -> onUpdate { it.copy(tintColor = c) }; showTintPicker = false },
             onDismiss = { showTintPicker = false },
+        )
+    }
+
+    // ── Save the current glass as a named theme ──────────────────────────────
+    if (showGlassSaveDialog) {
+        var name by remember { mutableStateOf("") }
+        AlertDialog(
+            onDismissRequest = { showGlassSaveDialog = false },
+            title = { Text("Save theme") },
+            text = {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    singleLine = true,
+                    label = { Text("Theme name") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = name.isNotBlank(),
+                    onClick = {
+                        onSavePreset(name)
+                        showGlassSaveDialog = false
+                        android.widget.Toast.makeText(context, "Saved \"${name.trim()}\"", android.widget.Toast.LENGTH_SHORT).show()
+                    },
+                ) { Text("Save") }
+            },
+            dismissButton = { TextButton(onClick = { showGlassSaveDialog = false }) { Text("Cancel") } },
+        )
+    }
+
+    // ── Import a shared theme code ────────────────────────────────────────────
+    if (showGlassImportDialog) {
+        var code by remember { mutableStateOf("") }
+        AlertDialog(
+            onDismissRequest = { showGlassImportDialog = false },
+            title = { Text("Import theme") },
+            text = {
+                Column {
+                    Text(
+                        "Paste a Player Glass theme code someone shared with you.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = code,
+                        onValueChange = { code = it },
+                        label = { Text("Theme code") },
+                        modifier = Modifier.fillMaxWidth().height(140.dp),
+                    )
+                    TextButton(onClick = {
+                        val clip = context.getSystemService(android.content.ClipboardManager::class.java)
+                        val primary = clip?.primaryClip
+                        if (primary != null && primary.itemCount > 0) {
+                            primary.getItemAt(0).coerceToText(context)?.let { code = it.toString() }
+                        }
+                    }) { Text("Paste from clipboard") }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = code.isNotBlank(),
+                    onClick = {
+                        val imported = onImportPreset(code)
+                        showGlassImportDialog = false
+                        android.widget.Toast.makeText(
+                            context,
+                            if (imported != null) "Imported \"$imported\"" else "That doesn't look like a valid theme code",
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                    },
+                ) { Text("Import") }
+            },
+            dismissButton = { TextButton(onClick = { showGlassImportDialog = false }) { Text("Cancel") } },
+        )
+    }
+
+    // ── Share / delete a saved theme ──────────────────────────────────────────
+    glassPresetAction?.let { target ->
+        AlertDialog(
+            onDismissRequest = { glassPresetAction = null },
+            title = { Text(target.name) },
+            text = { Text("Share this theme or remove it from your list.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(android.content.Intent.EXTRA_SUBJECT, "Player Glass theme: ${target.name}")
+                        putExtra(android.content.Intent.EXTRA_TEXT, onExportPreset(target))
+                    }
+                    context.startActivity(android.content.Intent.createChooser(send, "Share theme"))
+                    glassPresetAction = null
+                }) {
+                    Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Share")
+                }
+            },
+            dismissButton = {
+                Row {
+                    TextButton(onClick = {
+                        onDeletePreset(target.name)
+                        glassPresetAction = null
+                    }) {
+                        Icon(Icons.Default.DeleteOutline, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(6.dp))
+                        Text("Delete")
+                    }
+                    TextButton(onClick = { glassPresetAction = null }) { Text("Close") }
+                }
+            },
         )
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -471,6 +471,7 @@ private fun StudioPreview(fx: LyricsFxSettings) {
                     .liquidGlass(tint = accent)
                     .bassBeat(pulse, { 1f }, fx, anchors),
                 anchors = anchors,
+                fontSizeSp = fx.fontSizeSp,
             )
         }
         Text(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -61,8 +62,10 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -92,6 +95,7 @@ import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.drawGlassPlayPauseDisc
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.Letters3DLine
 import tf.monochrome.android.ui.player.LocalBeatPulse
@@ -750,20 +754,27 @@ private fun PlayerGlassTab(
                         painterResource(R.drawable.ic_glass_skip_previous), null,
                         Modifier.size(34.dp).playerGlass(accent), tint = accent,
                     )
-                    // Hollow glass ring + centred glyph, matching the real button.
-                    Box(Modifier.size(64.dp), contentAlignment = Alignment.Center) {
-                        Canvas(Modifier.fillMaxSize().playerGlass(accent)) {
-                            val stroke = size.minDimension * 0.12f
-                            drawCircle(
-                                color = accent,
-                                radius = (size.minDimension - stroke) / 2f,
-                                style = Stroke(width = stroke),
+                    // Solid glass disc with the play symbol punched out, plus the
+                    // drop shadow — matching the real play button.
+                    Box(
+                        Modifier
+                            .size(64.dp)
+                            .shadow(
+                                elevation = (glass.shadowDepth * 22f).dp,
+                                shape = CircleShape,
+                                clip = false,
                             )
+                            .clip(CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Canvas(
+                            Modifier
+                                .fillMaxSize()
+                                .playerGlass(accent)
+                                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                        ) {
+                            drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
                         }
-                        Icon(
-                            painterResource(R.drawable.ic_glass_play), null,
-                            Modifier.size(30.dp).playerGlass(accent), tint = accent,
-                        )
                     }
                     Icon(
                         painterResource(R.drawable.ic_glass_skip_next), null,
@@ -808,6 +819,10 @@ private fun PlayerGlassTab(
             "Depth (profondeur)", "%.2f".format(glass.depth), glass.depth, 0.5f..2f,
             description = "How thick and deep the relief reads — higher pops the buttons more in 3D.",
         ) { onUpdate { g -> g.copy(depth = it) } }
+        FxSlider(
+            "Shadow depth", "${(glass.shadowDepth * 100).toInt()}%", glass.shadowDepth, 0f..1f,
+            description = "Drop shadow under the round play button — lifts it off the surface.",
+        ) { onUpdate { g -> g.copy(shadowDepth = it) } }
         FxSlider(
             "Per-pixel samples",
             "${glass.sampleRings} (${when (glass.sampleRings) { 1 -> 5; 2 -> 9; else -> 13 }} taps)",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1,6 +1,8 @@
 package tf.monochrome.android.ui.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +19,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -36,7 +41,9 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,7 +56,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
+import android.content.Context
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -57,6 +66,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.io.File
 import tf.monochrome.android.data.preferences.PreferencesManager
 import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.ui.player.Letters3DLine
@@ -66,6 +76,8 @@ import tf.monochrome.android.ui.player.LyricGlyphAnchors
 import tf.monochrome.android.ui.player.LyricsFxLayer
 import tf.monochrome.android.ui.player.bassBeat
 import tf.monochrome.android.ui.player.liquidGlass
+import tf.monochrome.android.ui.player.rememberLyricFontFamily
+import tf.monochrome.android.ui.player.withLyricFont
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.exp
@@ -73,6 +85,7 @@ import kotlin.math.exp
 @HiltViewModel
 class LyricsFxStudioViewModel @Inject constructor(
     private val preferences: PreferencesManager,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
     // An in-memory working copy is the source of truth for the Studio UI and the
     // live preview, so every slider frame updates instantly with no I/O. A slider
@@ -85,6 +98,10 @@ class LyricsFxStudioViewModel @Inject constructor(
     private var userTouched = false
     private var persistJob: Job? = null
 
+    /** Fonts the user has imported (Settings › Appearance copies them here). */
+    private val _availableFonts = MutableStateFlow<List<File>>(emptyList())
+    val availableFonts: StateFlow<List<File>> = _availableFonts.asStateFlow()
+
     init {
         viewModelScope.launch {
             // Seed once from the persisted settings; after the user starts tuning,
@@ -92,6 +109,15 @@ class LyricsFxStudioViewModel @Inject constructor(
             val persisted = preferences.lyricsFx.first()
             if (!userTouched) _fx.value = persisted
         }
+        refreshFonts()
+    }
+
+    /** Re-list the imported font files (call when the Font section is shown). */
+    fun refreshFonts() {
+        _availableFonts.value = File(context.filesDir, "custom_fonts").listFiles()
+            ?.filter { it.isFile && (it.extension.equals("ttf", true) || it.extension.equals("otf", true)) }
+            ?.sortedBy { it.name.lowercase(java.util.Locale.US) }
+            ?: emptyList()
     }
 
     fun update(transform: (LyricsFxSettings) -> LyricsFxSettings) {
@@ -102,9 +128,12 @@ class LyricsFxStudioViewModel @Inject constructor(
 
     fun applyPreset(preset: LyricsFxSettings) {
         userTouched = true
-        _fx.value = preset.clamped()
+        // A theme changes only the look — keep the user's font, Bluetooth delay,
+        // and glass sample count (personal/device settings) across the switch.
+        val next = preset.withPersonalFrom(_fx.value).clamped()
+        _fx.value = next
         persistJob?.cancel()
-        viewModelScope.launch { preferences.setLyricsFx(preset) }
+        viewModelScope.launch { preferences.setLyricsFx(next) }
     }
 
     private fun schedulePersist() {
@@ -129,6 +158,7 @@ fun LyricsFxStudioScreen(
     viewModel: LyricsFxStudioViewModel = hiltViewModel(),
 ) {
     val fx by viewModel.fx.collectAsState()
+    val fonts by viewModel.availableFonts.collectAsState()
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -154,7 +184,7 @@ fun LyricsFxStudioScreen(
             ) {
                 LyricsFxSettings.PRESETS.forEach { (name, preset) ->
                     FilterChip(
-                        selected = fx == preset,
+                        selected = fx.matchesPreset(preset),
                         onClick = { viewModel.applyPreset(preset) },
                         label = { Text(name) },
                         colors = FilterChipDefaults.filterChipColors(
@@ -177,6 +207,21 @@ fun LyricsFxStudioScreen(
                 }
                 FxSlider("Letter spacing", "%.2f sp".format(fx.letterSpacingSp), fx.letterSpacingSp, -1f..1f) {
                     viewModel.update { s -> s.copy(letterSpacingSp = it) }
+                }
+            }
+
+            item {
+                StudioSection("Font")
+                FxToggle(
+                    "Custom lyrics font", fx.customFont,
+                    description = "Use one of your imported fonts for the lyrics only.",
+                ) { viewModel.update { s -> s.copy(customFont = it) } }
+                if (fx.customFont) {
+                    FontPicker(
+                        fonts = fonts,
+                        selectedPath = fx.customFontPath,
+                        onSelect = { viewModel.update { s -> s.copy(customFontPath = it) } },
+                    )
                 }
             }
 
@@ -265,6 +310,56 @@ fun LyricsFxStudioScreen(
                 FxSlider("Glow brightness", "${(fx.glowBrightness * 100).toInt()}%", fx.glowBrightness, 0f..0.6f) {
                     viewModel.update { s -> s.copy(glowBrightness = it) }
                 }
+                FxToggle(
+                    "Fixed direction", fx.rayFixedDirection,
+                    description = "Off = radial burst; on = parallel shafts all aimed one way.",
+                ) { viewModel.update { s -> s.copy(rayFixedDirection = it) } }
+                Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            "Ray direction",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            "%.0f°".format(fx.rayAngleDeg),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    Box(Modifier.fillMaxWidth().padding(top = 8.dp), contentAlignment = Alignment.Center) {
+                        DirectionDial(
+                            angleDeg = fx.rayAngleDeg,
+                            onAngleChange = { viewModel.update { s -> s.copy(rayAngleDeg = it) } },
+                        )
+                    }
+                }
+                FxSlider(
+                    "Spread", "%.0f°".format(fx.raySpreadDeg), fx.raySpreadDeg, 0f..360f,
+                    description = "Fan cone width around the direction. 360° = full even burst.",
+                ) { viewModel.update { s -> s.copy(raySpreadDeg = it) } }
+                FxSlider(
+                    "Decay", "${(fx.rayDecay * 100).toInt()}%", fx.rayDecay, 0f..1f,
+                    description = "Where each beam fades out along its length.",
+                ) { viewModel.update { s -> s.copy(rayDecay = it) } }
+                FxSlider("Taper", "${(fx.rayTaper * 100).toInt()}%", fx.rayTaper, 0f..1f,
+                    description = "Narrow the beams toward their tips.",
+                ) { viewModel.update { s -> s.copy(rayTaper = it) } }
+                FxSlider(
+                    "Hue shift", "%+.0f°".format(fx.rayHueShift), fx.rayHueShift, -180f..180f,
+                    description = "Recolour the rays off the album accent.",
+                ) { viewModel.update { s -> s.copy(rayHueShift = it) } }
+                FxSlider("Flicker", "${(fx.rayFlicker * 100).toInt()}%", fx.rayFlicker, 0f..1f,
+                    description = "Twinkle/shimmer the beams over time.",
+                ) { viewModel.update { s -> s.copy(rayFlicker = it) } }
+                FxSlider("Length jitter", "${(fx.rayLengthJitter * 100).toInt()}%", fx.rayLengthJitter, 0f..1f,
+                    description = "Randomise each beam's length for an organic burst.",
+                ) { viewModel.update { s -> s.copy(rayLengthJitter = it) } }
+                FxSlider(
+                    "Pulse reactivity", "${(fx.rayPulseAmount * 100).toInt()}%", fx.rayPulseAmount, 0f..1f,
+                    description = "How much the beams grow/brighten on the bass. 0 = steady.",
+                ) { viewModel.update { s -> s.copy(rayPulseAmount = it) } }
             }
 
             item {
@@ -292,6 +387,11 @@ fun LyricsFxStudioScreen(
                     fx.glassDispersion, 0f..2f,
                     description = "Colour fringing where the edges refract.",
                 ) { viewModel.update { s -> s.copy(glassDispersion = it) } }
+                FxSlider(
+                    "Bevel samples", "${1 + 4 * fx.glassSampleRings} taps/px",
+                    fx.glassSampleRings.toFloat(), 1f..3f, steps = 1,
+                    description = "Shader taps per pixel: higher = smoother glass, heavier GPU.",
+                ) { viewModel.update { s -> s.copy(glassSampleRings = it.toInt()) } }
             }
 
             item {
@@ -341,7 +441,7 @@ private fun StudioPreview(fx: LyricsFxSettings) {
                     lineHeight = (fx.fontSizeSp * 1.26f).sp,
                     letterSpacing = fx.letterSpacingSp.sp,
                     fontWeight = FontWeight.ExtraBold,
-                ),
+                ).withLyricFont(rememberLyricFontFamily(fx)),
                 color = accent,
                 modifier = Modifier
                     .liquidGlass(tint = accent)
@@ -434,6 +534,71 @@ private fun FxToggle(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+}
+
+/** Collapsible picker over the fonts the user imported (Settings › Appearance). */
+@Composable
+private fun FontPicker(
+    fonts: List<File>,
+    selectedPath: String,
+    onSelect: (String) -> Unit,
+) {
+    if (fonts.isEmpty()) {
+        Text(
+            text = "No imported fonts yet — add them in Settings › Appearance › Font Library.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        )
+        return
+    }
+    var expanded by remember { mutableStateOf(false) }
+    val selectedName = fonts.firstOrNull { it.absolutePath == selectedPath }?.nameWithoutExtension
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Font: " + (selectedName ?: "choose…"),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        AnimatedVisibility(visible = expanded) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                fonts.forEach { file ->
+                    val isSelected = file.absolutePath == selectedPath
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSelect(file.absolutePath) }
+                            .padding(vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            tint = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                            modifier = Modifier.padding(end = 12.dp),
+                        )
+                        Text(
+                            text = file.nameWithoutExtension,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -539,12 +539,13 @@ fun LyricsFxStudioScreen(
             item {
                 StudioSection("God Rays & Glow")
                 FxSlider(
-                    "Ray count", "${fx.rayCount}" + if (fx.rayCount == 0) " (off)" else "",
+                    "Rays per letter", "${fx.rayCount}" + if (fx.rayCount == 0) " (off)" else "",
                     fx.rayCount.toFloat(), 0f..24f, steps = 23,
+                    description = "How many light shafts each letter throws (split up and down).",
                 ) { viewModel.update { s -> s.copy(rayCount = it.toInt()) } }
-                FxSlider("Ray length", "${(fx.rayLength * 100).toInt()}% of screen", fx.rayLength, 0.1f..1f) {
-                    viewModel.update { s -> s.copy(rayLength = it) }
-                }
+                FxSlider("Ray length", "${(fx.rayLength * 100).toInt()}%", fx.rayLength, 0.1f..1f,
+                    description = "How far each shaft reaches from its letter.",
+                ) { viewModel.update { s -> s.copy(rayLength = it) } }
                 FxSlider("Ray width", "%.0f dp".format(fx.rayWidthDp), fx.rayWidthDp, 1f..16f) {
                     viewModel.update { s -> s.copy(rayWidthDp = it) }
                 }
@@ -553,7 +554,7 @@ fun LyricsFxStudioScreen(
                 }
                 FxSlider(
                     "Ray drift", "%.0f°/s".format(fx.raySpinDegPerSec), fx.raySpinDegPerSec, -60f..60f,
-                    description = "Slow sway of the whole light fan; negative drifts the other way.",
+                    description = "Slow sway of each letter's shafts; negative drifts the other way.",
                 ) { viewModel.update { s -> s.copy(raySpinDegPerSec = it) } }
                 FxSlider("Glow radius", "+%.0f dp".format(fx.glowRadiusDp), fx.glowRadiusDp, 0f..160f) {
                     viewModel.update { s -> s.copy(glowRadiusDp = it) }
@@ -583,8 +584,8 @@ fun LyricsFxStudioScreen(
                     }
                 }
                 FxSlider(
-                    "Spread", "%.0f°".format(fx.raySpreadDeg), fx.raySpreadDeg, 0f..360f,
-                    description = "Fan cone width. ~150° pours down over the line; 360° = full sun.",
+                    "Spread", "%.0f°".format(fx.raySpreadDeg), fx.raySpreadDeg, 0f..180f,
+                    description = "Fan of each letter's shafts. Tight = a vertical column; wide = a burst.",
                 ) { viewModel.update { s -> s.copy(raySpreadDeg = it) } }
                 FxSlider(
                     "Decay", "${(fx.rayDecay * 100).toInt()}%", fx.rayDecay, 0f..1f,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -326,8 +326,8 @@ fun LyricsFxStudioScreen(
                     viewModel.update { s -> s.copy(rayBrightness = it) }
                 }
                 FxSlider(
-                    "Ray spin", "%.0f°/s".format(fx.raySpinDegPerSec), fx.raySpinDegPerSec, -60f..60f,
-                    description = "Orbit speed of the beam fan; negative spins the other way.",
+                    "Ray drift", "%.0f°/s".format(fx.raySpinDegPerSec), fx.raySpinDegPerSec, -60f..60f,
+                    description = "Slow sway of the whole light fan; negative drifts the other way.",
                 ) { viewModel.update { s -> s.copy(raySpinDegPerSec = it) } }
                 FxSlider("Glow radius", "+%.0f dp".format(fx.glowRadiusDp), fx.glowRadiusDp, 0f..160f) {
                     viewModel.update { s -> s.copy(glowRadiusDp = it) }
@@ -335,10 +335,6 @@ fun LyricsFxStudioScreen(
                 FxSlider("Glow brightness", "${(fx.glowBrightness * 100).toInt()}%", fx.glowBrightness, 0f..0.6f) {
                     viewModel.update { s -> s.copy(glowBrightness = it) }
                 }
-                FxToggle(
-                    "Fixed direction", fx.rayFixedDirection,
-                    description = "Off = radial burst; on = parallel shafts all aimed one way.",
-                ) { viewModel.update { s -> s.copy(rayFixedDirection = it) } }
                 Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
@@ -362,14 +358,14 @@ fun LyricsFxStudioScreen(
                 }
                 FxSlider(
                     "Spread", "%.0f°".format(fx.raySpreadDeg), fx.raySpreadDeg, 0f..360f,
-                    description = "Fan cone width around the direction. 360° = full even burst.",
+                    description = "Fan cone width. ~150° pours down over the line; 360° = full sun.",
                 ) { viewModel.update { s -> s.copy(raySpreadDeg = it) } }
                 FxSlider(
                     "Decay", "${(fx.rayDecay * 100).toInt()}%", fx.rayDecay, 0f..1f,
-                    description = "Where each beam fades out along its length.",
+                    description = "Where each shaft fades out along its length.",
                 ) { viewModel.update { s -> s.copy(rayDecay = it) } }
                 FxSlider("Taper", "${(fx.rayTaper * 100).toInt()}%", fx.rayTaper, 0f..1f,
-                    description = "Narrow the beams toward their tips.",
+                    description = "How much the shafts widen toward their tips.",
                 ) { viewModel.update { s -> s.copy(rayTaper = it) } }
                 FxSlider(
                     "Hue shift", "%+.0f°".format(fx.rayHueShift), fx.rayHueShift, -180f..180f,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
@@ -98,6 +97,7 @@ import tf.monochrome.android.domain.model.LyricsFxSettings
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
+import tf.monochrome.android.ui.player.GlassDropShadow
 import tf.monochrome.android.ui.player.drawGlassPlayPauseDisc
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.Letters3DLine
@@ -763,29 +763,29 @@ private fun PlayerGlassTab(
                             Modifier.size(34.dp).playerGlass(accent), tint = accent,
                         )
                         // Solid glass disc with the play symbol punched out, plus the
-                        // drop shadow — matching the real play button.
-                        val discShadow = lerp(Color.Black, accent, glass.shadowTint)
-                            .copy(alpha = 0.25f + 0.6f * glass.shadowDepth)
+                        // same custom round drop shadow as the real play button.
                         Box(
-                            Modifier
-                                .size(64.dp)
-                                .shadow(
-                                    elevation = (4f + glass.shadowSoftness * 26f).dp,
-                                    shape = CircleShape,
-                                    clip = false,
-                                    ambientColor = discShadow,
-                                    spotColor = discShadow,
-                                )
-                                .clip(CircleShape),
+                            Modifier.size(64.dp),
                             contentAlignment = Alignment.Center,
                         ) {
-                            Canvas(
-                                Modifier
-                                    .fillMaxSize()
-                                    .playerGlass(accent)
-                                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                            GlassDropShadow(
+                                color = lerp(Color.Black, accent, glass.shadowTint)
+                                    .copy(alpha = 0.28f + 0.55f * glass.shadowDepth),
+                                softness = glass.shadowSoftness,
+                                depth = glass.shadowDepth,
+                            )
+                            Box(
+                                Modifier.fillMaxSize().clip(CircleShape),
+                                contentAlignment = Alignment.Center,
                             ) {
-                                drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
+                                Canvas(
+                                    Modifier
+                                        .fillMaxSize()
+                                        .playerGlass(accent)
+                                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                                ) {
+                                    drawGlassPlayPauseDisc(isPlaying = false, fill = accent)
+                                }
                             }
                         }
                         Icon(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -149,6 +149,17 @@ fun LyricsFxStudioScreen(
             }
 
             item {
+                StudioSection("Playback Sync")
+                FxSlider(
+                    "Bluetooth sync delay",
+                    "%+d ms".format(fx.bluetoothDelayMs.toInt()),
+                    fx.bluetoothDelayMs, -500f..1500f, steps = 39,
+                    description = "Delays synced lyrics to line up with Bluetooth audio latency. " +
+                        "Raise it until the words land with what you hear; negative pulls them earlier.",
+                ) { viewModel.update { s -> s.copy(bluetoothDelayMs = it) } }
+            }
+
+            item {
                 StudioSection("3D Letter Wave")
                 FxSlider(
                     "Tilt", "%.0f°".format(fx.rotationDegrees) + if (fx.rotationDegrees < 0.5f) " (off)" else "",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -75,6 +75,7 @@ import tf.monochrome.android.ui.player.LocalLyricsFx
 import tf.monochrome.android.ui.player.LyricGlyphAnchors
 import tf.monochrome.android.ui.player.LyricsFxLayer
 import tf.monochrome.android.ui.player.bassBeat
+import tf.monochrome.android.ui.player.fxaa
 import tf.monochrome.android.ui.player.liquidGlass
 import tf.monochrome.android.ui.player.rememberLyricFontFamily
 import tf.monochrome.android.ui.player.withLyricFont
@@ -395,6 +396,21 @@ fun LyricsFxStudioScreen(
             }
 
             item {
+                StudioSection("Anti-aliasing")
+                FxToggle(
+                    "Anti-aliasing (FXAA)", fx.fxaa,
+                    description = "Smooths jagged edges on the 3D letters and glass (needs Android 13+).",
+                ) { viewModel.update { s -> s.copy(fxaa = it) } }
+                if (fx.fxaa) {
+                    FxSlider(
+                        "AA strength", "${(fx.fxaaStrength * 100).toInt()}%",
+                        fx.fxaaStrength, 0f..1f,
+                        description = "How hard edges are smoothed; higher softens more.",
+                    ) { viewModel.update { s -> s.copy(fxaaStrength = it) } }
+                }
+            }
+
+            item {
                 Spacer(Modifier.height(20.dp))
                 OutlinedButton(
                     onClick = { viewModel.applyPreset(LyricsFxSettings.DEFAULT) },
@@ -444,6 +460,7 @@ private fun StudioPreview(fx: LyricsFxSettings) {
                 ).withLyricFont(rememberLyricFontFamily(fx)),
                 color = accent,
                 modifier = Modifier
+                    .fxaa()
                     .liquidGlass(tint = accent)
                     .bassBeat(pulse, { 1f }, fx, anchors),
                 anchors = anchors,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,6 +40,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -80,9 +83,14 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.io.File
 import tf.monochrome.android.data.preferences.PreferencesManager
+import androidx.compose.ui.res.painterResource
+import tf.monochrome.android.R
 import tf.monochrome.android.domain.model.Lyrics
 import tf.monochrome.android.domain.model.LyricsFxPreset
 import tf.monochrome.android.domain.model.LyricsFxSettings
+import tf.monochrome.android.domain.model.PlayerGlassSettings
+import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.Letters3DLine
 import tf.monochrome.android.ui.player.LocalBeatPulse
 import tf.monochrome.android.ui.player.LocalLyricGlyphAnchors
@@ -119,6 +127,12 @@ class LyricsFxStudioViewModel @Inject constructor(
     private var userTouched = false
     private var persistJob: Job? = null
 
+    /** Player-chrome (transport button) glass settings — the "Player Glass" tab. */
+    private val _playerGlass = MutableStateFlow(tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
+    val playerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = _playerGlass.asStateFlow()
+    private var playerGlassTouched = false
+    private var playerGlassPersistJob: Job? = null
+
     /** Fonts the user has imported (Settings › Appearance copies them here). */
     private val _availableFonts = MutableStateFlow<List<File>>(emptyList())
     val availableFonts: StateFlow<List<File>> = _availableFonts.asStateFlow()
@@ -135,6 +149,10 @@ class LyricsFxStudioViewModel @Inject constructor(
             // the in-memory copy leads so our own debounced writes never echo back.
             val persisted = preferences.lyricsFx.first()
             if (!userTouched) _fx.value = persisted
+        }
+        viewModelScope.launch {
+            val pg = preferences.playerGlass.first()
+            if (!playerGlassTouched) _playerGlass.value = pg
         }
         refreshFonts()
     }
@@ -153,6 +171,16 @@ class LyricsFxStudioViewModel @Inject constructor(
         userTouched = true
         _fx.value = transform(_fx.value).clamped()
         schedulePersist()
+    }
+
+    fun updatePlayerGlass(transform: (tf.monochrome.android.domain.model.PlayerGlassSettings) -> tf.monochrome.android.domain.model.PlayerGlassSettings) {
+        playerGlassTouched = true
+        _playerGlass.value = transform(_playerGlass.value).clamped()
+        playerGlassPersistJob?.cancel()
+        playerGlassPersistJob = viewModelScope.launch {
+            delay(200)
+            preferences.setPlayerGlass(_playerGlass.value)
+        }
     }
 
     fun applyPreset(preset: LyricsFxSettings) {
@@ -230,7 +258,11 @@ fun LyricsFxStudioScreen(
     val fonts by viewModel.availableFonts.collectAsState()
     val currentLyrics by viewModel.currentLyrics.collectAsState()
     val customPresets by viewModel.customPresets.collectAsState()
+    val playerGlass by viewModel.playerGlass.collectAsState()
     val context = LocalContext.current
+
+    // Which studio tab: 0 = Lyrics, 1 = Player Glass.
+    var selectedTab by remember { mutableStateOf(0) }
 
     // Preset save / import / share dialog state.
     var showSaveDialog by remember { mutableStateOf(false) }
@@ -251,6 +283,19 @@ fun LyricsFxStudioScreen(
             },
             colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
         )
+
+        TabRow(
+            selectedTabIndex = selectedTab,
+            containerColor = Color.Transparent,
+        ) {
+            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text("Lyrics") })
+            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text("Player Glass") })
+        }
+
+        if (selectedTab == 1) {
+            PlayerGlassTab(playerGlass) { viewModel.updatePlayerGlass(it) }
+            return@Column
+        }
 
         // Preview + presets are pinned above the scrolling sliders, so the
         // live example stays locked in view while you tune every parameter.
@@ -669,12 +714,89 @@ fun LyricsFxStudioScreen(
 }
 
 /**
- * Live preview: the production line renderer (3D letters + the bass-beat
- * element FX) driven by a synthetic 120 BPM kick pushed through the same
- * attack/release envelope + spring as the real bass pulse, so every slider
- * change is visible immediately, music or not. The god ray FX is applied to
- * the font element via [bassBeat] — exactly as it is on the active lyric line.
+ * The "Player Glass" tab: the same refractive-glass controls the lyrics have,
+ * for the player's transport buttons, over a live preview of the glass icons.
  */
+@Composable
+private fun PlayerGlassTab(
+    glass: PlayerGlassSettings,
+    onUpdate: ((PlayerGlassSettings) -> PlayerGlassSettings) -> Unit,
+) {
+    val accent = MaterialTheme.colorScheme.primary
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp),
+    ) {
+        Spacer(Modifier.height(12.dp))
+        // Live preview: the real transport icons under the current button glass.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(150.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(Color(0xFF121016)),
+            contentAlignment = Alignment.Center,
+        ) {
+            CompositionLocalProvider(LocalPlayerGlass provides glass) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(22.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.ic_glass_skip_previous), null,
+                        Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                    )
+                    Icon(
+                        painterResource(R.drawable.ic_glass_play), null,
+                        Modifier.size(58.dp).playerGlass(accent), tint = accent,
+                    )
+                    Icon(
+                        painterResource(R.drawable.ic_glass_skip_next), null,
+                        Modifier.size(34.dp).playerGlass(accent), tint = accent,
+                    )
+                }
+            }
+            Text(
+                text = "PREVIEW",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.35f),
+                modifier = Modifier.align(Alignment.TopStart).padding(10.dp),
+            )
+        }
+
+        StudioSection("Player Glass")
+        FxToggle(
+            "Button liquid glass", glass.enabled,
+            description = "3D refractive glass on the transport buttons (needs Android 13+).",
+        ) { onUpdate { g -> g.copy(enabled = it) } }
+        FxSlider(
+            "Glass opacity", "${(glass.bodyOpacity * 100).toInt()}%", glass.bodyOpacity, 0.2f..1f,
+            description = "Lower makes the buttons more see-through.",
+        ) { onUpdate { g -> g.copy(bodyOpacity = it) } }
+        FxSlider(
+            "Refraction", "%.2f".format(glass.refraction), glass.refraction, 0f..0.4f,
+            description = "How hard the beveled edges lens the backdrop behind them.",
+        ) { onUpdate { g -> g.copy(refraction = it) } }
+        FxSlider(
+            "Edge highlight", "${(glass.rimBrightness * 100).toInt()}%", glass.rimBrightness, 0f..2f,
+            description = "Brightness of the specular glass rim.",
+        ) { onUpdate { g -> g.copy(rimBrightness = it) } }
+        FxSlider(
+            "Chromatic aberration", "${(glass.dispersion * 100).toInt()}%", glass.dispersion, 0f..2f,
+            description = "Colour fringing at the refracting edges.",
+        ) { onUpdate { g -> g.copy(dispersion = it) } }
+        FxSlider(
+            "Per-pixel samples",
+            "${glass.sampleRings} (${when (glass.sampleRings) { 1 -> 5; 2 -> 9; else -> 13 }} taps)",
+            glass.sampleRings.toFloat(), 1f..3f, steps = 1,
+            description = "Bevel quality vs GPU cost.",
+        ) { onUpdate { g -> g.copy(sampleRings = it.toInt()) } }
+        Spacer(Modifier.height(48.dp))
+    }
+}
+
 @Composable
 private fun StudioPreview(
     fx: LyricsFxSettings,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -512,6 +512,7 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
     val spectrumFftSize by viewModel.spectrumFftSize.collectAsState()
     val spectrumBins by viewModel.spectrumBins.collectAsState()
     val playerDynamicColor by viewModel.playerDynamicColor.collectAsState()
+    val playerBlurredBackground by viewModel.playerBlurredBackground.collectAsState()
     val appFps by viewModel.appTargetFps.collectAsState()
     val appResolution by viewModel.appRenderResolution.collectAsState()
     val selectedPresetName = presets.firstOrNull { it.id == presetId }?.displayName ?: "Auto-select bundled preset"
@@ -658,6 +659,12 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
             subtitle = "Tint the player from the album art; off uses the theme color",
             checked = playerDynamicColor,
             onCheckedChange = { viewModel.setPlayerDynamicColor(it) }
+        )
+        SettingSwitchItem(
+            title = "Blurred Album Background",
+            subtitle = "Fill the player with the album art, stretched and heavily blurred",
+            checked = playerBlurredBackground,
+            onCheckedChange = { viewModel.setPlayerBlurredBackground(it) }
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -351,7 +351,7 @@ private fun AppearanceTab(viewModel: SettingsViewModel) {
         }
         SettingSwitchItem(
             title = "Dynamic Colors",
-            subtitle = "Extract accent colors from album art",
+            subtitle = "Master switch: tint the app AND the player from album art. Off = everything uses the theme color",
             checked = dynamicColors,
             onCheckedChange = { viewModel.setDynamicColors(it) }
         )
@@ -656,7 +656,7 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
         }
         SettingSwitchItem(
             title = "Dynamic Player Color",
-            subtitle = "Tint the player from the album art; off uses the theme color",
+            subtitle = "Tint the player from album art (needs Dynamic Colors on); off keeps the player on the theme color",
             checked = playerDynamicColor,
             onCheckedChange = { viewModel.setPlayerDynamicColor(it) }
         )

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -662,7 +662,7 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
         )
         SettingSwitchItem(
             title = "Blurred Album Background",
-            subtitle = "Fill the player with the album art, stretched and heavily blurred",
+            subtitle = "Behind the lyrics (collapsed and fullscreen): the album art stretched and heavily blurred",
             checked = playerBlurredBackground,
             onCheckedChange = { viewModel.setPlayerBlurredBackground(it) }
         )

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -172,6 +172,8 @@ class SettingsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.8f)
     val playerDynamicColor: StateFlow<Boolean> = preferences.playerDynamicColor
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+    val playerBlurredBackground: StateFlow<Boolean> = preferences.playerBlurredBackground
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
     val appTargetFps: StateFlow<Int> = preferences.appTargetFps
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
     val appRenderResolution: StateFlow<Int> = preferences.appRenderResolution
@@ -397,6 +399,7 @@ class SettingsViewModel @Inject constructor(
     fun setLyrics3dShadowDepth(value: Float) { viewModelScope.launch { preferences.setLyrics3dShadowDepth(value) } }
     fun setLyricsBassReact(value: Float) { viewModelScope.launch { preferences.setLyricsBassReact(value) } }
     fun setPlayerDynamicColor(enabled: Boolean) { viewModelScope.launch { preferences.setPlayerDynamicColor(enabled) } }
+    fun setPlayerBlurredBackground(enabled: Boolean) { viewModelScope.launch { preferences.setPlayerBlurredBackground(enabled) } }
     fun setAppTargetFps(fps: Int) { viewModelScope.launch { preferences.setAppTargetFps(fps) } }
     fun setAppRenderResolution(shortSide: Int) { viewModelScope.launch { preferences.setAppRenderResolution(shortSide) } }
     fun setVisualizerVsyncEnabled(value: Boolean) { viewModelScope.launch { preferences.setVisualizerVsyncEnabled(value) } }

--- a/app/src/main/res/drawable/ic_glass_forward_10.xml
+++ b/app/src/main/res/drawable/ic_glass_forward_10.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Forward 10s: a chunky filled circular arrow (clockwise) with a solid
+         "10", so the liquid-glass shader bevels it into 3D chrome like the other
+         transport glyphs. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9.8,3.79 A8.5,8.5 0 1 0 14.2,3.79 L13.48,6.49 A5.7,5.7 0 1 1 10.53,6.49 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14.2,2.0 L17.8,3.8 L14.2,5.6 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.8,9.7 h1.1 v4.7 h-1.1 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M10.5,12.05 A2.35,2.35 0 1 1 15.2,12.05 A2.35,2.35 0 1 1 10.5,12.05 Z M11.4,12.05 A1.45,1.45 0 1 0 14.3,12.05 A1.45,1.45 0 1 0 11.4,12.05 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_forward_10.xml
+++ b/app/src/main/res/drawable/ic_glass_forward_10.xml
@@ -3,20 +3,31 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Forward 10s: a chunky filled circular arrow (clockwise) with a solid
-         "10", so the liquid-glass shader bevels it into 3D chrome like the other
-         transport glyphs. -->
+    <!-- Forward 10s: a bold clockwise circular arrow (thick ring band with a gap +
+         arrowhead at the top-right) around a solid "10" — the mirror of the
+         rewind glyph, so the liquid-glass shader bevels it into clean 3D chrome.
+         The "10" is NOT mirrored so the digits stay readable. -->
+    <!-- Ring band (~314deg arc, gap at top). -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M9.8,3.79 A8.5,8.5 0 1 0 14.2,3.79 L13.48,6.49 A5.7,5.7 0 1 1 10.53,6.49 Z" />
+        android:pathData="M8.4,3.53 A9.2,9.2 0 1 0 15.6,3.53 L14.66,5.74 A6.8,6.8 0 1 1 9.34,5.74 Z" />
+    <!-- Arrowhead at the right of the gap, pointing right (clockwise). -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M14.2,2.0 L17.8,3.8 L14.2,5.6 Z" />
+        android:pathData="M17.7,4.6 L15.0,2.8 L14.5,5.9 Z" />
+    <!-- "1" -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M8.8,9.7 h1.1 v4.7 h-1.1 z" />
+        android:pathData="M9.4,9.8 h1.2 v5.0 h-1.2 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.6,13.9 h2.8 v0.9 h-2.8 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9.4,9.8 L8.0,10.8 L8.6,11.6 L9.4,11.05 Z" />
+    <!-- "0" ring -->
     <path
         android:fillColor="#FFFFFFFF"
         android:fillType="evenOdd"
-        android:pathData="M10.5,12.05 A2.35,2.35 0 1 1 15.2,12.05 A2.35,2.35 0 1 1 10.5,12.05 Z M11.4,12.05 A1.45,1.45 0 1 0 14.3,12.05 A1.45,1.45 0 1 0 11.4,12.05 Z" />
+        android:pathData="M11.6,12.3 A2.6,2.6 0 1 1 16.8,12.3 A2.6,2.6 0 1 1 11.6,12.3 Z M12.85,12.3 A1.35,1.35 0 1 0 15.55,12.3 A1.35,1.35 0 1 0 12.85,12.3 Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_glass_lyrics.xml
+++ b/app/src/main/res/drawable/ic_glass_lyrics.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Lyrics: a chunky speech bubble with three subtitle lines cut out, so the
+         liquid-glass shader bevels the body and the cut lines into 3D chrome. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M5,3.5 h12 a3,3 0 0 1 3,3 v6 a3,3 0 0 1 -3,3 h-12 a3,3 0 0 1 -3,-3 v-6 a3,3 0 0 1 3,-3 z M5,6.8 h10 v1.4 h-10 z M5,9.5 h10 v1.4 h-10 z M5,12.2 h7 v1.4 h-7 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4.5,15 l0,3.8 l4,-3.3 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_mixer.xml
+++ b/app/src/main/res/drawable/ic_glass_mixer.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Mixer/FX: three slider tracks each with a chunky knob, so the liquid-glass
+         shader bevels the bars and the round knobs into 3D chrome. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,5.1 h18 v1.8 h-18 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M5.6,6 A2.4,2.4 0 1 0 10.4,6 A2.4,2.4 0 1 0 5.6,6 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,11.1 h18 v1.8 h-18 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12.6,12 A2.4,2.4 0 1 0 17.4,12 A2.4,2.4 0 1 0 12.6,12 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,17.1 h18 v1.8 h-18 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4.6,18 A2.4,2.4 0 1 0 9.4,18 A2.4,2.4 0 1 0 4.6,18 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_pause.xml
+++ b/app/src/main/res/drawable/ic_glass_pause.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Two solid bars — chunky so the glass shader bevels them into 3D chrome. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6.5,4.5 h4 v15 h-4 z M13.5,4.5 h4 v15 h-4 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_play.xml
+++ b/app/src/main/res/drawable/ic_glass_play.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Solid play triangle: a chunky filled shape so the liquid-glass shader
+         bevels it into a 3D chrome wedge (thin outline icons bevel poorly). -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M7,4.5 L7,19.5 L19.5,12 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_playlist.xml
+++ b/app/src/main/res/drawable/ic_glass_playlist.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Playlist: three queue lines with a solid eighth note, so the liquid-glass
+         shader bevels the bars, note head, stem and flag into 3D chrome. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,5 h11 v1.8 h-11 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,10 h11 v1.8 h-11 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,15 h8 v1.8 h-8 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M17,8.2 h1.5 v9 h-1.5 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M18.5,8.2 l2.6,1.3 l-2.6,2.2 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M13,17.2 A2.7,2.7 0 1 0 18.4,17.2 A2.7,2.7 0 1 0 13,17.2 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_replay_10.xml
+++ b/app/src/main/res/drawable/ic_glass_replay_10.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Rewind 10s: a chunky filled circular arrow (counter-clockwise) with a
+         solid "10", so the liquid-glass shader bevels it into 3D chrome like the
+         other transport glyphs. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14.2,3.79 A8.5,8.5 0 1 1 9.8,3.79 L10.52,6.49 A5.7,5.7 0 1 0 13.47,6.49 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9.8,2.0 L6.2,3.8 L9.8,5.6 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.8,9.7 h1.1 v4.7 h-1.1 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M10.5,12.05 A2.35,2.35 0 1 1 15.2,12.05 A2.35,2.35 0 1 1 10.5,12.05 Z M11.4,12.05 A1.45,1.45 0 1 0 14.3,12.05 A1.45,1.45 0 1 0 11.4,12.05 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_replay_10.xml
+++ b/app/src/main/res/drawable/ic_glass_replay_10.xml
@@ -3,20 +3,30 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <!-- Rewind 10s: a chunky filled circular arrow (counter-clockwise) with a
-         solid "10", so the liquid-glass shader bevels it into 3D chrome like the
-         other transport glyphs. -->
+    <!-- Rewind 10s: a bold counter-clockwise circular arrow (thick ring band with
+         a gap + arrowhead at the top-left) around a solid "10", so the
+         liquid-glass shader bevels it into clean 3D chrome. -->
+    <!-- Ring band (~314deg arc, gap at top). -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M14.2,3.79 A8.5,8.5 0 1 1 9.8,3.79 L10.52,6.49 A5.7,5.7 0 1 0 13.47,6.49 Z" />
+        android:pathData="M15.6,3.53 A9.2,9.2 0 1 1 8.4,3.53 L9.34,5.74 A6.8,6.8 0 1 0 14.66,5.74 Z" />
+    <!-- Arrowhead at the left of the gap, pointing left (counter-clockwise). -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M9.8,2.0 L6.2,3.8 L9.8,5.6 Z" />
+        android:pathData="M6.3,4.6 L9.0,2.8 L9.5,5.9 Z" />
+    <!-- "1" -->
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M8.8,9.7 h1.1 v4.7 h-1.1 z" />
+        android:pathData="M9.4,9.8 h1.2 v5.0 h-1.2 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.6,13.9 h2.8 v0.9 h-2.8 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9.4,9.8 L8.0,10.8 L8.6,11.6 L9.4,11.05 Z" />
+    <!-- "0" ring -->
     <path
         android:fillColor="#FFFFFFFF"
         android:fillType="evenOdd"
-        android:pathData="M10.5,12.05 A2.35,2.35 0 1 1 15.2,12.05 A2.35,2.35 0 1 1 10.5,12.05 Z M11.4,12.05 A1.45,1.45 0 1 0 14.3,12.05 A1.45,1.45 0 1 0 11.4,12.05 Z" />
+        android:pathData="M11.6,12.3 A2.6,2.6 0 1 1 16.8,12.3 A2.6,2.6 0 1 1 11.6,12.3 Z M12.85,12.3 A1.35,1.35 0 1 0 15.55,12.3 A1.35,1.35 0 1 0 12.85,12.3 Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_glass_skip_next.xml
+++ b/app/src/main/res/drawable/ic_glass_skip_next.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Solid triangle + bar (skip next), chunky for the 3D glass bevel. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M5,5 L5,19 L15,12 Z M16.5,5 h2.5 v14 h-2.5 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_skip_previous.xml
+++ b/app/src/main/res/drawable/ic_glass_skip_previous.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Solid bar + triangle (skip previous), chunky for the 3D glass bevel. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,5 L19,19 L9,12 Z M5,5 h2.5 v14 h-2.5 z" />
+</vector>

--- a/app/src/main/res/drawable/ic_glass_timer.xml
+++ b/app/src/main/res/drawable/ic_glass_timer.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Timer: a stopwatch — chunky ring body, top crossbar + winding stem, and a
+         solid hand — so the liquid-glass shader bevels each into 3D chrome. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8.5,1 h7 v2.2 h-7 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M11,3 h2 v3.8 h-2 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M4.8,14 A7.2,7.2 0 1 1 19.2,14 A7.2,7.2 0 1 1 4.8,14 Z M6.8,14 A5.2,5.2 0 1 0 17.2,14 A5.2,5.2 0 1 0 6.8,14 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M11.3,14 h1.4 v-4.8 h-1.4 z" />
+</vector>

--- a/app/src/test/java/tf/monochrome/android/data/preferences/SettingsSyncCodecTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/preferences/SettingsSyncCodecTest.kt
@@ -1,0 +1,100 @@
+package tf.monochrome.android.data.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsSyncCodecTest {
+
+    private fun roundTrip(values: Map<String, Any>): Map<String, Any> =
+        SettingsSyncCodec.decode(SettingsSyncCodec.encode(values))
+
+    @Test
+    fun `preserves a Boolean`() {
+        val out = roundTrip(mapOf("k" to true))
+        assertEquals(true, out["k"])
+        assertTrue(out["k"] is Boolean)
+    }
+
+    @Test
+    fun `preserves an Int as Int`() {
+        val out = roundTrip(mapOf("k" to 42))
+        assertEquals(42, out["k"])
+        assertTrue("Int must not decode as Long", out["k"] is Int)
+    }
+
+    @Test
+    fun `preserves a Long as Long`() {
+        // 5_000_000_000 doesn't fit in Int — the type tag is what keeps it a Long.
+        val out = roundTrip(mapOf("k" to 5_000_000_000L))
+        assertEquals(5_000_000_000L, out["k"])
+        assertTrue("Long must not decode as Int", out["k"] is Long)
+    }
+
+    @Test
+    fun `preserves a Float as Float`() {
+        val out = roundTrip(mapOf("k" to 1.25f))
+        assertEquals(1.25f, out["k"] as Float, 0f)
+        assertTrue("Float must not decode as Double", out["k"] is Float)
+    }
+
+    @Test
+    fun `preserves a Double as Double`() {
+        val out = roundTrip(mapOf("k" to 3.14159))
+        assertEquals(3.14159, out["k"] as Double, 0.0)
+        assertTrue(out["k"] is Double)
+    }
+
+    @Test
+    fun `preserves a String including empty`() {
+        val out = roundTrip(mapOf("a" to "hello", "b" to ""))
+        assertEquals("hello", out["a"])
+        assertEquals("", out["b"])
+    }
+
+    @Test
+    fun `preserves a StringSet order-independently`() {
+        val out = roundTrip(mapOf("k" to setOf("x", "y", "z")))
+        assertEquals(setOf("x", "y", "z"), out["k"])
+    }
+
+    @Test
+    fun `round-trips a representative multi-type snapshot unchanged`() {
+        val original = mapOf(
+            "theme" to "dark",
+            "font_scale" to 1.15f,
+            "spectrum_fft_size" to 8192,
+            "some_long" to 9_000_000_000L,
+            "dynamic_colors" to false,
+            "favs" to setOf("1", "2"),
+            "preamp" to -6.0,
+        )
+        assertEquals(original, roundTrip(original))
+    }
+
+    @Test
+    fun `skips values of an unsupported type on encode`() {
+        // A nested list isn't a supported type — it's dropped, not thrown.
+        val json = SettingsSyncCodec.encode(mapOf("ok" to 1, "bad" to listOf(1, 2, 3)))
+        val out = SettingsSyncCodec.decode(json)
+        assertEquals(1, out["ok"])
+        assertNull(out["bad"])
+    }
+
+    @Test
+    fun `decode of garbage yields an empty map, never throws`() {
+        assertTrue(SettingsSyncCodec.decode("not json at all").isEmpty())
+        assertTrue(SettingsSyncCodec.decode("").isEmpty())
+        assertTrue(SettingsSyncCodec.decode("[1,2,3]").isEmpty())
+    }
+
+    @Test
+    fun `decode skips entries with a missing or unknown type tag`() {
+        val json = """{"a":{"t":"i","v":5},"b":{"v":7},"c":{"t":"zz","v":1}}"""
+        val out = SettingsSyncCodec.decode(json)
+        assertEquals(5, out["a"])
+        assertNull(out["b"])
+        assertNull(out["c"])
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
@@ -81,4 +81,55 @@ class LyricsFxSettingsTest {
             assertEquals("$name preset should already be within range", preset, preset.clamped())
         }
     }
+
+    @Test
+    fun `clamped coerces the new ray and glass fields`() {
+        val c = LyricsFxSettings(
+            rayAngleDeg = 500f,
+            raySpreadDeg = -30f,
+            rayHueShift = 400f,
+            rayPulseAmount = 5f,
+            glassSampleRings = 9,
+        ).clamped()
+        assertEquals(360f, c.rayAngleDeg, 0f)
+        assertEquals(0f, c.raySpreadDeg, 0f)
+        assertEquals(180f, c.rayHueShift, 0f)
+        assertEquals(1f, c.rayPulseAmount, 0f)
+        assertEquals(3, c.glassSampleRings)
+    }
+
+    @Test
+    fun `new fields survive serialization`() {
+        val original = LyricsFxSettings(
+            customFont = true,
+            customFontPath = "/data/user/0/app/files/custom_fonts/MyFont.ttf",
+            rayFixedDirection = true,
+            rayAngleDeg = 135f,
+            raySpreadDeg = 90f,
+            rayHueShift = -45f,
+            glassSampleRings = 3,
+        )
+        val decoded = json.decodeFromString<LyricsFxSettings>(json.encodeToString(original))
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `applying a preset keeps the personal font and device settings`() {
+        val personal = LyricsFxSettings(
+            customFont = true,
+            customFontPath = "/fonts/Mine.ttf",
+            bluetoothDelayMs = 220f,
+            glassSampleRings = 1,
+        )
+        val theme = LyricsFxSettings.PRESETS.first { it.first == "Neon" }.second
+        val applied = theme.withPersonalFrom(personal)
+        assertTrue(applied.customFont)
+        assertEquals("/fonts/Mine.ttf", applied.customFontPath)
+        assertEquals(220f, applied.bluetoothDelayMs, 0f)
+        assertEquals(1, applied.glassSampleRings)
+        // Aesthetic fields still come from the theme.
+        assertEquals(theme.rayCount, applied.rayCount)
+        // …and the chip-selection helper recognises the match despite the carry-over.
+        assertTrue(applied.matchesPreset(theme))
+    }
 }

--- a/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
@@ -17,9 +17,9 @@ class LyricsFxSettingsTest {
         assertEquals(12f, d.rotationDegrees, 0f)
         assertEquals(0.22f, d.wavePhaseStep, 0f)
         assertEquals(0.8f, d.bassReact, 0f)
-        // Crepuscular god-ray default: a downward fan of soft shafts.
-        assertEquals(14, d.rayCount)
-        assertEquals(150f, d.raySpreadDeg, 0f)
+        // Per-letter god-ray default: a few soft near-vertical shafts per glyph.
+        assertEquals(6, d.rayCount)
+        assertEquals(30f, d.raySpreadDeg, 0f)
     }
 
     @Test

--- a/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
@@ -2,6 +2,7 @@ package tf.monochrome.android.domain.model
 
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -141,5 +142,32 @@ class LyricsFxSettingsTest {
         assertEquals(theme.rayCount, applied.rayCount)
         // …and the chip-selection helper recognises the match despite the carry-over.
         assertTrue(applied.matchesPreset(theme))
+    }
+
+    @Test
+    fun `preset code round-trips through encode and decode`() {
+        val preset = LyricsFxPreset("My Look", LyricsFxSettings(fontSizeSp = 30f, rayCount = 20))
+        val code = LyricsFxPreset.encode(preset)
+        assertTrue("code carries the marker prefix", code.startsWith(LyricsFxPreset.CODE_PREFIX))
+        val back = LyricsFxPreset.decode(code)
+        assertEquals(preset.copy(settings = preset.settings.clamped()), back)
+    }
+
+    @Test
+    fun `decode tolerates a missing prefix and rejects junk`() {
+        val preset = LyricsFxPreset("Shared", LyricsFxSettings())
+        val withoutPrefix = LyricsFxPreset.encode(preset).removePrefix(LyricsFxPreset.CODE_PREFIX)
+        assertEquals("Shared", LyricsFxPreset.decode(withoutPrefix)?.name)
+        assertNull(LyricsFxPreset.decode("just some random text"))
+        assertNull(LyricsFxPreset.decode(""))
+    }
+
+    @Test
+    fun `decode re-clamps hostile out-of-range values`() {
+        val evil = LyricsFxPreset.CODE_PREFIX +
+            """{"name":"Evil","settings":{"fontSizeSp":9999.0,"rayCount":500}}"""
+        val decoded = LyricsFxPreset.decode(evil)!!
+        assertEquals(34f, decoded.settings.fontSizeSp, 0f)
+        assertEquals(24, decoded.settings.rayCount)
     }
 }

--- a/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
@@ -16,7 +16,9 @@ class LyricsFxSettingsTest {
         assertEquals(12f, d.rotationDegrees, 0f)
         assertEquals(0.22f, d.wavePhaseStep, 0f)
         assertEquals(0.8f, d.bassReact, 0f)
-        assertEquals(8, d.rayCount)
+        // Crepuscular god-ray default: a downward fan of soft shafts.
+        assertEquals(14, d.rayCount)
+        assertEquals(150f, d.raySpreadDeg, 0f)
     }
 
     @Test

--- a/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/LyricsFxSettingsTest.kt
@@ -90,12 +90,14 @@ class LyricsFxSettingsTest {
             rayHueShift = 400f,
             rayPulseAmount = 5f,
             glassSampleRings = 9,
+            fxaaStrength = 3f,
         ).clamped()
         assertEquals(360f, c.rayAngleDeg, 0f)
         assertEquals(0f, c.raySpreadDeg, 0f)
         assertEquals(180f, c.rayHueShift, 0f)
         assertEquals(1f, c.rayPulseAmount, 0f)
         assertEquals(3, c.glassSampleRings)
+        assertEquals(1f, c.fxaaStrength, 0f)
     }
 
     @Test
@@ -108,6 +110,8 @@ class LyricsFxSettingsTest {
             raySpreadDeg = 90f,
             rayHueShift = -45f,
             glassSampleRings = 3,
+            fxaa = true,
+            fxaaStrength = 0.4f,
         )
         val decoded = json.decodeFromString<LyricsFxSettings>(json.encodeToString(original))
         assertEquals(original, decoded)
@@ -120,6 +124,8 @@ class LyricsFxSettingsTest {
             customFontPath = "/fonts/Mine.ttf",
             bluetoothDelayMs = 220f,
             glassSampleRings = 1,
+            fxaa = true,
+            fxaaStrength = 0.9f,
         )
         val theme = LyricsFxSettings.PRESETS.first { it.first == "Neon" }.second
         val applied = theme.withPersonalFrom(personal)
@@ -127,6 +133,8 @@ class LyricsFxSettingsTest {
         assertEquals("/fonts/Mine.ttf", applied.customFontPath)
         assertEquals(220f, applied.bluetoothDelayMs, 0f)
         assertEquals(1, applied.glassSampleRings)
+        assertTrue(applied.fxaa)
+        assertEquals(0.9f, applied.fxaaStrength, 0f)
         // Aesthetic fields still come from the theme.
         assertEquals(theme.rayCount, applied.rayCount)
         // …and the chip-selection helper recognises the match despite the carry-over.

--- a/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
@@ -1,0 +1,152 @@
+package tf.monochrome.android.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerGlassSettingsTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test
+    fun `defaults reproduce the shipped glass`() {
+        val d = PlayerGlassSettings.DEFAULT
+        assertTrue(d.enabled)
+        assertEquals(0.5f, d.bodyOpacity, 0f)
+        assertEquals(0.16f, d.refraction, 0f)
+        assertEquals(1.3f, d.rimBrightness, 0f)
+        assertEquals(2, d.sampleRings)
+        assertTrue(d.progressGlass)
+        // Colour fields default to "use the current album colour".
+        assertEquals(0, d.tintColor)
+        assertEquals(0, d.previewBg)
+    }
+
+    @Test
+    fun `clamped coerces out-of-range values`() {
+        val c = PlayerGlassSettings(
+            bodyOpacity = 9f,
+            refraction = -1f,
+            dispersion = 99f,
+            sampleRings = 100,
+            lightAngleDeg = 999f,
+        ).clamped()
+        assertEquals(1f, c.bodyOpacity, 0f)
+        assertEquals(0f, c.refraction, 0f)
+        assertEquals(2f, c.dispersion, 0f)
+        assertEquals(3, c.sampleRings)
+        assertEquals(360f, c.lightAngleDeg, 0f)
+    }
+
+    @Test
+    fun `clamped replaces non-finite values with defaults`() {
+        val c = PlayerGlassSettings(
+            reflection = Float.NaN,
+            gloss = Float.POSITIVE_INFINITY,
+        ).clamped()
+        assertEquals(PlayerGlassSettings.DEFAULT.reflection, c.reflection, 0f)
+        assertEquals(PlayerGlassSettings.DEFAULT.gloss, c.gloss, 0f)
+    }
+
+    @Test
+    fun `serialization round-trips every field`() {
+        val original = PlayerGlassSettings(
+            enabled = false,
+            bodyOpacity = 0.7f,
+            refraction = 0.3f,
+            gloss = 0.9f,
+            surfaceMotion = 0.5f,
+            tintColor = 0x8834AACC.toInt(),
+            previewBg = 0xFF101010.toInt(),
+            progressGlass = false,
+        )
+        val decoded = json.decodeFromString<PlayerGlassSettings>(json.encodeToString(original))
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `unknown future keys decode without failing`() {
+        val body = """{"bodyOpacity":0.6,"someBrandNewGlassKnob":3.0}"""
+        val decoded = json.decodeFromString<PlayerGlassSettings>(body)
+        assertEquals(0.6f, decoded.bodyOpacity, 0f)
+        assertEquals(PlayerGlassSettings.DEFAULT.refraction, decoded.refraction, 0f)
+    }
+
+    @Test
+    fun `presets are all valid after clamping`() {
+        PlayerGlassSettings.PRESETS.forEach { (name, preset) ->
+            assertEquals("$name preset should already be within range", preset, preset.clamped())
+        }
+    }
+
+    @Test
+    fun `presets never touch the user colour or preview background`() {
+        PlayerGlassSettings.PRESETS.forEach { (name, preset) ->
+            assertEquals("$name preset must leave tintColor at 0", 0, preset.tintColor)
+            assertEquals("$name preset must leave previewBg at 0", 0, preset.previewBg)
+        }
+    }
+
+    @Test
+    fun `applying a theme keeps the personal colour and perf settings`() {
+        val personal = PlayerGlassSettings(
+            sampleRings = 1,
+            tintColor = 0xFF22CCFF.toInt(),
+            previewBg = 0xFF000000.toInt(),
+        )
+        val theme = PlayerGlassSettings.PRESETS.first { it.first == "Neon" }.second
+        val applied = theme.withPersonalFrom(personal)
+        assertEquals(1, applied.sampleRings)
+        assertEquals(0xFF22CCFF.toInt(), applied.tintColor)
+        assertEquals(0xFF000000.toInt(), applied.previewBg)
+        // Material fields still come from the theme.
+        assertEquals(theme.rimBrightness, applied.rimBrightness, 0f)
+        assertEquals(theme.reflection, applied.reflection, 0f)
+        // …and the chip-selection helper recognises the match despite the carry-over.
+        assertTrue(applied.matchesPreset(theme))
+    }
+
+    @Test
+    fun `matchesPreset is false for a different material`() {
+        val chrome = PlayerGlassSettings.PRESETS.first { it.first == "Chrome" }.second
+        val frosted = PlayerGlassSettings.PRESETS.first { it.first == "Frosted" }.second
+        assertTrue(chrome.matchesPreset(chrome))
+        assertTrue(!chrome.matchesPreset(frosted))
+    }
+
+    @Test
+    fun `preset code round-trips through encode and decode`() {
+        val preset = PlayerGlassPreset("My Glass", PlayerGlassSettings(bodyOpacity = 0.8f, gloss = 0.9f))
+        val code = PlayerGlassPreset.encode(preset)
+        assertTrue("code carries the marker prefix", code.startsWith(PlayerGlassPreset.CODE_PREFIX))
+        val back = PlayerGlassPreset.decode(code)
+        assertEquals(preset.copy(settings = preset.settings.clamped()), back)
+    }
+
+    @Test
+    fun `decode tolerates a missing prefix and rejects junk`() {
+        val preset = PlayerGlassPreset("Shared", PlayerGlassSettings())
+        val withoutPrefix = PlayerGlassPreset.encode(preset).removePrefix(PlayerGlassPreset.CODE_PREFIX)
+        assertEquals("Shared", PlayerGlassPreset.decode(withoutPrefix)?.name)
+        assertNull(PlayerGlassPreset.decode("just some random text"))
+        assertNull(PlayerGlassPreset.decode(""))
+    }
+
+    @Test
+    fun `decode re-clamps hostile out-of-range values`() {
+        val evil = PlayerGlassPreset.CODE_PREFIX +
+            """{"name":"Evil","settings":{"bodyOpacity":9999.0,"sampleRings":500}}"""
+        val decoded = PlayerGlassPreset.decode(evil)!!
+        assertEquals(1f, decoded.settings.bodyOpacity, 0f)
+        assertEquals(3, decoded.settings.sampleRings)
+    }
+
+    @Test
+    fun `blank imported name falls back to Imported`() {
+        val code = PlayerGlassPreset.CODE_PREFIX +
+            """{"name":"   ","settings":{}}"""
+        assertEquals("Imported", PlayerGlassPreset.decode(code)?.name)
+    }
+}

--- a/docs/supabase/user_settings.sql
+++ b/docs/supabase/user_settings.sql
@@ -1,0 +1,60 @@
+-- user_settings: one row per user holding a JSON blob of the app's
+-- allow-listed preferences (theme, Lyrics FX, EQ/DSP, visualizer, radio
+-- weights, …). The client writes it via SupabaseSyncRepository.pushSettings()
+-- and restores it on sign-in via pullSettings(). The blob is produced by
+-- SettingsSyncCodec (a tagged {"t":type,"v":value} object) so Int/Long/Float/
+-- Double round-trip exactly. Sensitive/device-only keys (auth tokens, device
+-- ids, per-device GPU/fps tuning, local file paths) are never included — see
+-- PreferencesManager.SETTINGS_SYNC_KEYS.
+--
+-- Run this in the Supabase SQL editor for the project that owns the app.
+
+create table if not exists public.user_settings (
+    user_id     uuid primary key
+                references auth.users (id) on delete cascade,
+    payload     jsonb       not null default '{}'::jsonb,
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+-- Keep updated_at fresh on every write (used for last-write-wins).
+create or replace function public.set_user_settings_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+    new.updated_at := now();
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_user_settings_updated_at on public.user_settings;
+create trigger trg_user_settings_updated_at
+    before update on public.user_settings
+    for each row execute function public.set_user_settings_updated_at();
+
+-- RLS: a user may only see and modify their own settings row.
+alter table public.user_settings enable row level security;
+
+drop policy if exists "user_settings_select_own" on public.user_settings;
+create policy "user_settings_select_own"
+    on public.user_settings for select
+    using (auth.uid() = user_id);
+
+drop policy if exists "user_settings_insert_own" on public.user_settings;
+create policy "user_settings_insert_own"
+    on public.user_settings for insert
+    with check (auth.uid() = user_id);
+
+drop policy if exists "user_settings_update_own" on public.user_settings;
+create policy "user_settings_update_own"
+    on public.user_settings for update
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);
+
+drop policy if exists "user_settings_delete_own" on public.user_settings;
+create policy "user_settings_delete_own"
+    on public.user_settings for delete
+    using (auth.uid() = user_id);


### PR DESCRIPTION
Started as a fix for the 3D lyric glyphs overlapping, and grew into a full lyrics / liquid-glass and player-visuals overhaul — including a tunable player-glass system (transport buttons, action dock, progress scrubber, and mini player) with sharable themes — plus a Supabase settings-sync feature (and the sync bug-fixes / live schema fixes uncovered along the way).

## Lyrics rendering & liquid glass
- **Fix glyph overlap** — lay out a horizontal gap sized to the peak 3D swell + extruded backing so letters kiss instead of collide (worst on CJK, which has no side bearing).
- **True refractive liquid glass** — reworked the `liquidGlass()` AGSL shader so the glyph body is see-through and the album-tinted backdrop is reconstructed in-shader and *lensed* through the bevel with per-channel chromatic aberration and a bright specular rim. The active line is handed to it solid; below API 33 (or on shader-compile failure) it's a no-op.
- **Physically-based relight** — the shared glass shader was rebuilt on proper optics: Schlick Fresnel, Snell refraction with per-channel dispersion, and a procedural environment ("room") reflection, with the surface ripple gated to bevels and the glint Fresnel-weighted so flat faces stay clean (no blob-lattice / specular wash).
- **FXAA anti-aliasing** — single-pass luma FXAA `RenderEffect` chained on the glass output (fixes the jaggies from the 3D tilt + reduced panel resolution).
- **One row per line, full width** — collapsed lyrics render each line on a single row across a full-screen-width surface, shrinking the font (down to 11sp) only when a line would overflow, never wrapping or cutting; bass-bounce headroom is reserved when fitting long lines so the pump never clips.
- **Decouple the lyric area from the album square** + a fixed bevel-safe side inset, so the tall 3D/glass letters and their bevels get vertical room and edge letters are never corner-cut; thin top/bottom edge feather so lines reach the borders.
- **Album ↔ lyrics dissolve** — replaced the snapping `Crossfade` with an explicit alpha dissolve (art fades out while the lyric surface fades in).
- **Debug logging** of the lyrics pipeline into the in-app Debug Log (state transitions only, never per-frame).

## Lyrics FX Studio
- All liquid-glass params exposed as sliders (opacity, refraction, edge highlight, chromatic aberration, bevel sample count).
- **Bluetooth sync delay** (−500..1500 ms) to line lyrics up with BT audio latency.
- **Custom lyrics font** with a collapsible picker over imported fonts.
- **10 themes** (Aurora, Neon, Frost, Ember, Cinematic, Vaporwave, Minimal Glass, Karaoke Pop, Sunbeam, Nightdrive); applying a theme preserves personal/device settings.
- **Edge margin + lines-per-block** controls, and a **live now-playing preview** (real synced lyrics when a track is playing).
- **Save / share / import custom presets** — share as a single copy-pasteable code (`TRYPTFX1:` + JSON); import re-clamps on the way in.
- **Perf:** debounced settings persistence so slider drags no longer round-trip through DataStore every frame.
- Studio reachable straight from the player's 3-dot overflow menu.

## Player visuals
- **Blurred, stretched album-art background** (Apple-Music / Spotify style) — shown only while lyrics are on (collapsed *and* fullscreen), cross-fading with the transition, over a deepened album-tinted scrim; the lyric glass lenses the real album tones behind it.
- **Dynamic Colors is now a true master switch** — off makes the *whole* player static (background, glow, accents, glass), not just the app theme.
- **God rays** were iterated (per-glyph starbursts → crepuscular fan → per-letter shafts) and then **removed** from the app.

## Player glass — transport, dock, progress & mini player
A single tunable AGSL glass treatment (`playerGlass` / `liquidGlassPanel`, the same `LIQUID_GLASS_SRC` as the lyrics) across all player chrome, with a **Player Glass** Studio tab driving it.
- **Transport buttons** — the play/pause button is a solid glass disc with the symbol punched out (`BlendMode.Clear`); prev·play·next (the ±10s buttons were removed). Skip glyphs are solid glass, 50% larger, with shape-accurate blurred drop shadows (the round disc shadow is a blurred circle, not the platform elevation shadow that facets into an octagon).
- **Action dock** — one liquid-glass slab with the four tool icons (Lyrics / Timer / Mixer / Playlist) hollowed out of it via `DstOut`, label-less, accent-filled, icons grown to fill the freed space.
- **Glass progress bar** — a thin liquid-glass "thermometer" tube scrubber that fills up, with a playhead dot that swells the tube into a smooth sine-wave bulge (toggleable; falls back to a Material slider). Drag-to-seek commits the drag's final position.
- **Press-bulge on every glass tap** — pressing any glass control (play disc, skip icons, dock buttons, mini-player buttons) swells the glass into an animated shader dome under the finger, replacing the square Material ripple.
- **Full control set** in the Studio tab: opacity, refraction, edge highlight, chromatic aberration, sample rings, roundness, depth, reflection, gloss, surface motion, tilt reactivity, light angle, edge width, frosted blur, and shadow depth/softness/tint — over a pinned live preview, plus background + button-tint colour swatches with an HSV picker (current/custom).
- **Theme system** — 11 built-in glass materials (Chrome, Frosted, Liquid, Crystal, Bubble, Minimal, Neon, Obsidian, Pillow, Mirror, Default) plus save / import / share of custom themes as a copy-pasteable code (`TRYPTGLASS1:` + JSON); a theme changes only the material and preserves the user's colour/perf.
- **Mini player** — the persistent bottom bar now renders as the same tunable glass with its play/skip icons punched out like the dock and the press-bulge on tap, with a dedicated **Mini Player** Studio tab (its own synced settings blob, sharing the same controls, live mini-player preview, and theme pool). Falls back to the previous haze bar + Material icons below API 33 or when button glass is off, and clears the screen edges on wide displays.
- **Perf** — one ref-counted gravity-sensor listener shared across all glass surfaces instead of one per modifier.

## Supabase — settings sync & fixes
- **Sync all settings to the user database** — a pure, type-tagged `SettingsSyncCodec` (Int/Long/Float/Double survive the JSON round-trip), an allow-list in `PreferencesManager` (auth tokens, device ids, per-device tuning and local file paths are never exported), `push/pullSettings`, and a debounced `SettingsSyncCoordinator` that auto-saves on change and pulls on sign-in. The player-glass, mini-player-glass and theme-preset keys ride this sync automatically.
- **Sync correctness fixes** found in a multi-agent audit — `pullAll` now dedups play-events (no more inflating Listening Stats), `pushAll` pushes only un-synced events, and the sync UI reports "finished with issues" instead of a false "Sync complete".
- **Live database fixes** (applied to the project, also tracked in `docs/supabase/`):
  - Added the missing **`play_history.unified_json`** column — the real "lingering error" that was silently 400-ing every Recently-Played push.
  - Created the **`user_settings`** table (per-user `jsonb`, updated-at trigger, 4 RLS policies) that settings-sync writes to.

## Housekeeping
- CI compile fixes along the way (`isSp`, preset `decode` return, `animateFloat` import) and test updates to match the retuned defaults; new `PlayerGlassSettingsTest` covering clamp / serialization / theme carry-over / matchesPreset / hostile-code re-clamp.

> Note: the AGSL shader / glass visuals can't be verified in CI — they need an on-device look. All Kotlin checks (build, Unit Tests, Android Lint, Build Debug APK) run on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)