### PR TITLE
UI/UX audit remediation (P0–P7) + local album-art auto-restore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,34 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Run unit tests
+        shell: bash
+        run: |
+          set -o pipefail
+          ./gradlew testDebugUnitTest --stacktrace 2>&1 | tee gradle-test.log
+
+      - name: Summarize test failure
+        if: failure()
+        run: |
+          echo "::group::Gradle test failure tail"
+          tail -n 200 gradle-test.log | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "::endgroup::"
+          first=$(grep -E -m 1 "^e: |FAILURE:|error:|Unresolved reference|Execution failed|> There were failing tests" gradle-test.log || true)
+          if [ -n "$first" ]; then
+            echo "::error::$first"
+          fi
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-report
+          path: |
+            app/build/reports/tests/testDebugUnitTest
+            gradle-test.log
+          retention-days: 14
+          if-no-files-found: ignore
+
       - name: Build debug APK
         shell: bash
         run: |

--- a/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
+++ b/app/src/main/java/tf/monochrome/android/MonochromeApp.kt
@@ -87,6 +87,9 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
     @Inject
     lateinit var settingsSyncCoordinator: tf.monochrome.android.data.sync.SettingsSyncCoordinator
 
+    @Inject
+    lateinit var artworkRefreshDetector: tf.monochrome.android.data.local.scanner.ArtworkRefreshDetector
+
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override val workManagerConfiguration: Configuration
@@ -174,6 +177,13 @@ class MonochromeApp : Application(), Configuration.Provider, SingletonImageLoade
         // Auto-save app settings to the user's Supabase row: pull on sign-in,
         // then push (debounced) whenever an allow-listed setting changes.
         settingsSyncCoordinator.start(appScope)
+        // Local-file album art self-heal. Covers extracted at scan time live
+        // in cacheDir/artwork, which Android reaps under storage pressure —
+        // without this check the library shows placeholders after a cache
+        // wipe until the user manually hits refresh.
+        appScope.launch {
+            runCatching { artworkRefreshDetector.refreshIfArtworkMissing() }
+        }
     }
 
     private fun registerPlaybackNotificationChannel() {

--- a/app/src/main/java/tf/monochrome/android/data/auth/SupabaseAuthManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/auth/SupabaseAuthManager.kt
@@ -74,6 +74,11 @@ class SupabaseAuthManager @Inject constructor(
     private val _isSigningIn = MutableStateFlow(false)
     val isSigningIn: StateFlow<Boolean> = _isSigningIn.asStateFlow()
 
+    // The Google OAuth Custom Tab has no "cancelled" callback, so track whether
+    // a deep-link callback ever arrived. If the user returns to the app without
+    // one, cancelPendingSignInIfNoCallback clears the stuck spinner.
+    @Volatile private var oauthCallbackReceived = false
+
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
@@ -98,6 +103,7 @@ class SupabaseAuthManager @Inject constructor(
      *   tf.monotrypt.android://login-callback?code=...
      */
     suspend fun signInWithGoogle(context: Context) {
+        oauthCallbackReceived = false
         _isSigningIn.value = true
         _errorMessage.value = null
         _successMessage.value = null
@@ -119,7 +125,19 @@ class SupabaseAuthManager @Inject constructor(
      * Implicit flow: tokens arrive in the URL fragment (#access_token=...&refresh_token=...)
      * PKCE fallback: code arrives as query param (?code=...)
      */
+    /**
+     * Clear a stuck "Signing in…" state when the user came back from the OAuth
+     * Custom Tab without completing it (there is no cancel callback, so the
+     * screen calls this on resume). No-op once a deep-link callback has arrived.
+     */
+    fun cancelPendingSignInIfNoCallback() {
+        if (_isSigningIn.value && !oauthCallbackReceived) {
+            _isSigningIn.value = false
+        }
+    }
+
     suspend fun handleDeepLink(uri: Uri) {
+        oauthCallbackReceived = true
         Log.d("SupabaseAuth", "Deep-link received: $uri")
         Log.d("SupabaseAuth", "Fragment: ${uri.fragment}")
         try {

--- a/app/src/main/java/tf/monochrome/android/data/downloads/DownloadManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/downloads/DownloadManager.kt
@@ -3,8 +3,10 @@ package tf.monochrome.android.data.downloads
 import android.content.Context
 import androidx.lifecycle.asFlow
 import androidx.work.Constraints
+import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -51,6 +53,9 @@ class DownloadManager @Inject constructor(
         val artistName: String,
         val artworkUri: String?,
         val isThxSpatialAudio: Boolean,
+        // The exact worker input used to enqueue this download, kept so a failed
+        // download can be re-run without needing the original Track back.
+        val inputData: Data,
     )
     private val meta = ConcurrentHashMap<Long, DownloadMeta>()
 
@@ -72,13 +77,35 @@ class DownloadManager @Inject constructor(
         workManager.cancelAllWorkByTag("download")
     }
 
-    private fun enqueueDownload(track: Track) {
-        meta[track.id] = DownloadMeta(
-            title = track.title,
-            artistName = track.artist?.name ?: track.displayArtist.ifBlank { "Unknown Artist" },
-            artworkUri = track.coverUrl,
-            isThxSpatialAudio = track.isThxSpatialAudio,
+    /**
+     * Re-run a previously enqueued download (typically after a FAILED state).
+     * REPLACE clears the terminal work record and starts fresh, so the failed
+     * row turns back into a queued/downloading one.
+     */
+    fun retry(trackId: Long) {
+        val data = meta[trackId]?.inputData ?: return
+        workManager.enqueueUniqueWork(
+            "download_$trackId",
+            ExistingWorkPolicy.REPLACE,
+            buildRequest(trackId, data),
         )
+    }
+
+    private fun buildRequest(trackId: Long, inputData: Data): OneTimeWorkRequest {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+        return OneTimeWorkRequestBuilder<DownloadWorker>()
+            .setInputData(inputData)
+            .setConstraints(constraints)
+            .addTag("download")
+            // Per-track tag so the aggregate observer can recover the track id
+            // from WorkInfo (which doesn't expose the unique work name).
+            .addTag("download_$trackId")
+            .build()
+    }
+
+    private fun enqueueDownload(track: Track) {
         val inputData = workDataOf(
             DownloadWorker.KEY_TRACK_ID to track.id,
             DownloadWorker.KEY_TRACK_TITLE to track.title,
@@ -89,24 +116,18 @@ class DownloadManager @Inject constructor(
             DownloadWorker.KEY_VERSION to track.version,
             DownloadWorker.KEY_IS_THX to track.isThxSpatialAudio,
         )
-
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
-        val downloadRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-            .setInputData(inputData)
-            .setConstraints(constraints)
-            .addTag("download")
-            // Per-track tag so the aggregate observer can recover the track id
-            // from WorkInfo (which doesn't expose the unique work name).
-            .addTag("download_${track.id}")
-            .build()
+        meta[track.id] = DownloadMeta(
+            title = track.title,
+            artistName = track.artist?.name ?: track.displayArtist.ifBlank { "Unknown Artist" },
+            artworkUri = track.coverUrl,
+            isThxSpatialAudio = track.isThxSpatialAudio,
+            inputData = inputData,
+        )
 
         workManager.enqueueUniqueWork(
             "download_${track.id}",
             ExistingWorkPolicy.KEEP,
-            downloadRequest
+            buildRequest(track.id, inputData),
         )
     }
 
@@ -141,7 +162,15 @@ class DownloadManager @Inject constructor(
             .asFlow()
             .map { workInfos ->
                 workInfos
-                    .filter { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING || it.state == WorkInfo.State.BLOCKED }
+                    // Keep FAILED alongside the in-flight states — otherwise a
+                    // failed download silently disappeared from the pill and the
+                    // monitor with no way to see or retry it.
+                    .filter {
+                        it.state == WorkInfo.State.ENQUEUED ||
+                            it.state == WorkInfo.State.RUNNING ||
+                            it.state == WorkInfo.State.BLOCKED ||
+                            it.state == WorkInfo.State.FAILED
+                    }
                     .mapNotNull { info ->
                         val trackId = info.tags
                             .firstOrNull { it.startsWith("download_") }
@@ -152,6 +181,7 @@ class DownloadManager @Inject constructor(
                         val progress = info.progress.getFloat(DownloadWorker.KEY_PROGRESS, 0f)
                         val status = when (info.state) {
                             WorkInfo.State.RUNNING -> DownloadStatus.DOWNLOADING
+                            WorkInfo.State.FAILED -> DownloadStatus.FAILED
                             else -> DownloadStatus.QUEUED
                         }
                         id to TrackDownloadState(status, progress)

--- a/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/PlaylistImportService.kt
@@ -87,8 +87,13 @@ class PlaylistImportService @Inject constructor(
                 ?: musicRepository.searchTracks(query).getOrNull().orEmpty()
 
             val bestMatch = if (strictAlbumMatch && csvTrack.album.isNotBlank()) {
-                results.find { it.album?.title?.equals(csvTrack.album, ignoreCase = true) == true }
-                    ?: results.firstOrNull()
+                // Truly strict: if no result's album matches, leave the row
+                // unmatched rather than substituting an arbitrary same-named
+                // track from a different album. Titles are normalized (edition
+                // suffixes, punctuation) so "(Remastered)" etc. don't cause
+                // false misses.
+                val wanted = normalizeAlbum(csvTrack.album)
+                results.find { normalizeAlbum(it.album?.title.orEmpty()) == wanted }
             } else {
                 results.firstOrNull()
             }
@@ -111,4 +116,20 @@ class PlaylistImportService @Inject constructor(
         _progress.value = done
         return done
     }
+
+    /**
+     * Normalize an album title for strict comparison: drop parenthetical/
+     * bracketed qualifiers and common edition/remaster wording, strip
+     * punctuation, and collapse whitespace so "Album (Remastered 2011)" and
+     * "Album - Deluxe Edition" compare equal to "Album".
+     */
+    private fun normalizeAlbum(raw: String): String =
+        raw.lowercase()
+            .replace(Regex("\\(.*?\\)|\\[.*?]"), " ")
+            .replace(
+                Regex("\\b(remaster(ed)?|deluxe|expanded|anniversary|edition|version|mono|stereo|bonus|track)\\b(\\s+\\d{2,4})?"),
+                " "
+            )
+            .replace(Regex("[^a-z0-9]+"), " ")
+            .trim()
 }

--- a/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/db/LocalMediaDao.kt
@@ -71,6 +71,12 @@ interface LocalMediaDao {
     @Query("SELECT filePath, lastModified, artworkCacheKey, hasEmbeddedArt, artist, title FROM local_tracks")
     suspend fun getAllTrackScanInfo(): List<TrackScanInfo>
 
+    // Distinct because album-cover propagation gives every track in an album
+    // the same key — a 500-track album is one row here, so the startup
+    // artwork eviction probe stays cheap.
+    @Query("SELECT DISTINCT artworkCacheKey FROM local_tracks WHERE artworkCacheKey IS NOT NULL")
+    suspend fun getDistinctArtworkCacheKeys(): List<String>
+
     // ── Albums ──────────────────────────────────────────────────────
 
     @Query("SELECT * FROM local_albums ORDER BY artist, title")

--- a/app/src/main/java/tf/monochrome/android/data/local/scanner/ArtworkRefreshDetector.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/scanner/ArtworkRefreshDetector.kt
@@ -1,0 +1,71 @@
+package tf.monochrome.android.data.local.scanner
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import tf.monochrome.android.data.local.db.LocalMediaDao
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Detects evicted album-art cache files at app start and self-heals.
+ *
+ * Embedded covers are extracted to `cacheDir/artwork` at scan time, and
+ * Android reclaims the cache directory under storage pressure (or a
+ * "cleaner" app / manual "Clear cache" wipes it). Room rows then point at
+ * vanished JPGs, so every local track and album renders a placeholder until
+ * the user manually hits refresh in the Library tab. Running
+ * [refreshIfArtworkMissing] once per process start makes that repair
+ * automatic — needsReRead() already re-extracts art for rows whose cache
+ * file is gone; nothing was triggering it without user action.
+ *
+ * Only keys inside our own artwork cache dir are probed. Sidecar covers
+ * (cover.jpg next to the audio) live on external storage, where a missing
+ * file can simply mean an unmounted SD card — auto-starting a scan in that
+ * state would prune the whole volume's tracks from the library.
+ */
+@Singleton
+class ArtworkRefreshDetector @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val localMediaDao: LocalMediaDao,
+    private val scanCoordinator: ScanCoordinator,
+) {
+
+    suspend fun refreshIfArtworkMissing() {
+        // Empty library: nothing to repair, and onboarding's ScanWorker owns
+        // the first scan.
+        if (localMediaDao.getTrackCount() == 0) return
+
+        val evicted = countEvictedArtwork(
+            cachedKeys = localMediaDao.getDistinctArtworkCacheKeys(),
+            artworkCacheDirPath = File(context.cacheDir, "artwork").absolutePath,
+        )
+        if (evicted == 0) return
+
+        Log.i(TAG, "$evicted cached artwork file(s) evicted — rescanning to restore album art")
+        // fullScan, not incremental: the cache files vanished without the
+        // audio files' mtime changing, and only fullScan's needsReRead()
+        // path re-checks artwork existence. It re-reads tags solely for the
+        // broken rows, so an otherwise-intact library passes through fast.
+        scanCoordinator.runFullScan()
+    }
+
+    companion object {
+        private const val TAG = "ArtworkRefresh"
+
+        /**
+         * Count cache keys under [artworkCacheDirPath] whose file no longer
+         * exists. Pure function so it's unit testable; [artworkFileExists]
+         * is injectable for the same reason.
+         */
+        fun countEvictedArtwork(
+            cachedKeys: List<String>,
+            artworkCacheDirPath: String,
+            artworkFileExists: (String) -> Boolean = { File(it).exists() },
+        ): Int {
+            val root = artworkCacheDirPath.trimEnd('/') + "/"
+            return cachedKeys.count { it.startsWith(root) && !artworkFileExists(it) }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/data/local/scanner/ScanCoordinator.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/scanner/ScanCoordinator.kt
@@ -28,6 +28,9 @@ class ScanCoordinator @Inject constructor(
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
 
+    /** Clears the last terminal progress so the UI can dismiss the bar. */
+    fun clearProgress() { _scanProgress.value = null }
+
     /** Runs a full scan, or returns immediately if any scan is in flight. */
     suspend fun runFullScan() = runGuarded { mediaScanner.fullScan() }
 

--- a/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
+++ b/app/src/main/java/tf/monochrome/android/data/local/tags/TagReader.kt
@@ -416,6 +416,11 @@ class TagReader @Inject constructor(
 
         if (!cacheFile.exists()) {
             try {
+                // The lazy mkdirs above runs once per process, but the cache
+                // dir can vanish mid-process (Settings "Clear cache", OS
+                // eviction) — recreate it or this write fails silently and
+                // every track falls back to its raw file path.
+                artworkCacheDir.mkdirs()
                 FileOutputStream(cacheFile).use { it.write(artworkBytes) }
             } catch (_: Exception) {
                 return filePath // fallback

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -238,6 +238,11 @@ class PreferencesManager @Inject constructor(
         // Library tab order
         private val LIBRARY_TAB_ORDER = stringPreferencesKey("library_tab_order")
 
+        // Library sort selections (serialized "<KEY>:asc" / "<KEY>:desc")
+        private val SONG_SORT = stringPreferencesKey("library_song_sort")
+        private val ALBUM_SORT = stringPreferencesKey("library_album_sort")
+        private val ARTIST_SORT = stringPreferencesKey("library_artist_sort")
+
         // Car mode
         private val CAR_MODE_BAND_COUNT = intPreferencesKey("car_mode_band_count")
 
@@ -1144,6 +1149,14 @@ class PreferencesManager @Inject constructor(
     suspend fun setLibraryTabOrder(order: List<String>) {
         dataStore.edit { it[LIBRARY_TAB_ORDER] = order.joinToString(",") }
     }
+
+    // --- Library sort selections (persist Songs/Albums/Artists sort order) ---
+    val songSort: Flow<String?> = dataStore.data.map { it[SONG_SORT] }
+    val albumSort: Flow<String?> = dataStore.data.map { it[ALBUM_SORT] }
+    val artistSort: Flow<String?> = dataStore.data.map { it[ARTIST_SORT] }
+    suspend fun setSongSort(value: String) { dataStore.edit { it[SONG_SORT] = value } }
+    suspend fun setAlbumSort(value: String) { dataStore.edit { it[ALBUM_SORT] = value } }
+    suspend fun setArtistSort(value: String) { dataStore.edit { it[ARTIST_SORT] = value } }
 
     // --- Car mode ---
     val carModeBandCount: Flow<Int> = dataStore.data.map { it[CAR_MODE_BAND_COUNT] ?: 10 }

--- a/app/src/main/java/tf/monochrome/android/player/QueueManager.kt
+++ b/app/src/main/java/tf/monochrome/android/player/QueueManager.kt
@@ -105,16 +105,24 @@ class QueueManager @Inject constructor() {
         if (fromIndex !in queue.indices || toIndex !in queue.indices) return
         if (fromIndex == toIndex) return
 
-        val currentTrack = queue.getOrNull(_currentIndex.value)
+        val cur = _currentIndex.value
 
         val item = queue.removeAt(fromIndex)
         queue.add(toIndex, item)
-
         _queue.value = queue
-        _currentIndex.value = currentTrack
-            ?.let { track -> queue.indexOfFirst { it.id == track.id } }
-            ?.takeIf { it >= 0 }
-            ?: _currentIndex.value.coerceIn(0, queue.lastIndex)
+
+        // Track the current position through the move POSITIONALLY, not by an
+        // id search: indexOfFirst{ it.id == current.id } jumped the now-playing
+        // marker onto the wrong copy whenever the queue held duplicate tracks.
+        _currentIndex.value = when {
+            cur == fromIndex -> toIndex // the moved item itself was playing
+            else -> {
+                var c = cur
+                if (fromIndex < c) c-- // an earlier item was pulled out
+                if (toIndex <= c) c++ // an item was inserted at/before it
+                c.coerceIn(0, queue.lastIndex)
+            }
+        }
         updateCurrentTrack()
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/carmode/GraphicEqComponent.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/carmode/GraphicEqComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -104,7 +105,7 @@ fun EqSlider(
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(20.dp)
+                .heightIn(min = 20.dp)
         )
 
         Spacer(modifier = Modifier.height(4.dp))
@@ -118,7 +119,7 @@ fun EqSlider(
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(16.dp)
+                .heightIn(min = 16.dp)
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/components/A11yModifiers.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/A11yModifiers.kt
@@ -1,0 +1,62 @@
+package tf.monochrome.android.ui.components
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
+
+/**
+ * Shared accessibility helpers for the app's custom Canvas controls.
+ *
+ * The player, mixer and EQ are built from raw [androidx.compose.foundation.Canvas]
+ * widgets (faders, knobs, the seek tube, mute/solo boxes). Canvas emits no
+ * semantics of its own, so TalkBack announced them as unlabeled — or not at all.
+ * These modifiers attach the missing semantics without changing the visuals.
+ */
+
+/**
+ * Semantics for a custom control that represents a value along a range —
+ * a fader, knob, or seek bar. TalkBack reads [label] and [stateText], and the
+ * [setProgress] action lets the user adjust it with swipe up/down.
+ */
+fun Modifier.adjustableSemantics(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    stateText: (Float) -> String,
+    onValueChange: (Float) -> Unit,
+): Modifier = semantics {
+    contentDescription = label
+    val clamped = value.coerceIn(range.start, range.endInclusive)
+    progressBarRangeInfo = ProgressBarRangeInfo(clamped, range)
+    stateDescription = stateText(value)
+    setProgress { target ->
+        onValueChange(target.coerceIn(range.start, range.endInclusive))
+        true
+    }
+}
+
+/** Button role + spoken [label] (and optional [state]) for a custom clickable. */
+fun Modifier.buttonSemantics(
+    label: String,
+    state: String? = null,
+): Modifier = semantics {
+    contentDescription = label
+    role = Role.Button
+    if (state != null) stateDescription = state
+}
+
+/** Switch role + [label] + on/off state for mute/solo-style toggle boxes. */
+fun Modifier.toggleSemantics(
+    label: String,
+    checked: Boolean,
+): Modifier = semantics {
+    contentDescription = label
+    role = Role.Switch
+    stateDescription = if (checked) "On" else "Off"
+}

--- a/app/src/main/java/tf/monochrome/android/ui/components/AlbumItem.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/AlbumItem.kt
@@ -39,7 +39,10 @@ fun AlbumItem(
         CoverImage(
             url = album.coverUrl,
             contentDescription = album.title,
-            size = MonoDimens.coverCard,
+            // Subtract the card's own padding so the cover stays square inside
+            // the padded column instead of being requested at the full card
+            // width and cropped to a portrait 136x160.
+            size = MonoDimens.coverCard - MonoDimens.spacingMd * 2,
             cornerRadius = MonoDimens.radiusSm
         )
         Spacer(modifier = Modifier.height(MonoDimens.spacingSm))

--- a/app/src/main/java/tf/monochrome/android/ui/components/ClickableArtists.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/ClickableArtists.kt
@@ -47,7 +47,9 @@ fun ClickableArtists(
         return
     }
 
-    FlowRow(modifier = modifier) {
+    // Cap at one line so many credited artists don't wrap to unbounded rows
+    // (uneven list-row heights, stretched cards).
+    FlowRow(modifier = modifier, maxLines = 1) {
         artists.forEachIndexed { index, artist ->
             val isLink = artist.id != null && artist.id > 0L
             val separator = if (index < artists.lastIndex) ", " else ""

--- a/app/src/main/java/tf/monochrome/android/ui/components/ClickableArtists.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/ClickableArtists.kt
@@ -59,7 +59,14 @@ fun ClickableArtists(
                 color = if (isLink) linkColor else color,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = if (isLink) Modifier.clickable { onArtistClick(artist) } else Modifier,
+                // Inline link: a hard 48dp min-size would blow up the one-line
+                // subtitle row across every track list, so give it a Button role
+                // instead — TalkBack then announces it as an activatable link.
+                modifier = if (isLink) {
+                    Modifier
+                        .clickable { onArtistClick(artist) }
+                        .buttonSemantics(label = artist.name)
+                } else Modifier,
             )
             if (separator.isNotEmpty()) {
                 Text(text = separator, style = style, color = color, maxLines = 1)
@@ -104,7 +111,11 @@ fun TrackArtistAlbumLine(
                 color = if (albumLinkable) linkColor else color,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = if (albumLinkable) Modifier.clickable { onAlbumClick() } else Modifier,
+                modifier = if (albumLinkable) {
+                    Modifier
+                        .clickable { onAlbumClick() }
+                        .buttonSemantics(label = albumTitle)
+                } else Modifier,
             )
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/components/CoverImage.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CoverImage.kt
@@ -27,28 +27,28 @@ fun CoverImage(
     size: Dp = MonoDimens.coverList,
     cornerRadius: Dp = MonoDimens.radiusSm
 ) {
-    if (url != null) {
-        AsyncImage(
-            model = url,
+    // The music-note fallback sits behind the image, so it shows through both
+    // when the url is null AND when a non-null url fails to load (previously a
+    // failed load rendered a blank box). A successfully loaded image covers it.
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(cornerRadius))
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.MusicNote,
             contentDescription = contentDescription,
-            contentScale = ContentScale.Crop,
-            modifier = modifier
-                .size(size)
-                .clip(RoundedCornerShape(cornerRadius))
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(size / 2)
         )
-    } else {
-        Box(
-            modifier = modifier
-                .size(size)
-                .clip(RoundedCornerShape(cornerRadius))
-                .background(MaterialTheme.colorScheme.surfaceVariant),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.MusicNote,
-                contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(size / 2)
+        if (url != null) {
+            AsyncImage(
+                model = url,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
             )
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -254,8 +254,11 @@ fun CreatePlaylistDialog(
                             }
                             onDismiss()
                         },
-                        enabled = name.isNotBlank() &&
-                            (canImport || !isUploadMode || onImportCsv == null)
+                        // A non-blank name is enough: onClick imports when a CSV
+                        // file is picked, otherwise creates a plain playlist. The
+                        // old extra conditions left the button disabled for a
+                        // plainly-named playlist in the default (upload) mode.
+                        enabled = name.isNotBlank()
                     ) {
                         Text(if (canImport) "Import" else confirmLabel)
                     }

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -25,10 +25,17 @@ import androidx.compose.ui.window.DialogProperties
 fun CreatePlaylistDialog(
     onDismiss: () -> Unit,
     onSubmit: (name: String, description: String) -> Unit,
-    onImportCsv: ((uri: Uri, strictMatch: Boolean, name: String, description: String) -> Unit)? = null
+    onImportCsv: ((uri: Uri, strictMatch: Boolean, name: String, description: String) -> Unit)? = null,
+    initialName: String = "",
+    initialDescription: String = "",
+    title: String = "Create Playlist",
+    confirmLabel: String = "Create",
 ) {
-    var name by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+    // Seed from the initial values so the "Edit playlist" reuse of this dialog
+    // shows the existing name/description instead of blanks (submitting blank
+    // used to wipe them).
+    var name by remember { mutableStateOf(initialName) }
+    var description by remember { mutableStateOf(initialDescription) }
     var isUploadMode by remember { mutableStateOf(true) }
     var selectedFormat by remember { mutableStateOf("CSV") }
     var selectedSource by remember { mutableStateOf("Spotify") }
@@ -62,7 +69,7 @@ fun CreatePlaylistDialog(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Text(
-                    text = "Create Playlist",
+                    text = title,
                     style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -238,7 +245,7 @@ fun CreatePlaylistDialog(
                         },
                         enabled = name.isNotBlank() && (selectedUri != null || !isUploadMode || onImportCsv == null)
                     ) {
-                        Text(if (onImportCsv != null && isUploadMode && selectedUri != null) "Import" else "Create")
+                        Text(if (onImportCsv != null && isUploadMode && selectedUri != null) "Import" else confirmLabel)
                     }
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -194,7 +194,7 @@ fun CreatePlaylistDialog(
                             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surfaceVariant, contentColor = MaterialTheme.colorScheme.onSurface),
                             shape = RoundedCornerShape(8.dp)
                         ) {
-                            Text(if (selectedUri != null) "File selected" else "Choisir un fichier")
+                            Text(if (selectedUri != null) "File selected" else "Choose a file")
                         }
 
                         Text(
@@ -234,18 +234,24 @@ fun CreatePlaylistDialog(
                         Text("Cancel")
                     }
                     Spacer(modifier = Modifier.width(8.dp))
+                    // Only the CSV format actually imports; a file picked while
+                    // an unsupported format is selected must not silently run
+                    // the CSV importer (it created garbage playlists).
+                    val canImport = onImportCsv != null && isUploadMode &&
+                        selectedUri != null && selectedFormat == "CSV"
                     Button(
                         onClick = {
-                            if (onImportCsv != null && isUploadMode && selectedUri != null) {
-                                onImportCsv(selectedUri!!, strictAlbumMatch, name, description)
+                            if (canImport) {
+                                onImportCsv!!(selectedUri!!, strictAlbumMatch, name, description)
                             } else {
                                 onSubmit(name, description)
                             }
                             onDismiss()
                         },
-                        enabled = name.isNotBlank() && (selectedUri != null || !isUploadMode || onImportCsv == null)
+                        enabled = name.isNotBlank() &&
+                            (canImport || !isUploadMode || onImportCsv == null)
                     ) {
-                        Text(if (onImportCsv != null && isUploadMode && selectedUri != null) "Import" else confirmLabel)
+                        Text(if (canImport) "Import" else confirmLabel)
                     }
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -118,7 +118,7 @@ fun CreatePlaylistDialog(
                     value = description,
                     onValueChange = { description = it },
                     placeholder = { Text("Description (optional)") },
-                    modifier = Modifier.fillMaxWidth().height(100.dp),
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 100.dp),
                     shape = RoundedCornerShape(8.dp),
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha=0.3f),

--- a/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/CreatePlaylistDialog.kt
@@ -34,18 +34,23 @@ fun CreatePlaylistDialog(
     // Seed from the initial values so the "Edit playlist" reuse of this dialog
     // shows the existing name/description instead of blanks (submitting blank
     // used to wipe them).
-    var name by remember { mutableStateOf(initialName) }
-    var description by remember { mutableStateOf(initialDescription) }
-    var isUploadMode by remember { mutableStateOf(true) }
-    var selectedFormat by remember { mutableStateOf("CSV") }
-    var selectedSource by remember { mutableStateOf("Spotify") }
-    var selectedUri by remember { mutableStateOf<Uri?>(null) }
-    var strictAlbumMatch by remember { mutableStateOf(false) }
+    // rememberSaveable so typed input and the picked file survive the process
+    // death that the SAF file picker can trigger (the picker launches another
+    // activity, and low-memory devices reclaim this one behind it).
+    var name by rememberSaveable { mutableStateOf(initialName) }
+    var description by rememberSaveable { mutableStateOf(initialDescription) }
+    var isUploadMode by rememberSaveable { mutableStateOf(true) }
+    var selectedFormat by rememberSaveable { mutableStateOf("CSV") }
+    var selectedSource by rememberSaveable { mutableStateOf("Spotify") }
+    var selectedUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    var strictAlbumMatch by rememberSaveable { mutableStateOf(false) }
 
     val filePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
         onResult = { uri ->
-            selectedUri = uri
+            // Cancelling the picker delivers a null uri; keep the previously
+            // selected file instead of clearing it.
+            if (uri != null) selectedUri = uri
         }
     )
 

--- a/app/src/main/java/tf/monochrome/android/ui/components/DownloadIndicator.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/DownloadIndicator.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.components
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
@@ -13,7 +14,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -34,10 +37,46 @@ fun DownloadIndicator(
     accentColor: Color = MaterialTheme.colorScheme.primary
 ) {
     when (state.status) {
-        DownloadStatus.IDLE, DownloadStatus.FAILED -> return
+        DownloadStatus.IDLE -> return
+        DownloadStatus.FAILED -> FailedIndicator(modifier, size)
         DownloadStatus.QUEUED -> QueuedIndicator(modifier, size, accentColor)
         DownloadStatus.DOWNLOADING -> DownloadingIndicator(state.progress, modifier, size, accentColor)
         DownloadStatus.COMPLETED -> CompletedIndicator(modifier, size, accentColor)
+    }
+}
+
+@Composable
+private fun FailedIndicator(
+    modifier: Modifier,
+    size: Float,
+) {
+    // A FAILED download used to render nothing — indistinguishable from a track
+    // that was never downloaded. Draw a red ring + cross so failure is visible.
+    val errorColor = MaterialTheme.colorScheme.error
+    Canvas(modifier = modifier.size(size.dp)) {
+        val strokeWidth = size * 0.1f
+        val padding = strokeWidth
+        drawArc(
+            color = errorColor,
+            startAngle = -90f,
+            sweepAngle = 360f,
+            useCenter = false,
+            topLeft = Offset(padding, padding),
+            size = Size(this.size.width - padding * 2, this.size.height - padding * 2),
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+        )
+        val cx = this.size.width / 2f
+        val cy = this.size.height / 2f
+        val arm = this.size.width * 0.18f
+        val cross = size * 0.1f
+        drawLine(
+            errorColor, Offset(cx - arm, cy - arm), Offset(cx + arm, cy + arm),
+            strokeWidth = cross, cap = StrokeCap.Round
+        )
+        drawLine(
+            errorColor, Offset(cx + arm, cy - arm), Offset(cx - arm, cy + arm),
+            strokeWidth = cross, cap = StrokeCap.Round
+        )
     }
 }
 
@@ -147,15 +186,20 @@ private fun CompletedIndicator(
     size: Float,
     accentColor: Color
 ) {
-    // Pop-in scale animation
-    val scale by animateFloatAsState(
-        targetValue = 1f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMedium
-        ),
-        label = "completedScale"
-    )
+    // Pop-in scale animation. animateFloatAsState(targetValue = 1f) started
+    // already AT 1f (its initial value defaults to the target), so the pop
+    // never played. Drive it from 0 with an Animatable instead.
+    val scaleAnim = remember { Animatable(0f) }
+    LaunchedEffect(Unit) {
+        scaleAnim.animateTo(
+            targetValue = 1f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium
+            )
+        )
+    }
+    val scale = scaleAnim.value
 
     Canvas(modifier = modifier.size(size.dp)) {
         val scaledSize = this.size

--- a/app/src/main/java/tf/monochrome/android/ui/components/SpotifyPlaylistPickerDialog.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/SpotifyPlaylistPickerDialog.kt
@@ -113,7 +113,10 @@ fun SpotifyPlaylistPickerDialog(
                         )
                     }
                     else -> {
-                        LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                        // weight(fill=false) so the list yields space to the
+                        // trailing Cancel row on short/landscape windows
+                        // instead of pushing it off-screen.
+                        LazyColumn(modifier = Modifier.weight(1f, fill = false).heightIn(max = 420.dp)) {
                             item {
                                 PickerRow(
                                     title = "Liked Songs",

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackContextMenu.kt
@@ -1,6 +1,8 @@
 package tf.monochrome.android.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -64,7 +66,13 @@ fun TrackContextMenu(
         sheetState = sheetState,
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = MonoDimens.cardAlpha)
     ) {
-        Column(modifier = Modifier.padding(bottom = 24.dp)) {
+        Column(
+            modifier = Modifier
+                // Scrollable so the bottom actions (Go to album/artist) stay
+                // reachable when the sheet is taller than a landscape window.
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = 24.dp)
+        ) {
             // Track header
             Row(
                 modifier = Modifier

--- a/app/src/main/java/tf/monochrome/android/ui/components/TrackItem.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/TrackItem.kt
@@ -176,7 +176,9 @@ fun TrackItem(
                         color = MaterialTheme.colorScheme.primary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.clickable(onClick = effectiveOnAlbumClick)
+                        // weight(fill=false) so a long album title ellipsizes and
+                        // shares the row instead of squeezing the artist to zero.
+                        modifier = Modifier.weight(1f, fill = false).clickable(onClick = effectiveOnAlbumClick)
                     )
                 } else if (track.album != null) {
                     Text(
@@ -184,7 +186,8 @@ fun TrackItem(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
                     )
                 }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/debug/DebugLogScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/debug/DebugLogScreen.kt
@@ -111,11 +111,13 @@ fun DebugLogScreen(
 
     val listState = rememberLazyListState()
 
-    // Auto-scroll to the newest entry whenever the visible list grows. Cheap
-    // because `entries.size` is the only state read; it doesn't flap when the
-    // same list is re-emitted.
+    // Auto-scroll to the newest entry only when the user is already at (or
+    // near) the bottom — otherwise a new log line every ~250ms yanked them
+    // back down and made scrolling up to read an earlier entry impossible.
     LaunchedEffect(entries.size) {
-        if (entries.isNotEmpty()) {
+        if (entries.isEmpty()) return@LaunchedEffect
+        val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+        if (lastVisible >= entries.lastIndex - 1) {
             listState.scrollToItem(entries.lastIndex)
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/debug/DebugLogScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/debug/DebugLogScreen.kt
@@ -41,7 +41,12 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -67,6 +72,25 @@ fun DebugLogScreen(
     val levelFilter by viewModel.levelFilter.collectAsState()
     val totalSize by viewModel.totalSize.collectAsState()
     val context = LocalContext.current
+
+    var showClearConfirm by remember { mutableStateOf(false) }
+    if (showClearConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirm = false },
+            title = { Text("Clear log buffer?") },
+            text = { Text("This discards the current diagnostic log. Copy or export it first if you need it.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearConfirm = false
+                    viewModel.clear()
+                    Toast.makeText(context, "Log cleared", Toast.LENGTH_SHORT).show()
+                }) { Text("Clear", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
 
     // Create a text file picker, seeded with a timestamped filename so successive
     // exports don't overwrite each other. SAF handles the actual write.
@@ -126,7 +150,7 @@ fun DebugLogScreen(
                 }) {
                     Icon(Icons.Default.Download, contentDescription = "Export to file")
                 }
-                IconButton(onClick = { viewModel.clear() }) {
+                IconButton(onClick = { showClearConfirm = true }) {
                     Icon(Icons.Default.Delete, contentDescription = "Clear buffer")
                 }
             },

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailScreen.kt
@@ -69,6 +69,13 @@ fun ArtistDetailScreen(
     val artistDetail by viewModel.artistDetail.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
+
+    val dlMsgContext = androidx.compose.ui.platform.LocalContext.current
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.downloadMessage.collect { msg ->
+            android.widget.Toast.makeText(dlMsgContext, msg, android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
     val favoriteTrackIds by playerViewModel.favoriteTrackIds.collectAsState()
     val playlists by playerViewModel.playlists.collectAsState()
 

--- a/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/ArtistDetailViewModel.kt
@@ -4,11 +4,15 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import tf.monochrome.android.data.api.QobuzIdRegistry
 import tf.monochrome.android.data.downloads.DownloadManager
@@ -34,6 +38,10 @@ class ArtistDetailViewModel @Inject constructor(
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
+
+    /** One-shot messages for the artist screen (download-all outcome). */
+    private val _downloadMessage = MutableSharedFlow<String>(extraBufferCapacity = 2)
+    val downloadMessage: SharedFlow<String> = _downloadMessage.asSharedFlow()
 
     init {
         loadArtist()
@@ -100,7 +108,7 @@ class ArtistDetailViewModel @Inject constructor(
         viewModelScope.launch {
             _isDownloadingAll.value = true
             try {
-                val tracks = coroutineScope {
+                val perRelease = coroutineScope {
                     releases.map { album ->
                         async {
                             val slug = qobuzIdRegistry.albumSlugFor(album.id)
@@ -109,11 +117,22 @@ class ArtistDetailViewModel @Inject constructor(
                             } else {
                                 repository.getAlbum(album.id)
                             }
-                            result.getOrNull()?.tracks.orEmpty()
+                            result.getOrNull()?.tracks
                         }
-                    }.flatMap { it.await() }
-                }.distinctBy { it.id }
-                if (tracks.isNotEmpty()) downloadManager.downloadTracks(tracks)
+                    }.awaitAll()
+                }
+                val failed = perRelease.count { it == null }
+                val tracks = perRelease.filterNotNull().flatten().distinctBy { it.id }
+                when {
+                    tracks.isNotEmpty() -> {
+                        downloadManager.downloadTracks(tracks)
+                        _downloadMessage.tryEmit(
+                            if (failed > 0) "Downloading ${tracks.size} tracks (couldn't fetch $failed release${if (failed == 1) "" else "s"})"
+                            else "Downloading ${tracks.size} tracks"
+                        )
+                    }
+                    else -> _downloadMessage.tryEmit("Couldn't fetch releases. Check your connection.")
+                }
             } finally {
                 _isDownloadingAll.value = false
             }

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalAlbumDetailScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalAlbumDetailScreen.kt
@@ -266,7 +266,9 @@ private fun LocalTrackRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            IconButton(onClick = onAddToQueue, modifier = Modifier.size(32.dp)) {
+            // Default IconButton size keeps the touch target at the 48dp
+            // minimum (was forced to 32dp); the glyph stays 20dp.
+            IconButton(onClick = onAddToQueue) {
                 Icon(
                     Icons.AutoMirrored.Filled.PlaylistAdd,
                     contentDescription = "Add to queue",

--- a/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/detail/LocalGenreDetailViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import tf.monochrome.android.data.local.repository.LocalMediaRepository
 import tf.monochrome.android.domain.model.UnifiedTrack
-import java.net.URLDecoder
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,9 +18,9 @@ class LocalGenreDetailViewModel @Inject constructor(
     localMediaRepository: LocalMediaRepository
 ) : ViewModel() {
 
-    val genreName: String = savedStateHandle.get<String>("genre")
-        ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
-        .orEmpty()
+    // Navigation already decoded this once; the previous manual URLDecoder
+    // call was a second decode that mangled genres containing '+' or '%'.
+    val genreName: String = savedStateHandle.get<String>("genre").orEmpty()
 
     val tracks: StateFlow<List<UnifiedTrack>> =
         if (genreName.isBlank()) MutableStateFlow(emptyList())

--- a/app/src/main/java/tf/monochrome/android/ui/donate/DonateViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/donate/DonateViewModel.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.donate
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,6 +31,7 @@ class DonateViewModel @Inject constructor(
     private val backend: DonationBackend,
     private val authManager: SupabaseAuthManager,
     private val store: DonationStore,
+    private val savedState: SavedStateHandle,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<DonateUiState>(DonateUiState.Idle)
@@ -39,7 +41,11 @@ class DonateViewModel @Inject constructor(
     val active: StateFlow<SavedSubscription?> = store.active
 
     // Held between "prepared on backend" and "PaymentSheet completed" so we can
-    // persist the subscription once payment actually succeeds.
+    // persist the subscription once payment actually succeeds. Mirrored into
+    // SavedStateHandle (KEY_PENDING_*) because Stripe's PaymentSheet is a
+    // separate activity: if the OS kills our process while it's up, this
+    // in-memory field is lost, but the persisted ids survive so onCompleted
+    // can still record the (now-charged) subscription and offer a cancel.
     private var pending: DonationSubscription? = null
 
     /** Kick off a subscription for [tier]; on success the UI presents the sheet. */
@@ -59,6 +65,10 @@ class DonateViewModel @Inject constructor(
             _state.value = result.fold(
                 onSuccess = {
                     pending = it
+                    // Persist before the sheet is presented so a process death
+                    // during payment can't lose the subscription.
+                    savedState[KEY_PENDING_SUB] = it.subscriptionId
+                    savedState[KEY_PENDING_CUSTOMER] = it.customerId
                     DonateUiState.ReadyToPresent(it)
                 },
                 onFailure = {
@@ -79,24 +89,40 @@ class DonateViewModel @Inject constructor(
     }
 
     fun onCompleted() {
-        // Payment succeeded — remember the subscription so we can offer a cancel button.
-        pending?.let { sub ->
-            val subscriptionId = sub.subscriptionId
-            if (subscriptionId != null) store.save(subscriptionId, sub.customerId)
+        // Payment succeeded — remember the subscription so we can offer a cancel
+        // button. Fall back to the persisted ids when `pending` was cleared by a
+        // process death while the sheet was up.
+        val subscriptionId = pending?.subscriptionId ?: savedState.get<String>(KEY_PENDING_SUB)
+        val customerId = pending?.customerId ?: savedState.get<String>(KEY_PENDING_CUSTOMER)
+        if (subscriptionId != null && customerId != null) {
+            store.save(subscriptionId, customerId)
+        } else {
+            // Charged but we lost the ids — log loudly instead of silently
+            // dropping the subscription (which would hide the cancel button).
+            android.util.Log.e(
+                "DonateViewModel",
+                "Donation completed but subscription id was unavailable; cancel button will not appear"
+            )
         }
-        pending = null
+        clearPending()
         _state.value = DonateUiState.Completed
     }
 
     /** Donor dismissed the sheet — quietly return to the tier picker. */
     fun onCanceled() {
-        pending = null
+        clearPending()
         _state.value = DonateUiState.Idle
     }
 
     fun onFailed(message: String) {
-        pending = null
+        clearPending()
         _state.value = DonateUiState.Failed(message)
+    }
+
+    private fun clearPending() {
+        pending = null
+        savedState.remove<String>(KEY_PENDING_SUB)
+        savedState.remove<String>(KEY_PENDING_CUSTOMER)
     }
 
     /** Cancel the active subscription (stops future charges). Idempotent on the
@@ -121,6 +147,11 @@ class DonateViewModel @Inject constructor(
 
     /** Return to the initial state (e.g. after showing a thank-you / cancelled note). */
     fun reset() { _state.value = DonateUiState.Idle }
+
+    private companion object {
+        const val KEY_PENDING_SUB = "pending_sub_id"
+        const val KEY_PENDING_CUSTOMER = "pending_customer_id"
+    }
 }
 
 sealed interface DonateUiState {

--- a/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
@@ -2,7 +2,10 @@ package tf.monochrome.android.ui.downloads
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -166,6 +169,14 @@ fun DownloadsMonitorSheet(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
+                // Bounded, scrollable list so a big batch doesn't clip its
+                // trailing entries (the whole sheet was a fixed Column before).
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = 360.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
                 downloads.forEach { d ->
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         CoverImage(
@@ -209,6 +220,7 @@ fun DownloadsMonitorSheet(
                             Icon(Icons.Default.Close, contentDescription = "Cancel")
                         }
                     }
+                }
                 }
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterUi.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -50,6 +51,7 @@ fun DownloadProgressPill(
     modifier: Modifier = Modifier,
 ) {
     val current = downloads.firstOrNull { it.status == DownloadStatus.DOWNLOADING }
+        ?: downloads.firstOrNull { it.status != DownloadStatus.FAILED }
         ?: downloads.firstOrNull() ?: return
     val remaining = downloads.size
 
@@ -139,6 +141,7 @@ fun DownloadsMonitorSheet(
     onCancel: (Long) -> Unit,
     onCancelAll: () -> Unit,
     onDismiss: () -> Unit,
+    onRetry: (Long) -> Unit = {},
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
@@ -200,24 +203,49 @@ fun DownloadsMonitorSheet(
                                 )
                             }
                             Text(
-                                text = if (d.status == DownloadStatus.DOWNLOADING) d.artistName else "Queued",
+                                text = when (d.status) {
+                                    DownloadStatus.DOWNLOADING -> d.artistName
+                                    DownloadStatus.FAILED -> "Failed — tap retry"
+                                    else -> "Queued"
+                                },
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                color = if (d.status == DownloadStatus.FAILED) {
+                                    MaterialTheme.colorScheme.error
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
-                            Spacer(Modifier.height(6.dp))
-                            if (d.status == DownloadStatus.DOWNLOADING && d.progress > 0f) {
-                                LinearProgressIndicator(
-                                    progress = { d.progress },
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                            } else {
-                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                            // No progress bar for a failed row; queued shows an
+                            // indeterminate bar, downloading shows real progress.
+                            when (d.status) {
+                                DownloadStatus.FAILED -> Unit
+                                DownloadStatus.DOWNLOADING -> {
+                                    Spacer(Modifier.height(6.dp))
+                                    if (d.progress > 0f) {
+                                        LinearProgressIndicator(
+                                            progress = { d.progress },
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    } else {
+                                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                                    }
+                                }
+                                else -> {
+                                    Spacer(Modifier.height(6.dp))
+                                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                                }
                             }
                         }
-                        IconButton(onClick = { onCancel(d.trackId) }) {
-                            Icon(Icons.Default.Close, contentDescription = "Cancel")
+                        if (d.status == DownloadStatus.FAILED) {
+                            IconButton(onClick = { onRetry(d.trackId) }) {
+                                Icon(Icons.Default.Refresh, contentDescription = "Retry")
+                            }
+                        } else {
+                            IconButton(onClick = { onCancel(d.trackId) }) {
+                                Icon(Icons.Default.Close, contentDescription = "Cancel")
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/downloads/DownloadCenterViewModel.kt
@@ -3,12 +3,15 @@ package tf.monochrome.android.ui.downloads
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import tf.monochrome.android.data.downloads.ActiveDownload
 import tf.monochrome.android.data.downloads.DownloadManager
+import tf.monochrome.android.data.downloads.DownloadStatus
 import javax.inject.Inject
 
 /**
@@ -24,11 +27,39 @@ class DownloadCenterViewModel @Inject constructor(
     val active: StateFlow<List<ActiveDownload>> = downloadManager.observeActiveDownloads()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    /** Mean progress across all in-flight downloads, for the aggregate indicator. */
-    val overallProgress: StateFlow<Float> = active
-        .map { list -> if (list.isEmpty()) 0f else list.map { it.progress }.average().toFloat() }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0f)
+    private val _overallProgress = MutableStateFlow(0f)
+
+    /**
+     * Mean progress for the aggregate indicator. Averaging only the currently
+     * in-flight downloads made the ring jump *backwards* every time one finished
+     * (a completed 90% item left the list, so the remaining lower-progress items
+     * pulled the mean down). Instead we accumulate progress per track across the
+     * batch — a download that leaves the list is remembered as 100% — so the
+     * aggregate only ever moves forward until the batch drains. FAILED items are
+     * excluded so a failure doesn't peg the ring.
+     */
+    val overallProgress: StateFlow<Float> = _overallProgress.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val batch = mutableMapOf<Long, Float>()
+            active.collect { list ->
+                val inFlight = list.filter { it.status != DownloadStatus.FAILED }
+                if (inFlight.isEmpty()) {
+                    batch.clear()
+                    _overallProgress.value = 0f
+                } else {
+                    val activeIds = inFlight.map { it.trackId }.toSet()
+                    // Anything previously tracked but no longer listed completed.
+                    batch.keys.filter { it !in activeIds }.forEach { batch[it] = 1f }
+                    inFlight.forEach { batch[it.trackId] = it.progress }
+                    _overallProgress.value = batch.values.average().toFloat()
+                }
+            }
+        }
+    }
 
     fun cancel(trackId: Long) = downloadManager.cancel(trackId)
     fun cancelAll() = downloadManager.cancelAll()
+    fun retry(trackId: Long) = downloadManager.retry(trackId)
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqComponents.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqComponents.kt
@@ -213,13 +213,18 @@ fun AlphabeticalIndexSidebar(
                     .padding(vertical = 1.dp)
             )
         }
-        // Add # for numbers/special
+        // '#' bucket (numeric-named models) — render like the letters so it's
+        // actually clickable when present, not a permanently-disabled label.
+        val hashAvailable = '#' in availableLetters
         Text(
             "#",
             fontSize = 10.sp,
-            fontWeight = FontWeight.Normal,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
-            modifier = Modifier.padding(vertical = 1.dp)
+            fontWeight = if (hashAvailable) FontWeight.Bold else FontWeight.Normal,
+            color = if (hashAvailable) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f),
+            modifier = Modifier
+                .clickable(enabled = hashAvailable) { onLetterClicked('#') }
+                .padding(vertical = 1.dp)
         )
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -251,36 +252,38 @@ class EqViewModel @Inject constructor(
             }
         }
 
+        // Resolve the custom-targets list AND the selected target together so
+        // the selection restores against freshly-parsed customs. The previous
+        // two independent collectors raced: the target id usually emitted
+        // before the customs JSON, so a saved custom target resolved to null
+        // and the selection silently reverted to the default on every restart.
         viewModelScope.launch {
-            preferences.eqTargetId.collect { targetId ->
-                val target = FrequencyTargets.getTargetById(targetId)
-                    ?: _customTargets.value.find { it.id == targetId }
-                if (target != null) {
-                    _selectedTarget.value = target
-                }
-            }
-        }
-
-        viewModelScope.launch {
-            preferences.eqCustomTargetsJson.collect { json ->
-                try {
-                    val jsonParser = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
-                    val stored = jsonParser.decodeFromString<List<StoredCustomTarget>>(json)
-                    val customs = stored.map { st ->
-                        EqTarget(
-                            id = st.id,
-                            label = st.label,
-                            data = EqDataParser.parseRawData(st.rawData),
-                            filename = ""
-                        )
+            combine(
+                preferences.eqTargetId,
+                preferences.eqCustomTargetsJson
+            ) { targetId, customsJson -> targetId to customsJson }
+                .collect { (targetId, customsJson) ->
+                    val customs = try {
+                        val jsonParser = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+                        jsonParser.decodeFromString<List<StoredCustomTarget>>(customsJson).map { st ->
+                            EqTarget(
+                                id = st.id,
+                                label = st.label,
+                                data = EqDataParser.parseRawData(st.rawData),
+                                filename = ""
+                            )
+                        }
+                    } catch (_: Exception) {
+                        emptyList()
                     }
                     _customTargets.value = customs
                     _availableTargets.value = FrequencyTargets.getAllTargets() + customs
-                } catch (_: Exception) {
-                    _customTargets.value = emptyList()
-                    _availableTargets.value = FrequencyTargets.getAllTargets()
+                    val target = FrequencyTargets.getTargetById(targetId)
+                        ?: customs.find { it.id == targetId }
+                    if (target != null) {
+                        _selectedTarget.value = target
+                    }
                 }
-            }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -974,10 +974,12 @@ class EqViewModel @Inject constructor(
         try {
             val jsonParser = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
 
-            // Load existing stored data to preserve raw strings
-            val existingJson = preferences.eqCustomTargetsJson.stateIn(
-                viewModelScope, SharingStarted.Eagerly, "[]"
-            ).value
+            // Load existing stored data to preserve raw strings. Must await
+            // the actual DataStore emission: the previous stateIn(...).value
+            // read raced and returned the "[]" initial value, so every save
+            // wiped the rawData of all targets not passed in `rawData` —
+            // importing or deleting one custom target erased the others.
+            val existingJson = preferences.eqCustomTargetsJson.first()
             val existingStored = try {
                 jsonParser.decodeFromString<List<StoredCustomTarget>>(existingJson)
             } catch (_: Exception) { emptyList() }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import android.widget.Toast
 import androidx.compose.ui.Alignment
@@ -94,18 +95,21 @@ fun EqualizerScreen(
     val availableHeadphones by viewModel.availableHeadphones.collectAsState()
     val showTutorial by viewModel.showTutorial.collectAsState()
 
-    var showSaveDialog by remember { mutableStateOf(false) }
+    // rememberSaveable for dialog visibility + typed input so a background
+    // process death (e.g. while a SAF picker is up) doesn't drop a half-filled
+    // save/target dialog or reset the expanded sections.
+    var showSaveDialog by rememberSaveable { mutableStateOf(false) }
     var showTargetMenu by remember { mutableStateOf(false) }
     var showHeadphoneSelect by remember { mutableStateOf(false) }
     var showMeasurementUpload by remember { mutableStateOf(false) }
     var showPresetMenu by remember { mutableStateOf(false) }
-    var showBandsExpanded by remember { mutableStateOf(true) }
-    var showProfilesExpanded by remember { mutableStateOf(true) }
-    var saveName by remember { mutableStateOf("") }
-    var saveDescription by remember { mutableStateOf("") }
-    var showTargetNameDialog by remember { mutableStateOf(false) }
-    var pendingTargetData by remember { mutableStateOf("") }
-    var targetName by remember { mutableStateOf("") }
+    var showBandsExpanded by rememberSaveable { mutableStateOf(true) }
+    var showProfilesExpanded by rememberSaveable { mutableStateOf(true) }
+    var saveName by rememberSaveable { mutableStateOf("") }
+    var saveDescription by rememberSaveable { mutableStateOf("") }
+    var showTargetNameDialog by rememberSaveable { mutableStateOf(false) }
+    var pendingTargetData by rememberSaveable { mutableStateOf("") }
+    var targetName by rememberSaveable { mutableStateOf("") }
     var presetToDelete by remember { mutableStateOf<tf.monochrome.android.domain.model.EqPreset?>(null) }
 
     val context = LocalContext.current

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -282,6 +282,18 @@ fun EqualizerScreen(
                             }
                         }
                     )
+                    // Entry point for the guided measurement-calibration flow,
+                    // which was fully built but previously unreachable.
+                    TextButton(onClick = { showMeasurementUpload = true }) {
+                        Icon(
+                            Icons.Default.UploadFile,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text("Upload & calibrate a measurement")
+                    }
                 }
               }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -130,9 +130,12 @@ fun EqualizerScreen(
             val rawData = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
             if (!rawData.isNullOrEmpty()) {
                 viewModel.importMeasurementData(rawData)
+            } else {
+                android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
             }
         } catch (e: Exception) {
             viewModel.clearError()
+            android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -147,8 +150,35 @@ fun EqualizerScreen(
                 pendingTargetData = rawData
                 targetName = ""
                 showTargetNameDialog = true
+            } else {
+                android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
             }
-        } catch (_: Exception) { }
+        } catch (_: Exception) {
+            android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    // Export EQ: serialize the current bands to an EqualizerAPO-style
+    // ParametricEQ.txt (widely importable) and save via SAF.
+    var pendingEqExport by remember { mutableStateOf<String?>(null) }
+    val eqExportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("text/plain")
+    ) { uri ->
+        val text = pendingEqExport
+        pendingEqExport = null
+        if (uri != null && text != null) {
+            val ok = try {
+                context.contentResolver.openOutputStream(uri)?.use { it.write(text.toByteArray()) }
+                true
+            } catch (_: Exception) {
+                false
+            }
+            android.widget.Toast.makeText(
+                context,
+                if (ok) "EQ exported" else "Couldn't export EQ",
+                android.widget.Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     // AutoEQ tutorial dialog (first visit)
@@ -371,7 +401,14 @@ fun EqualizerScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(
-                        onClick = { /* export EQ preset */ },
+                        onClick = {
+                            if (currentBands.isEmpty()) {
+                                android.widget.Toast.makeText(context, "No EQ bands to export", android.widget.Toast.LENGTH_SHORT).show()
+                            } else {
+                                pendingEqExport = buildParametricEqText(currentBands, currentPreamp)
+                                eqExportLauncher.launch("MonochromeEQ.txt")
+                            }
+                        },
                         modifier = Modifier
                             .size(52.dp)
                             .liquidGlass(
@@ -987,4 +1024,29 @@ private fun parseSampleRate(label: String): Float = when (label) {
     "96k" -> 96000f
     "192k" -> 192000f
     else -> 48000f
+}
+
+/**
+ * Serialize the current EQ to EqualizerAPO-style ParametricEQ text, which
+ * Wavelet, Poweramp, RootlessJamesDSP and most parametric EQs can import.
+ */
+private fun buildParametricEqText(
+    bands: List<tf.monochrome.android.domain.model.EqBand>,
+    preamp: Float,
+): String {
+    val us = java.util.Locale.US
+    val sb = StringBuilder()
+    sb.append("Preamp: ").append(String.format(us, "%.1f", preamp)).append(" dB\n")
+    var n = 1
+    for (b in bands) {
+        if (!b.enabled) continue
+        val code = when (b.type) {
+            tf.monochrome.android.domain.model.FilterType.LOWSHELF -> "LSC"
+            tf.monochrome.android.domain.model.FilterType.HIGHSHELF -> "HSC"
+            else -> "PK"
+        }
+        sb.append(String.format(us, "Filter %d: ON %s Fc %.0f Hz Gain %.1f dB Q %.2f\n", n, code, b.freq, b.gain, b.q))
+        n++
+    }
+    return sb.toString()
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -2,7 +2,8 @@ package tf.monochrome.android.ui.eq
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -146,6 +148,20 @@ fun FrequencyResponseGraph(
     var selectedBandId by remember { mutableIntStateOf(-1) }
     var isDragging by remember { mutableStateOf(false) }
 
+    // The pointer gestures below are keyed on Unit so they are NOT torn down and
+    // restarted every time a band drag mutates `eqBands` (which froze the drag
+    // mid-gesture). All the values they need are read through updated-state
+    // holders so the once-created gesture coroutines still see live data.
+    val latestEqBands by rememberUpdatedState(eqBands)
+    val latestCorrected by rememberUpdatedState(correctedCurve)
+    val latestPreamp by rememberUpdatedState(preamp)
+    val latestSampleRate by rememberUpdatedState(sampleRate)
+    val latestMinGain by rememberUpdatedState(minGain)
+    val latestMaxGain by rememberUpdatedState(maxGain)
+    val latestZeroOffset by rememberUpdatedState(zeroOffset)
+    val latestMaxAbsDragGain by rememberUpdatedState(maxAbsDragGain)
+    val latestOnBandDragged by rememberUpdatedState(onBandDragged)
+
     val graphBackground = MaterialTheme.colorScheme.surface
     val legendBackground = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
     val legendLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -163,44 +179,59 @@ fun FrequencyResponseGraph(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
-                .pointerInput(eqBands, minGain, maxGain) {
+                .pointerInput(Unit) {
                     if (onBandDragged == null) return@pointerInput
                     detectTapGestures { offset ->
                         val tapped = findNearestBand(
-                            offset, eqBands, size.width.toFloat(), size.height.toFloat(),
-                            minGain, maxGain, zeroOffset
+                            offset, latestEqBands, latestCorrected, latestPreamp, latestSampleRate,
+                            size.width.toFloat(), size.height.toFloat(),
+                            latestMinGain, latestMaxGain, latestZeroOffset
                         )
                         selectedBandId = if (tapped == selectedBandId) -1 else tapped
                     }
                 }
-                .pointerInput(eqBands, minGain, maxGain, selectedBandId) {
+                .pointerInput(Unit) {
                     if (onBandDragged == null) return@pointerInput
-                    detectDragGestures(
-                        onDragStart = { offset ->
-                            // If a band is already selected, drag that one
-                            // Otherwise try to grab nearest band directly
-                            if (selectedBandId < 0) {
-                                selectedBandId = findNearestBand(
-                                    offset, eqBands, size.width.toFloat(), size.height.toFloat(),
-                                    minGain, maxGain, zeroOffset
-                                )
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        // Grab the band nearest the finger's landing point. If none
+                        // is under it, bail without consuming so the enclosing
+                        // pager / scroll gets the drag instead of the graph
+                        // swallowing it.
+                        val bandId = findNearestBand(
+                            down.position, latestEqBands, latestCorrected,
+                            latestPreamp, latestSampleRate,
+                            size.width.toFloat(), size.height.toFloat(),
+                            latestMinGain, latestMaxGain, latestZeroOffset
+                        )
+                        if (bandId < 0) return@awaitEachGesture
+
+                        val touchSlop = viewConfiguration.touchSlop
+                        var started = false
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull() ?: break
+                            if (!change.pressed) break
+                            val pos = change.position
+                            if (!started) {
+                                // Wait for real movement before claiming the band,
+                                // so a stationary press still reaches the tap
+                                // detector (which toggles selection).
+                                if ((pos - down.position).getDistance() < touchSlop) continue
+                                started = true
+                                selectedBandId = bandId
+                                isDragging = true
                             }
-                            isDragging = selectedBandId >= 0
-                        },
-                        onDrag = { change, _ ->
-                            if (selectedBandId >= 0 && isDragging) {
-                                change.consume()
-                                val freq = xToFreq(change.position.x, size.width.toFloat())
-                                val gain = yToGain(
-                                    change.position.y, size.height.toFloat(),
-                                    minGain, maxGain, zeroOffset, maxAbsDragGain
-                                )
-                                onBandDragged(selectedBandId, freq, gain)
-                            }
-                        },
-                        onDragEnd = { isDragging = false },
-                        onDragCancel = { isDragging = false }
-                    )
+                            change.consume()
+                            val freq = xToFreq(pos.x, size.width.toFloat())
+                            val gain = yToGain(
+                                pos.y, size.height.toFloat(),
+                                latestMinGain, latestMaxGain, latestZeroOffset, latestMaxAbsDragGain
+                            )
+                            latestOnBandDragged?.invoke(bandId, freq, gain)
+                        }
+                        isDragging = false
+                    }
                 }
         ) {
             val w = size.width
@@ -249,13 +280,7 @@ fun FrequencyResponseGraph(
                 if (!band.enabled) return@forEach
                 // Find normalized positions
                 val dotX = freqToX(band.freq, w)
-                val bandGain = if (correctedCurve.isNotEmpty()) {
-                    interpolateGain(band.freq, correctedCurve)
-                } else {
-                    var gainAtFreq = preamp + zeroOffset
-                    eqBands.forEach { b -> if (b.enabled) gainAtFreq += AutoEqEngine.calculateBiquadResponse(band.freq, b, sampleRate) }
-                    gainAtFreq
-                }
+                val bandGain = bandDotGain(band, correctedCurve, eqBands, preamp, zeroOffset, sampleRate)
                 val dotY = gainToY(bandGain, h, minGain, maxGain)
 
                 val isSelected = selectedBandId == band.id
@@ -514,9 +539,34 @@ private fun yToGain(
         .coerceIn(-maxAbsDragGain, maxAbsDragGain)
 }
 
+/**
+ * The Y-gain a band's dot is actually DRAWN at: the corrected curve's value at
+ * the band frequency (or, with no measurement, the summed biquad response around
+ * the zero baseline). Hit-testing must use this same value — the dots sit on the
+ * corrected curve, not at the raw `band.gain + zeroOffset`, so tapping the dot
+ * where it's shown previously missed the band on peaky/overlapping filters.
+ */
+private fun bandDotGain(
+    band: EqBand,
+    correctedCurve: List<FrequencyPoint>,
+    bands: List<EqBand>,
+    preamp: Float,
+    zeroOffset: Float,
+    sampleRate: Float
+): Float = if (correctedCurve.isNotEmpty()) {
+    interpolateGain(band.freq, correctedCurve)
+} else {
+    var gainAtFreq = preamp + zeroOffset
+    bands.forEach { b -> if (b.enabled) gainAtFreq += AutoEqEngine.calculateBiquadResponse(band.freq, b, sampleRate) }
+    gainAtFreq
+}
+
 private fun findNearestBand(
     position: Offset,
     bands: List<EqBand>,
+    correctedCurve: List<FrequencyPoint>,
+    preamp: Float,
+    sampleRate: Float,
     width: Float,
     height: Float,
     minGain: Float,
@@ -529,7 +579,10 @@ private fun findNearestBand(
     bands.forEach { band ->
         if (!band.enabled) return@forEach
         val dotX = freqToX(band.freq, width)
-        val dotY = gainToY(band.gain + zeroOffset, height, minGain, maxGain)
+        val dotY = gainToY(
+            bandDotGain(band, correctedCurve, bands, preamp, zeroOffset, sampleRate),
+            height, minGain, maxGain
+        )
         val dist = sqrt((position.x - dotX).pow(2) + (position.y - dotY).pow(2))
         if (dist < threshold && dist < nearestDist) {
             nearest = band.id

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -297,7 +297,9 @@ fun FrequencyResponseGraph(
                     val infoText = "${band.freq.toInt()}Hz  ${"%.1f".format(band.gain)}dB"
                     val paint = android.graphics.Paint().apply {
                         color = android.graphics.Color.WHITE
-                        textSize = 28f
+                        // sp (not raw px) so the label scales with display
+                        // density and the user's font-size setting.
+                        textSize = 12.sp.toPx()
                         textAlign = android.graphics.Paint.Align.CENTER
                         isFakeBoldText = true
                     }
@@ -652,7 +654,7 @@ private fun DrawScope.drawDbLabels(width: Float, height: Float, minGain: Float, 
     }
     val paint = android.graphics.Paint().apply {
         color = android.graphics.Color.argb(120, 180, 180, 180)
-        textSize = 22f
+        textSize = 10.sp.toPx()
         textAlign = android.graphics.Paint.Align.LEFT
         isAntiAlias = true
     }
@@ -674,7 +676,7 @@ private fun DrawScope.drawDbLabels(width: Float, height: Float, minGain: Float, 
 private fun DrawScope.drawFreqLabels(width: Float, height: Float) {
     val paint = android.graphics.Paint().apply {
         color = android.graphics.Color.argb(120, 180, 180, 180)
-        textSize = 20f
+        textSize = 9.sp.toPx()
         textAlign = android.graphics.Paint.Align.CENTER
         isAntiAlias = true
     }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -149,6 +149,9 @@ fun FrequencyResponseGraph(
     val graphBackground = MaterialTheme.colorScheme.surface
     val legendBackground = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f)
     val legendLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    // Theme-aware curve colors (were hardcoded white → invisible on the light
+    // theme). The target uses `primary` to match its "Target (Primary)" legend.
+    val curveNeutral = MaterialTheme.colorScheme.onSurface
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -233,7 +236,7 @@ fun FrequencyResponseGraph(
 
             // Target curve (bright white dashed) — normalized to measurement
             if (normalizedTarget.size > 1) {
-                drawDashedCurve(normalizedTarget, Color.White, w, h, minGain, maxGain, 2.5f)
+                drawDashedCurve(normalizedTarget, primary, w, h, minGain, maxGain, 2.5f)
             }
 
             // Corrected curve (bright red solid) with fabfilter pro-q 3 style fill
@@ -263,7 +266,7 @@ fun FrequencyResponseGraph(
                         val biquad = AutoEqEngine.calculateBiquadResponse(p.freq, band, sampleRate)
                         FrequencyPoint(p.freq, zeroOffset + biquad)
                     }
-                    drawCurve(contributionPoints, Color.White.copy(alpha = 0.2f), w, h, minGain, maxGain, 1.5f)
+                    drawCurve(contributionPoints, curveNeutral.copy(alpha = 0.2f), w, h, minGain, maxGain, 1.5f)
 
                     // Floating Tooltip
                     val infoText = "${band.freq.toInt()}Hz  ${"%.1f".format(band.gain)}dB"
@@ -314,7 +317,7 @@ fun FrequencyResponseGraph(
                 )
                 // White border
                 drawCircle(
-                    color = Color.White,
+                    color = curveNeutral,
                     radius = if (isSelected) 15f else 13f,
                     center = Offset(dotX, dotY),
                     style = Stroke(width = if (isSelected) 3f else 2.5f)
@@ -333,7 +336,7 @@ fun FrequencyResponseGraph(
                 horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
             ) {
                 LegendDot("Original", Color(0xFF4A9EFF), legendLabelColor)
-                LegendDot("Target (Primary)", Color.White, legendLabelColor)
+                LegendDot("Target (Primary)", primary, legendLabelColor)
                 LegendDot("Corrected", Color(0xFFFF4444), legendLabelColor)
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -190,7 +190,7 @@ fun FrequencyResponseGraph(
                                 val freq = xToFreq(change.position.x, size.width.toFloat())
                                 val gain = yToGain(
                                     change.position.y, size.height.toFloat(),
-                                    minGain, maxGain, maxAbsDragGain
+                                    minGain, maxGain, zeroOffset, maxAbsDragGain
                                 )
                                 onBandDragged(selectedBandId, freq, gain)
                             }
@@ -497,10 +497,17 @@ private fun yToGain(
     height: Float,
     minGain: Float,
     maxGain: Float,
+    zeroOffset: Float,
     maxAbsDragGain: Float = EqLimits.AUTOEQ_MAX_BAND_DB,
 ): Float {
     val ratio = ((height - GRAPH_PADDING_BOTTOM) - y) / (height - GRAPH_PADDING_TOP - GRAPH_PADDING_BOTTOM)
-    return (minGain + ratio.coerceIn(0f, 1f) * (maxGain - minGain))
+    // The graph's gain axis is centered on zeroOffset (the SPL normalization
+    // level on the AutoEQ screen, ~75 dB), but band gains are stored relative
+    // to zero and drawn at band.gain + zeroOffset (see findNearestBand). The
+    // inverse mapping must subtract the offset before clamping — without it,
+    // the absolute SPL value (always >> maxAbsDragGain) pegged every drag at
+    // +maxAbsDragGain.
+    return (minGain + ratio.coerceIn(0f, 1f) * (maxGain - minGain) - zeroOffset)
         .coerceIn(-maxAbsDragGain, maxAbsDragGain)
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/eq/MeasurementUploadScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/MeasurementUploadScreen.kt
@@ -82,7 +82,9 @@ fun MeasurementUploadScreen(
         uri ?: return@rememberLauncherForActivityResult
         try {
             val rawData = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-            if (!rawData.isNullOrEmpty()) {
+            if (rawData.isNullOrEmpty()) {
+                android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
+            } else {
                 measurementData = rawData
                 // Pull the file's display name off the SAF URI and use it as
                 // the headphone name (sans extension). This is what makes
@@ -103,7 +105,9 @@ fun MeasurementUploadScreen(
                         ?: headphoneName
                 }
             }
-        } catch (_: Exception) { }
+        } catch (_: Exception) {
+            android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
+        }
     }
 
     Column(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -141,14 +141,10 @@ fun ParametricEqScreen(
             item {
               tf.monochrome.android.devedit.DevEditable("peq_preview_graph", Modifier.fillMaxWidth()) {
                 Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                    if (spectrumEnabled && spectrumBins.isNotEmpty()) {
-                        SpectrumOverlay(
-                            bins = spectrumBins,
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.55f),
-                            modifier = Modifier.fillMaxWidth(),
-                            height = 160.dp
-                        )
-                    }
+                    // Feed the spectrum INTO the graph — it draws it over its own
+                    // (opaque) background and under the EQ curve. A separate
+                    // overlay behind the graph was hidden by that background on
+                    // every theme except the transparent 'Clear' one.
                     FrequencyResponseGraph(
                         originalCurve = emptyList(),
                         targetCurve = emptyList(),
@@ -157,6 +153,8 @@ fun ParametricEqScreen(
                         centerOnZero = true,
                         showLegend = false,
                         maxAbsDragGain = EqLimits.PARAMETRIC_MAX_BAND_DB,
+                        spectrumBins = if (spectrumEnabled) spectrumBins else FloatArray(0),
+                        spectrumColor = MaterialTheme.colorScheme.primary,
                     )
                 }
               }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -71,6 +72,17 @@ fun ParametricEqScreen(
         DisposableEffect(Unit) {
             viewModel.spectrumAnalyzer.acquire()
             onDispose { viewModel.spectrumAnalyzer.release() }
+        }
+    }
+
+    // Surface preset save/load/persist errors that the ViewModel reports but
+    // no screen was collecting (silent failures / silent corrupted-load).
+    val eqError by viewModel.error.collectAsState()
+    val eqErrorContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(eqError) {
+        eqError?.let {
+            android.widget.Toast.makeText(eqErrorContext, it, android.widget.Toast.LENGTH_SHORT).show()
+            viewModel.clearError()
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -66,19 +67,19 @@ class ParametricEqViewModel @Inject constructor(
             repository.getAllPresets().collect { _allPresets.value = it }
         }
         viewModelScope.launch {
-            // Restore bands from persistent storage
-            val bandsJson = preferences.paramEqBandsJson.stateIn(
-                viewModelScope, SharingStarted.Eagerly, null
-            ).value
+            // Restore bands from persistent storage. Await the first real
+            // DataStore emission with first(): the previous stateIn(...).value
+            // pattern raced and almost always read the null initial value, so
+            // saved bands never restored and the next saveBands() overwrote
+            // them with the defaults.
+            val bandsJson = preferences.paramEqBandsJson.first()
             if (!bandsJson.isNullOrBlank()) {
                 try {
                     val bands = json.decodeFromString<List<EqBand>>(bandsJson)
                     if (bands.isNotEmpty()) _currentBands.value = bands
                 } catch (_: Exception) { }
             }
-            val activeId = preferences.paramEqActivePresetId.stateIn(
-                viewModelScope, SharingStarted.Eagerly, null
-            ).value
+            val activeId = preferences.paramEqActivePresetId.first()
             if (activeId != null) {
                 _activePreset.value = repository.getPresetById(activeId)
             }

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -237,6 +237,7 @@ fun HomeScreen(
             onCancel = downloadCenter::cancel,
             onCancelAll = downloadCenter::cancelAll,
             onDismiss = { showDownloadsMonitor = false },
+            onRetry = downloadCenter::retry,
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -159,6 +159,12 @@ fun HomeScreen(
 
     val selection = tf.monochrome.android.ui.components.rememberTrackSelectionState<Long>()
     androidx.activity.compose.BackHandler(enabled = selection.active) { selection.clear() }
+    // Back closes an open search (and clears the query so the feed returns)
+    // instead of falling through and exiting the app.
+    androidx.activity.compose.BackHandler(enabled = searchOpen) {
+        searchViewModel.onQueryChange("")
+        searchOpen = false
+    }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -125,8 +125,15 @@ fun HomeScreen(
         androidx.compose.runtime.mutableStateOf(false)
     }
     val searchFocus = androidx.compose.runtime.remember { androidx.compose.ui.focus.FocusRequester() }
-    androidx.compose.runtime.LaunchedEffect(searchOpen) {
-        if (searchOpen) searchFocus.requestFocus()
+    // Only grab focus on a genuine user open (pendingFocus is non-saveable, so
+    // returning from a detail screen with searchOpen restored true does NOT
+    // re-pop the keyboard over the results).
+    var pendingSearchFocus by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+    androidx.compose.runtime.LaunchedEffect(pendingSearchFocus) {
+        if (pendingSearchFocus) {
+            pendingSearchFocus = false
+            runCatching { searchFocus.requestFocus() }
+        }
     }
     val isRadioActive by playerViewModel.isRadioActive.collectAsState()
     val isRadioGenerating by playerViewModel.isRadioGenerating.collectAsState()
@@ -239,7 +246,9 @@ fun HomeScreen(
                             // home feed comes back.
                             searchViewModel.onQueryChange("")
                         }
-                        searchOpen = !searchOpen
+                        val opening = !searchOpen
+                        searchOpen = opening
+                        if (opening) pendingSearchFocus = true
                     }) {
                         Icon(
                             if (searchOpen) Icons.Default.Clear else Icons.Default.Search,

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -80,6 +80,7 @@ import tf.monochrome.android.ui.navigation.Screen
 import tf.monochrome.android.ui.navigation.openCatalogArtist
 import tf.monochrome.android.ui.player.PlayerViewModel
 import tf.monochrome.android.ui.search.SearchQueryField
+import tf.monochrome.android.ui.search.SearchHistoryContent
 import tf.monochrome.android.ui.search.SearchResultsContent
 import tf.monochrome.android.ui.search.SearchViewModel
 import tf.monochrome.android.ui.theme.MonoDimens
@@ -118,6 +119,7 @@ fun HomeScreen(
     val isLoadingMore by searchViewModel.isLoadingMore.collectAsState()
     val endReached by searchViewModel.endReached.collectAsState()
     val searchError by searchViewModel.searchError.collectAsState()
+    val searchHistory by searchViewModel.searchHistory.collectAsState()
     val recommendations by searchViewModel.recommendations.collectAsState()
     val hasSearchResults = searchQuery.isNotBlank()
 
@@ -359,6 +361,16 @@ fun HomeScreen(
                 endReached = endReached,
                 searchError = searchError,
                 onRetry = searchViewModel::submitSearch,
+                // Recent-search history — previously only reachable from the
+                // orphaned standalone SearchScreen; now shown when the Home
+                // search is open with an empty query.
+                emptyContent = {
+                    SearchHistoryContent(
+                        history = searchHistory,
+                        onSelect = searchViewModel::selectHistoryQuery,
+                        onClearHistory = searchViewModel::clearSearchHistory,
+                    )
+                },
             )
         } else if (isLoading) {
             LoadingScreen()

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -117,6 +117,7 @@ fun HomeScreen(
     val showSourceFilter by searchViewModel.showSourceFilter.collectAsState()
     val isLoadingMore by searchViewModel.isLoadingMore.collectAsState()
     val endReached by searchViewModel.endReached.collectAsState()
+    val searchError by searchViewModel.searchError.collectAsState()
     val recommendations by searchViewModel.recommendations.collectAsState()
     val hasSearchResults = searchQuery.isNotBlank()
 
@@ -350,6 +351,8 @@ fun HomeScreen(
                 onLoadMore = searchViewModel::loadMore,
                 isLoadingMore = isLoadingMore,
                 endReached = endReached,
+                searchError = searchError,
+                onRetry = searchViewModel::submitSearch,
             )
         } else if (isLoading) {
             LoadingScreen()

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeScreen.kt
@@ -147,6 +147,11 @@ fun HomeScreen(
     var showCreatePlaylistDialog by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf(false)
     }
+    // Tracks handed over from an "Add to playlist → New Playlist" tap, added to
+    // the playlist once it's created so they aren't dropped on the way.
+    var pendingTracksForNewPlaylist by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf<List<Track>>(emptyList())
+    }
     var showAddToPlaylistForSelection by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf(false)
     }
@@ -177,9 +182,13 @@ fun HomeScreen(
 
     if (showCreatePlaylistDialog) {
         CreatePlaylistDialog(
-            onDismiss = { showCreatePlaylistDialog = false },
+            onDismiss = {
+                showCreatePlaylistDialog = false
+                pendingTracksForNewPlaylist = emptyList()
+            },
             onSubmit = { name, description ->
-                playerViewModel.createPlaylist(name, description)
+                playerViewModel.createPlaylist(name, description, pendingTracksForNewPlaylist)
+                pendingTracksForNewPlaylist = emptyList()
                 showCreatePlaylistDialog = false
             }
         )
@@ -194,6 +203,7 @@ fun HomeScreen(
                 showAddToPlaylistForTrack = null
             },
             onCreateNew = {
+                pendingTracksForNewPlaylist = listOf(track)
                 showAddToPlaylistForTrack = null
                 showCreatePlaylistDialog = true
             }
@@ -214,6 +224,7 @@ fun HomeScreen(
                 selection.clear()
             },
             onCreateNew = {
+                pendingTracksForNewPlaylist = recentTracks.filter { it.id in selection.selectedIds }
                 showAddToPlaylistForSelection = false
                 showCreatePlaylistDialog = true
             }

--- a/app/src/main/java/tf/monochrome/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/home/HomeViewModel.kt
@@ -48,11 +48,15 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val tracks = libraryRepository.getHistory().first()
-                _recentTracks.value = tracks.take(20)
+                // Collect the history flow (not first()) so "Recently Played"
+                // stays live — new plays appear and "Remove from history"
+                // actually removes the row instead of doing nothing.
+                libraryRepository.getHistory().collect { tracks ->
+                    _recentTracks.value = tracks.take(20)
+                    _isLoading.value = false
+                }
             } catch (_: Exception) {
                 // Empty state shown by HomeScreen when recentTracks stays empty.
-            } finally {
                 _isLoading.value = false
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
@@ -32,11 +32,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -63,6 +65,15 @@ fun DownloadsScreen(
     val downloadedTracks by viewModel.downloadedTracks.collectAsState()
     val albumGroups by viewModel.albumGroups.collectAsState()
     val playlists by playerViewModel.playlists.collectAsState()
+
+    // Surface delete failures (e.g. a sideloaded file the provider won't remove)
+    // instead of silently leaving the row behind.
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.messages.collect { msg ->
+            android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
 
     val selection = rememberTrackSelectionState<Long>()
     BackHandler(enabled = selection.active) { selection.clear() }

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -66,6 +68,33 @@ fun DownloadsScreen(
     BackHandler(enabled = selection.active) { selection.clear() }
     var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    // Deleting removes the actual audio files from disk with no undo, and the
+    // trash icon sits right next to add-to-playlist in the selection bar — a
+    // mis-tap must not silently destroy the user's downloads.
+    if (showDeleteConfirm) {
+        val count = selection.count
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete $count download${if (count == 1) "" else "s"}?") },
+            text = { Text("The audio file${if (count == 1) "" else "s"} will be permanently removed from this device.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteDownloads(
+                        downloadedTracks.filter { it.id in selection.selectedIds }
+                    )
+                    showDeleteConfirm = false
+                    selection.clear()
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
 
     if (showCreatePlaylistDialog) {
         CreatePlaylistDialog(
@@ -132,10 +161,7 @@ fun DownloadsScreen(
                 selection.clear()
             },
             onAddToPlaylist = { showAddToPlaylistForSelection = true },
-            onDelete = {
-                viewModel.deleteDownloads(downloadedTracks.filter { it.id in selection.selectedIds })
-                selection.clear()
-            },
+            onDelete = { showDeleteConfirm = true },
             deleteContentDescription = "Delete downloads"
         )
     }

--- a/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/DownloadsViewModel.kt
@@ -6,13 +6,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import tf.monochrome.android.data.db.dao.DownloadDao
 import tf.monochrome.android.data.db.entity.DownloadedTrackEntity
 import tf.monochrome.android.data.preferences.PreferencesManager
@@ -184,29 +188,51 @@ class DownloadsViewModel @Inject constructor(
         )
     }
 
+    // One-shot user messages (e.g. a delete that couldn't remove the file).
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 4)
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
+
     fun deleteDownload(track: DownloadedTrackEntity) {
-        viewModelScope.launch { deleteOne(track) }
+        viewModelScope.launch {
+            if (!deleteOne(track)) {
+                _messages.tryEmit("Couldn't delete “${track.title}”")
+            }
+        }
     }
 
     fun deleteDownloads(tracks: List<DownloadedTrackEntity>) {
-        viewModelScope.launch { tracks.forEach { deleteOne(it) } }
+        viewModelScope.launch {
+            val failed = tracks.count { !deleteOne(it) }
+            if (failed > 0) {
+                _messages.tryEmit("Couldn't delete $failed file${if (failed == 1) "" else "s"}")
+            }
+        }
     }
 
-    private suspend fun deleteOne(track: DownloadedTrackEntity) {
-        if (track.filePath.startsWith("content://")) {
-            try {
-                val uri = track.filePath.toUri()
-                val docFile = DocumentFile.fromSingleUri(appCtx, uri)
-                docFile?.delete()
-            } catch (e: Exception) {
-                // Ignore exceptions during content deletion
+    /**
+     * Removes the file and its Room record. Returns whether the file itself was
+     * actually removed — a sideloaded (SAF content://) file that the provider
+     * refuses to delete would otherwise silently reappear on the next folder
+     * scan, so the caller surfaces a message on false. Runs off the main thread.
+     */
+    private suspend fun deleteOne(track: DownloadedTrackEntity): Boolean =
+        withContext(Dispatchers.IO) {
+            val fileRemoved = if (track.filePath.startsWith("content://")) {
+                try {
+                    val uri = track.filePath.toUri()
+                    DocumentFile.fromSingleUri(appCtx, uri)?.delete() ?: false
+                } catch (e: Exception) {
+                    false
+                }
+            } else {
+                val file = File(track.filePath)
+                !file.exists() || file.delete()
             }
-        } else {
-            val file = File(track.filePath)
-            if (file.exists()) file.delete()
+            // App-written downloads live in Room; sideloaded rows don't, so this
+            // is a harmless no-op for them (they leave once the file is gone).
+            downloadDao.deleteDownloadedTrack(track.id)
+            fileRemoved
         }
-        downloadDao.deleteDownloadedTrack(track.id)
-    }
 
     companion object {
         const val SINGLES_LABEL = "Singles"

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -259,6 +259,11 @@ fun LibraryScreen(
             )
         }
 
+        val sectionStateHolder = androidx.compose.runtime.saveable.rememberSaveableStateHolder()
+        // Preserve each tab's scroll position (and the Local tab's own sub-tab
+        // state) across tab switches, instead of remounting a fresh list that
+        // snaps back to the top every time the user changes tabs.
+        sectionStateHolder.SaveableStateProvider(currentSectionId) {
         when (currentSectionId) {
             "overview" ->
                 LazyColumn(
@@ -495,6 +500,7 @@ fun LibraryScreen(
 
             "downloads" ->
                 DownloadsScreen(navController = navController)
+        }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -137,10 +137,10 @@ fun LibraryScreen(
 
     // Surface CSV import outcome — previously importProgress was never
     // collected, so a malformed CSV produced no error and no playlist.
-    val importProgress by viewModel.importProgress.collectAsState()
+    val importProgressState = viewModel.importProgress.collectAsState()
     val importMsgContext = androidx.compose.ui.platform.LocalContext.current
-    LaunchedEffect(importProgress) {
-        when (val p = importProgress) {
+    LaunchedEffect(importProgressState.value) {
+        when (val p = importProgressState.value) {
             is tf.monochrome.android.data.import_.ImportProgress.Done -> {
                 android.widget.Toast.makeText(
                     importMsgContext,

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -135,6 +135,28 @@ fun LibraryScreen(
         )
     }
 
+    // Surface CSV import outcome — previously importProgress was never
+    // collected, so a malformed CSV produced no error and no playlist.
+    val importProgress by viewModel.importProgress.collectAsState()
+    val importMsgContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(importProgress) {
+        when (val p = importProgress) {
+            is tf.monochrome.android.data.import_.ImportProgress.Done -> {
+                android.widget.Toast.makeText(
+                    importMsgContext,
+                    "Imported ${p.matched}/${p.total} tracks into \"${p.playlistName}\"",
+                    android.widget.Toast.LENGTH_LONG
+                ).show()
+                viewModel.resetImportProgress()
+            }
+            is tf.monochrome.android.data.import_.ImportProgress.Failed -> {
+                android.widget.Toast.makeText(importMsgContext, "Import failed: ${p.message}", android.widget.Toast.LENGTH_LONG).show()
+                viewModel.resetImportProgress()
+            }
+            else -> {}
+        }
+    }
+
     showAddToPlaylistForTrack?.let { track ->
         AddToPlaylistSheet(
             playlists = playlists,

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -90,7 +90,9 @@ fun LibraryScreen(
 
     var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
 
-    var showCreatePlaylistDialog by remember { mutableStateOf(false) }
+    // Saveable so the dialog reopens after a process death triggered by its own
+    // SAF CSV picker; the dialog's typed fields + picked uri are saveable too.
+    var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForSelection by remember { mutableStateOf(false) }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
@@ -34,10 +34,6 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
-    /** Live CSV/Spotify import progress so the screen can show status. */
-    val importProgress: StateFlow<tf.monochrome.android.data.import_.ImportProgress> =
-        playlistImportService.progress
-
     fun resetImportProgress() { playlistImportService.resetProgress() }
 
     fun importCsvPlaylist(uri: Uri, strictAlbumMatch: Boolean, name: String, description: String?) {

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryViewModel.kt
@@ -34,6 +34,12 @@ class LibraryViewModel @Inject constructor(
         }
     }
 
+    /** Live CSV/Spotify import progress so the screen can show status. */
+    val importProgress: StateFlow<tf.monochrome.android.data.import_.ImportProgress> =
+        playlistImportService.progress
+
+    fun resetImportProgress() { playlistImportService.resetProgress() }
+
     fun importCsvPlaylist(uri: Uri, strictAlbumMatch: Boolean, name: String, description: String?) {
         viewModelScope.launch {
             playlistImportService.reportFetching("CSV")

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -184,9 +184,14 @@ fun LocalLibraryTab(
         }
         // If we have audio but not images yet, prompt once silently — but
         // don't gate the UI; the user has already opted into local library
-        // and the absence of cover images shouldn't block playback.
-        LaunchedEffect(permissionState.allPermissionsGranted) {
-            if (!permissionState.allPermissionsGranted) {
+        // and the absence of cover images shouldn't block playback. Keyed on
+        // Unit + a saveable one-shot flag so the system dialog fires once,
+        // instead of re-firing every time the Library tab re-enters
+        // composition (the effect was keyed on the still-false grant state).
+        var imagePermissionRequested by rememberSaveable { mutableStateOf(false) }
+        LaunchedEffect(Unit) {
+            if (!permissionState.allPermissionsGranted && !imagePermissionRequested) {
+                imagePermissionRequested = true
                 permissionState.launchMultiplePermissionRequest()
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -178,9 +178,18 @@ fun LocalLibraryTab(
             }
         }
 
-        // Scan progress bar
-        if (isScanning) {
+        // Scan progress bar — also shown on the terminal Complete/Error states
+        // (previously dead UI) so the user sees the summary or the error, then
+        // auto-dismissed a few seconds later.
+        val scanTerminal = scanProgress is ScanProgress.Complete || scanProgress is ScanProgress.Error
+        if (isScanning || scanTerminal) {
             ScanProgressBar(scanProgress)
+        }
+        LaunchedEffect(scanProgress) {
+            if (scanProgress is ScanProgress.Complete || scanProgress is ScanProgress.Error) {
+                kotlinx.coroutines.delay(4000)
+                viewModel.clearScanProgress()
+            }
         }
 
         // Search bar

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -57,7 +57,9 @@ import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -121,6 +123,17 @@ fun LocalLibraryTab(
     var selectedSubTab by rememberSaveable { mutableIntStateOf(0) }
     val subTabs = listOf("Albums", "Artists", "Songs", "Genres", "Folders")
     var showSearch by remember { mutableStateOf(false) }
+    val searchFocus = remember { androidx.compose.ui.focus.FocusRequester() }
+    // Focus the field (and pop the IME) the moment search opens, so it doesn't
+    // take a second tap.
+    LaunchedEffect(showSearch) {
+        if (showSearch) runCatching { searchFocus.requestFocus() }
+    }
+    // Clear the query when leaving the library, so a stale search doesn't
+    // resurface (and instantly replace the tab with old results) next time.
+    DisposableEffect(Unit) {
+        onDispose { viewModel.setSearchQuery("") }
+    }
 
     val context = LocalContext.current
 
@@ -199,6 +212,7 @@ fun LocalLibraryTab(
                 onValueChange = { viewModel.setSearchQuery(it) },
                 modifier = Modifier
                     .fillMaxWidth()
+                    .focusRequester(searchFocus)
                     .padding(horizontal = 16.dp, vertical = 4.dp),
                 placeholder = { Text("Search local library...") },
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
@@ -64,9 +64,42 @@ class LocalLibraryViewModel @Inject constructor(
     private val _artistSort = MutableStateFlow(LibrarySort(LibrarySortKey.NAME))
     val artistSort: StateFlow<LibrarySort> = _artistSort.asStateFlow()
 
-    fun setSongSort(sort: LibrarySort) { _songSort.value = sort }
-    fun setAlbumSort(sort: LibrarySort) { _albumSort.value = sort }
-    fun setArtistSort(sort: LibrarySort) { _artistSort.value = sort }
+    init {
+        // Restore persisted sort selections so they survive process death and
+        // app restarts instead of snapping back to Name / A→Z.
+        viewModelScope.launch {
+            preferencesManager.songSort.collect { _songSort.value = parseSort(it) }
+        }
+        viewModelScope.launch {
+            preferencesManager.albumSort.collect { _albumSort.value = parseSort(it) }
+        }
+        viewModelScope.launch {
+            preferencesManager.artistSort.collect { _artistSort.value = parseSort(it) }
+        }
+    }
+
+    fun setSongSort(sort: LibrarySort) {
+        _songSort.value = sort
+        viewModelScope.launch { preferencesManager.setSongSort(sort.serialize()) }
+    }
+    fun setAlbumSort(sort: LibrarySort) {
+        _albumSort.value = sort
+        viewModelScope.launch { preferencesManager.setAlbumSort(sort.serialize()) }
+    }
+    fun setArtistSort(sort: LibrarySort) {
+        _artistSort.value = sort
+        viewModelScope.launch { preferencesManager.setArtistSort(sort.serialize()) }
+    }
+
+    private fun LibrarySort.serialize(): String = "${key.name}:${if (ascending) "asc" else "desc"}"
+
+    private fun parseSort(raw: String?): LibrarySort {
+        val default = LibrarySort(LibrarySortKey.NAME)
+        if (raw.isNullOrBlank()) return default
+        val parts = raw.split(":")
+        val key = LibrarySortKey.entries.firstOrNull { it.name == parts.getOrNull(0) } ?: return default
+        return LibrarySort(key, ascending = parts.getOrNull(1) != "desc")
+    }
 
     val sortedTracks: StateFlow<List<UnifiedTrack>> = combine(localTracks, _songSort) { tracks, sort ->
         tracks.applySort(sort)

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryViewModel.kt
@@ -146,6 +146,9 @@ class LocalLibraryViewModel @Inject constructor(
         viewModelScope.launch { scanCoordinator.runIncrementalScan() }
     }
 
+    /** Dismiss the terminal scan-progress bar (Complete/Error). */
+    fun clearScanProgress() { scanCoordinator.clearProgress() }
+
     // ── Collection import ───────────────────────────────────────────
 
     private val _importResult = MutableStateFlow<Result<String>?>(null)

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
@@ -36,6 +37,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -78,6 +80,7 @@ fun PlaylistScreen(
 
     var showMenu by remember { mutableStateOf(false) }
     var showEditDialog by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
@@ -153,6 +156,24 @@ fun PlaylistScreen(
         )
     }
 
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete playlist?") },
+            text = { Text("\"${playlistInfo?.name.orEmpty()}\" will be permanently deleted. This can't be undone.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteConfirm = false
+                    viewModel.deletePlaylist()
+                    navController.popBackStack()
+                }) { Text("Delete", color = MaterialTheme.colorScheme.error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+
     val editInfo = playlistInfo
     if (showEditDialog && editInfo != null) {
         CreatePlaylistDialog(
@@ -211,8 +232,7 @@ fun PlaylistScreen(
                         leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
                         onClick = {
                             showMenu = false
-                            viewModel.deletePlaylist()
-                            navController.popBackStack()
+                            showDeleteConfirm = true
                         }
                     )
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -162,7 +162,7 @@ fun PlaylistScreen(
                 showEditDialog = false
             },
             initialName = editInfo.name,
-            initialDescription = editInfo.description,
+            initialDescription = editInfo.description.orEmpty(),
             title = "Edit Playlist",
             confirmLabel = "Save",
         )

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -349,7 +349,7 @@ fun PlaylistScreen(
                     )
                 }
             } else {
-                items(tracks) { track ->
+                items(tracks, key = { it.id }) { track ->
                     TrackItem(
                         track = track,
                         isLiked = favoriteTrackIds.contains(track.id),

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistScreen.kt
@@ -153,13 +153,18 @@ fun PlaylistScreen(
         )
     }
 
-    if (showEditDialog && playlistInfo != null) {
+    val editInfo = playlistInfo
+    if (showEditDialog && editInfo != null) {
         CreatePlaylistDialog(
             onDismiss = { showEditDialog = false },
             onSubmit = { name, desc ->
                 viewModel.updatePlaylist(name, desc)
                 showEditDialog = false
-            }
+            },
+            initialName = editInfo.name,
+            initialDescription = editInfo.description,
+            title = "Edit Playlist",
+            confirmLabel = "Save",
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
@@ -8,9 +8,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import tf.monochrome.android.data.db.entity.UserPlaylistEntity
 import tf.monochrome.android.data.repository.LibraryRepository
 import tf.monochrome.android.domain.model.Track
@@ -58,7 +60,13 @@ class PlaylistViewModel @Inject constructor(
     
     fun deletePlaylist() {
         viewModelScope.launch {
-            libraryRepository.deletePlaylist(playlistId)
+            // The screen pops the back stack right after calling this, which
+            // clears the ViewModel and cancels viewModelScope. Run the delete in
+            // a NonCancellable block so the DB write isn't aborted mid-flight
+            // and the playlist can't come back on the next launch.
+            withContext(NonCancellable) {
+                libraryRepository.deletePlaylist(playlistId)
+            }
         }
     }
     

--- a/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/PlaylistViewModel.kt
@@ -64,7 +64,15 @@ class PlaylistViewModel @Inject constructor(
     
     fun updatePlaylist(name: String, description: String) {
         viewModelScope.launch {
-            libraryRepository.updatePlaylist(playlistId, name, description)
+            // Preserve the current visibility — updatePlaylist's isPublic
+            // param defaults to false, so omitting it silently made public
+            // playlists private on every edit.
+            libraryRepository.updatePlaylist(
+                playlistId,
+                name,
+                description,
+                isPublic = _playlistInfo.value?.isPublic ?: false
+            )
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/main/MainActivity.kt
@@ -112,6 +112,11 @@ class MainActivity : ComponentActivity() {
             supabaseAuthManager.initialize()
         }
 
+        // A cold start triggered by the OAuth redirect delivers the callback as
+        // the launch intent (onNewIntent never fires) — handle it here too so
+        // login completes instead of silently failing.
+        handleDeepLinkIntent(intent)
+
         FrequencyTargets.init(applicationContext)
 
         // Apply the user's app-wide frame-rate / resolution preference by
@@ -325,9 +330,18 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        // Route OAuth callback deep-links: Spotify (tryptify://spotify-callback)
-        // vs Supabase (tf.monotrypt.android://login-callback)
-        val uri = intent.data ?: return
+        handleDeepLinkIntent(intent)
+    }
+
+    /**
+     * Route OAuth callback deep-links: Spotify (tryptify://spotify-callback) vs
+     * Supabase (tf.monotrypt.android://login-callback). Handled from BOTH
+     * onNewIntent (app already running) and onCreate (cold start after process
+     * death, where the redirect delivers the callback as the launch intent —
+     * previously dropped, so login silently failed).
+     */
+    private fun handleDeepLinkIntent(intent: Intent?) {
+        val uri = intent?.data ?: return
         lifecycleScope.launch {
             if (uri.scheme == "tryptify" && uri.host == "spotify-callback") {
                 spotifyAuthManager.handleCallback(uri)

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -120,7 +120,7 @@ fun FLChannelStrip(
                 text = if (isMaster) "M" else "${bus.index + 1}",
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
-                color = if (isSelected) onAccent else Color.White
+                color = if (isSelected) onAccent else colors.onSurfaceVariant
             )
         }
 
@@ -129,7 +129,8 @@ fun FLChannelStrip(
             text = bus.name,
             fontSize = 10.sp,
             fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
-            color = Color.White.copy(alpha = if (isSelected) 1f else 0.82f),
+            // Theme color (was hardcoded white → invisible on the light theme).
+            color = colors.onSurface.copy(alpha = if (isSelected) 1f else 0.82f),
             textAlign = TextAlign.Center,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +36,7 @@ import tf.monochrome.android.audio.dsp.model.BusConfig
 import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.components.toggleSemantics
 import tf.monochrome.android.ui.player.PlayerDesignTokens
 
 /** Fixed fader travel so strips stay compact instead of stretching the whole
@@ -205,6 +207,7 @@ fun FLChannelStrip(
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             Box(
                 modifier = Modifier
+                    .minimumInteractiveComponentSize()
                     .size(26.dp)
                     .clip(CircleShape)
                     .background(if (bus.muted) colors.error else inactiveButton)
@@ -213,7 +216,8 @@ fun FLChannelStrip(
                         color = if (bus.muted) colors.error.copy(alpha = 0.75f) else colors.outline.copy(alpha = 0.12f),
                         shape = CircleShape
                     )
-                    .bounceClick(onClick = onToggleMute),
+                    .bounceClick(onClick = onToggleMute)
+                    .toggleSemantics(label = "Mute", checked = bus.muted),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -227,6 +231,7 @@ fun FLChannelStrip(
             if (!isMaster) {
                 Box(
                     modifier = Modifier
+                        .minimumInteractiveComponentSize()
                         .size(26.dp)
                         .clip(CircleShape)
                         .background(if (bus.soloed) accent else inactiveButton)
@@ -235,7 +240,8 @@ fun FLChannelStrip(
                             color = if (bus.soloed) accent.copy(alpha = 0.78f) else colors.outline.copy(alpha = 0.12f),
                             shape = CircleShape
                         )
-                        .bounceClick(onClick = onToggleSolo),
+                        .bounceClick(onClick = onToggleSolo)
+                        .toggleSemantics(label = "Solo", checked = bus.soloed),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLKnob.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLKnob.kt
@@ -3,6 +3,7 @@ package tf.monochrome.android.ui.mixer
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -93,7 +94,8 @@ internal fun FLKnobControl(
     color: Color,
     onValueChange: (Float) -> Unit,
     modifier: Modifier = Modifier,
-    steps: Int? = null
+    steps: Int? = null,
+    default: Float? = null
 ) {
     val fraction = ((value - min) / (max - min)).coerceIn(0f, 1f)
     var isTouching by remember { mutableStateOf(false) }
@@ -105,6 +107,7 @@ internal fun FLKnobControl(
     // which would make the knob snap back and appear frozen while dragging.
     val latestValue by rememberUpdatedState(value)
     val latestOnValueChange by rememberUpdatedState(onValueChange)
+    val latestDefault by rememberUpdatedState(default)
 
     Column(
         modifier = modifier.padding(horizontal = 4.dp, vertical = 6.dp),
@@ -128,14 +131,28 @@ internal fun FLKnobControl(
         Canvas(
             modifier = Modifier
                 .size(64.dp)
+                // Double-tap resets to the parameter default. Kept in its own
+                // detector so it composes with — and yields to — the drag
+                // gesture below: a real drag consumes movement, which cancels
+                // this tap detector before it can fire.
+                .pointerInput(min, max, steps) {
+                    detectTapGestures(
+                        onDoubleTap = {
+                            val d = latestDefault ?: return@detectTapGestures
+                            latestOnValueChange(snapValue(d, min, max, steps))
+                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        }
+                    )
+                }
                 .pointerInput(min, max) {
                     val cx = size.width / 2f
                     val cy = size.height / 2f
+                    val touchSlop = viewConfiguration.touchSlop
 
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
-                        isTouching = true
-                        var lastPos = down.position
+                        val downPos = down.position
+                        var lastPos = downPos
                         var lastAngle: Float? = null
                         val range = max - min
                         // Seed a running accumulator from the live value at the
@@ -143,48 +160,78 @@ internal fun FLKnobControl(
                         // keeps each move relative to the actual current value
                         // instead of a stale closure-captured one.
                         var current = latestValue
+                        // Don't grab the pointer until the finger has travelled
+                        // past touch slop: below it we leave events unconsumed so
+                        // a parent scroll (the FX-chain list) can claim the drag
+                        // instead of the knob swallowing every touch.
+                        var dragging = false
+                        // Mode is locked ONCE the moment slop is crossed, from the
+                        // finger's initial landing point — so a single gesture no
+                        // longer flips between rotary / vertical / fine mid-drag.
+                        var mode = -1 // 0 = fine-tune, 1 = rotary, 2 = vertical
 
                         while (true) {
                             val event = awaitPointerEvent()
                             val change = event.changes.firstOrNull() ?: break
-                            if (!change.pressed) {
-                                isTouching = false
-                                break
-                            }
+                            if (!change.pressed) break
 
                             val pos = change.position
+
+                            if (!dragging) {
+                                val distFromDown = kotlin.math.sqrt(
+                                    (pos.x - downPos.x) * (pos.x - downPos.x) +
+                                        (pos.y - downPos.y) * (pos.y - downPos.y)
+                                )
+                                if (distFromDown < touchSlop) continue
+                                dragging = true
+                                isTouching = true
+                                val distFromCenter = kotlin.math.sqrt(
+                                    (downPos.x - cx) * (downPos.x - cx) +
+                                        (downPos.y - cy) * (downPos.y - cy)
+                                )
+                                mode = when {
+                                    distFromCenter > cx * 1.5f -> 0
+                                    distFromCenter > cx * 0.3f -> 1
+                                    else -> 2
+                                }
+                                lastAngle = if (mode == 1) {
+                                    kotlin.math.atan2(pos.y - cy, pos.x - cx)
+                                } else null
+                                lastPos = pos
+                                change.consume()
+                                continue
+                            }
+
                             val dx = pos.x - lastPos.x
                             val dy = pos.y - lastPos.y
-
-                            // Distance from knob center determines mode
-                            val distFromCenter = kotlin.math.sqrt(
-                                (pos.x - cx) * (pos.x - cx) + (pos.y - cy) * (pos.y - cy)
-                            )
-
                             val oldFrac = ((current - min) / range).coerceIn(0f, 1f)
 
-                            if (distFromCenter > cx * 1.5f) {
-                                // ── Fine-tune mode: far from knob, horizontal drag ──
-                                val sensitivity = range / 800f
-                                current = (current + dx * sensitivity).coerceIn(min, max)
-                            } else if (distFromCenter > cx * 0.3f) {
-                                // ── Rotary mode: circular drag around knob ──
-                                val angle = kotlin.math.atan2(pos.y - cy, pos.x - cx)
-                                if (lastAngle != null) {
-                                    var delta = angle - lastAngle!!
-                                    // Wrap around -PI/PI boundary
-                                    if (delta > Math.PI.toFloat()) delta -= 2f * Math.PI.toFloat()
-                                    if (delta < -Math.PI.toFloat()) delta += 2f * Math.PI.toFloat()
-                                    // Map rotation to value change (full circle = full range)
-                                    current = (current + delta / (1.5f * Math.PI.toFloat()) * range)
-                                        .coerceIn(min, max)
+                            when (mode) {
+                                0 -> {
+                                    // ── Fine-tune: far from knob, horizontal drag ──
+                                    val sensitivity = range / 800f
+                                    current = (current + dx * sensitivity).coerceIn(min, max)
                                 }
-                                lastAngle = angle
-                            } else {
-                                // ── Vertical drag mode: standard coarse control ──
-                                val sensitivity = range / 250f
-                                current = (current - dy * sensitivity).coerceIn(min, max)
-                                lastAngle = null
+                                1 -> {
+                                    // ── Rotary: circular drag around knob ──
+                                    val angle = kotlin.math.atan2(pos.y - cy, pos.x - cx)
+                                    val prev = lastAngle
+                                    if (prev != null) {
+                                        var delta = angle - prev
+                                        // Wrap around -PI/PI boundary
+                                        if (delta > Math.PI.toFloat()) delta -= 2f * Math.PI.toFloat()
+                                        if (delta < -Math.PI.toFloat()) delta += 2f * Math.PI.toFloat()
+                                        // Map rotation to value change (full circle = full range)
+                                        current = (current + delta / (1.5f * Math.PI.toFloat()) * range)
+                                            .coerceIn(min, max)
+                                    }
+                                    lastAngle = angle
+                                }
+                                else -> {
+                                    // ── Vertical: standard coarse control ──
+                                    val sensitivity = range / 250f
+                                    current = (current - dy * sensitivity).coerceIn(min, max)
+                                }
                             }
 
                             latestOnValueChange(snapValue(current, min, max, steps))
@@ -202,6 +249,7 @@ internal fun FLKnobControl(
                             lastPos = pos
                             change.consume()
                         }
+                        isTouching = false
                     }
                 }
         ) {

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLKnob.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLKnob.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.material3.Text
+import tf.monochrome.android.ui.components.adjustableSemantics
 import kotlin.math.cos
 import kotlin.math.round
 import kotlin.math.sin
@@ -131,6 +132,13 @@ internal fun FLKnobControl(
         Canvas(
             modifier = Modifier
                 .size(64.dp)
+                .adjustableSemantics(
+                    label = label,
+                    value = value,
+                    range = min..max,
+                    stateText = { formatParamValue(it, ParamDef(label, min, max, it, unit, steps)) },
+                    onValueChange = { onValueChange(snapValue(it, min, max, steps)) },
+                )
                 // Double-tap resets to the parameter default. Kept in its own
                 // detector so it composes with — and yields to — the drag
                 // gesture below: a real drag consumes movement, which cancels

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/InsertRack.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/InsertRack.kt
@@ -68,6 +68,7 @@ fun InsertRack(
     allBuses: List<BusConfig> = emptyList(),
     onSlotTap: (slotIndex: Int) -> Unit,
     onAddPlugin: () -> Unit,
+    onPluginReplace: (busIndex: Int, slotIndex: Int) -> Unit = { _, _ -> },
     onPluginBypass: (busIndex: Int, slotIndex: Int) -> Unit,
     onPluginRemove: (busIndex: Int, slotIndex: Int) -> Unit,
     onParameterChange: (busIndex: Int, slotIndex: Int, paramIndex: Int, value: Float) -> Unit,
@@ -150,7 +151,7 @@ fun InsertRack(
                     onDryWetChange = { dw ->
                         if (plugin != null) onPluginDryWet(busIndex, slotIndex, dw)
                     },
-                    onReplace = { onAddPlugin() },
+                    onReplace = { onPluginReplace(busIndex, slotIndex) },
                     onRemove  = { onPluginRemove(busIndex, slotIndex) }
                 )
 
@@ -339,7 +340,8 @@ private fun InsertSlot(
                     text = { Text("Replace") },
                     onClick = {
                         showContextMenu = false
-                        onRemove()
+                        // Defer removal to the picker's confirm — cancelling
+                        // must not destroy the current plugin.
                         onReplace()
                     }
                 )

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
@@ -455,6 +455,7 @@ fun MixerScreen(
                                 allBuses = buses,
                                 onSlotTap = { slotIdx -> viewModel.editPlugin(selectedBusIndex, slotIdx) },
                                 onAddPlugin = { viewModel.showAddPlugin() },
+                                onPluginReplace = { busIdx, slotIdx -> viewModel.showReplacePlugin(busIdx, slotIdx) },
                                 onPluginBypass = { busIdx, slotIdx -> viewModel.togglePluginBypass(busIdx, slotIdx) },
                                 onPluginRemove = { busIdx, slotIdx -> viewModel.removePlugin(busIdx, slotIdx) },
                                 onParameterChange = { busIdx, slotIdx, paramIdx, value ->

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
@@ -223,8 +223,13 @@ fun MixerScreen(
                 val text = context.contentResolver.openInputStream(uri)
                     ?.bufferedReader()?.use { it.readText() }
                 if (text.isNullOrBlank()) error("Empty file")
-                viewModel.importPreset(text)
-                Toast.makeText(context, "Preset imported", Toast.LENGTH_SHORT).show()
+                viewModel.importPreset(text) { ok ->
+                    Toast.makeText(
+                        context,
+                        if (ok) "Preset imported" else "Import failed: not a valid preset file",
+                        if (ok) Toast.LENGTH_SHORT else Toast.LENGTH_LONG
+                    ).show()
+                }
             }.onFailure {
                 Toast.makeText(context, "Import failed: ${it.message}", Toast.LENGTH_LONG).show()
             }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
@@ -67,6 +67,12 @@ class MixerViewModel @Inject constructor(
     private val _editingPlugin = MutableStateFlow<Pair<Int, Int>?>(null) // busIndex, slotIndex
     val editingPlugin: StateFlow<Pair<Int, Int>?> = _editingPlugin.asStateFlow()
 
+    // When set, the next picker selection replaces the plugin at this
+    // (busIndex, slotIndex) instead of appending. Nothing is removed until the
+    // user actually picks a replacement — cancelling the picker leaves the
+    // original plugin (and its settings) intact.
+    private val _pendingReplaceSlot = MutableStateFlow<Pair<Int, Int>?>(null)
+
     fun setEnabled(enabled: Boolean) = dspManager.setEnabled(enabled)
 
     fun selectBus(index: Int) { _selectedBusIndex.value = index }
@@ -89,9 +95,31 @@ class MixerViewModel @Inject constructor(
     // ── Plugin chain ────────────────────────────────────────────────────
 
     fun showAddPlugin() { _showPluginPicker.value = true }
-    fun dismissPluginPicker() { _showPluginPicker.value = false }
+
+    /** Open the picker in "replace this slot" mode (no removal happens yet). */
+    fun showReplacePlugin(busIndex: Int, slotIndex: Int) {
+        _pendingReplaceSlot.value = busIndex to slotIndex
+        _showPluginPicker.value = true
+    }
+
+    fun dismissPluginPicker() {
+        _showPluginPicker.value = false
+        _pendingReplaceSlot.value = null
+    }
 
     fun addPlugin(type: SnapinType) {
+        val pending = _pendingReplaceSlot.value
+        if (pending != null) {
+            val (busIndex, slotIndex) = pending
+            _pendingReplaceSlot.value = null
+            _showPluginPicker.value = false
+            val bus = buses.value.getOrNull(busIndex) ?: return
+            // Remove the old plugin and insert the replacement at the same slot
+            // so the chain's processing order is preserved.
+            if (slotIndex in bus.plugins.indices) dspManager.removePlugin(busIndex, slotIndex)
+            dspManager.addPlugin(busIndex, slotIndex, type)
+            return
+        }
         val busIndex = _selectedBusIndex.value
         val bus = buses.value.getOrNull(busIndex) ?: return
         if (bus.plugins.size >= DspEngineManager.MAX_PLUGINS_PER_BUS) {

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerViewModel.kt
@@ -215,21 +215,35 @@ class MixerViewModel @Inject constructor(
      * back to treating the text as raw engine state JSON), persist it as a
      * custom preset, and apply it live.
      */
-    fun importPreset(text: String) {
+    fun importPreset(text: String, onResult: (Boolean) -> Unit = {}) {
         viewModelScope.launch {
             val trimmed = text.trim()
             val file = runCatching {
                 json.decodeFromString(MixPresetFile.serializer(), trimmed)
             }.getOrNull()
 
-            val name = file?.name?.takeIf { it.isNotBlank() } ?: "Imported Preset"
-            val stateJson = file?.stateJson?.takeIf { it.isNotBlank() } ?: trimmed
+            // Only accept a valid MixPresetFile envelope or a bare engine-state
+            // JSON *object*. Rejecting anything else stops the old behavior of
+            // saving arbitrary files as a junk preset and resetting the mixer,
+            // then falsely toasting success.
+            val stateJson = when {
+                file?.stateJson?.takeIf { it.isNotBlank() } != null -> file.stateJson
+                runCatching { json.parseToJsonElement(trimmed) }.getOrNull()
+                    is kotlinx.serialization.json.JsonObject -> trimmed
+                else -> null
+            }
+            if (stateJson == null) {
+                onResult(false)
+                return@launch
+            }
 
+            val name = file?.name?.takeIf { it.isNotBlank() } ?: "Imported Preset"
             presetRepository.savePreset(
                 MixPreset(name = name, stateJson = stateJson, isCustom = true)
             )
             dspManager.loadStateJson(stateJson)
             _currentPresetName.value = name
+            onResult(true)
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/PanKnob.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/PanKnob.kt
@@ -1,11 +1,14 @@
 package tf.monochrome.android.ui.mixer
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -16,9 +19,9 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
-import kotlin.math.PI
-import kotlin.math.atan2
+import tf.monochrome.android.ui.components.adjustableSemantics
 import kotlin.math.cos
+import kotlin.math.roundToInt
 import kotlin.math.sin
 
 /**
@@ -48,32 +51,63 @@ fun PanKnob(
     // Remember whether we already fired a haptic for the centre detent
     val firedDetent = remember { mutableSetOf<Boolean>() }
 
+    // Gesture coroutine is keyed on Unit — read the live value through an
+    // updated-state holder so a drag starts from the actual current pan.
+    val latestValue by rememberUpdatedState(value)
+    val latestOnValueChange by rememberUpdatedState(onValueChange)
+
     Canvas(
         modifier = modifier
+            // Keep the 28dp visual but expand the touch target to the 48dp
+            // accessibility minimum so it isn't a near-impossible hit.
+            .minimumInteractiveComponentSize()
             .size(28.dp)
-            .pointerInput(Unit) {
-                val cx = size.width / 2f
-                val cy = size.height / 2f
-                detectDragGestures { change, _ ->
-                    change.consume()
-                    val pos = change.position
-                    // atan2 with 0 = up (12 o'clock)
-                    val angle = atan2(pos.x - cx, -(pos.y - cy)).toFloat()
-                    val maxAngle = (135f * PI / 180f).toFloat()
-                    val clamped = angle.coerceIn(-maxAngle, maxAngle)
-                    val newVal = (clamped / maxAngle).coerceIn(-1f, 1f)
-                    onValueChange(newVal)
-
-                    // Haptic tick at centre detent
-                    if (newVal in -0.05f..0.05f) {
-                        if (firedDetent.isEmpty()) {
-                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                            firedDetent.add(true)
-                        }
-                    } else {
-                        firedDetent.clear()
+            .adjustableSemantics(
+                label = "Pan",
+                value = value,
+                range = -1f..1f,
+                stateText = { v ->
+                    when {
+                        v < -0.02f -> "${(-v * 100).roundToInt()}% left"
+                        v > 0.02f -> "${(v * 100).roundToInt()}% right"
+                        else -> "Center"
                     }
-                }
+                },
+                onValueChange = onValueChange,
+            )
+            .pointerInput(Unit) {
+                // Delta-based vertical drag (up = right, down = left). The knob
+                // sits inside the horizontally-scrolling channel row; an
+                // omnidirectional detectDragGestures with absolute-angle mapping
+                // both stole the row's horizontal scroll and snapped the pan to
+                // wherever the finger first landed. Vertical-only relative drag
+                // fixes both — sideways swipes scroll the row, and the grab
+                // starts from the current value.
+                var startVal = 0f
+                var accumPx = 0f
+                detectVerticalDragGestures(
+                    onDragStart = {
+                        startVal = latestValue
+                        accumPx = 0f
+                    },
+                    onVerticalDrag = { change, dragAmount ->
+                        change.consume()
+                        accumPx += dragAmount
+                        // ~150px of travel spans the full -1..+1 range.
+                        val newVal = (startVal - accumPx / 150f).coerceIn(-1f, 1f)
+                        latestOnValueChange(newVal)
+
+                        // Haptic tick at centre detent
+                        if (newVal in -0.05f..0.05f) {
+                            if (firedDetent.isEmpty()) {
+                                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                firedDetent.add(true)
+                            }
+                        } else {
+                            firedDetent.clear()
+                        }
+                    }
+                )
             }
     ) {
         val cx = size.width / 2f

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/PluginEditorSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/PluginEditorSheet.kt
@@ -94,7 +94,8 @@ fun PluginEditorSheet(
                                 color = knobColor(paramIndex),
                                 onValueChange = { onParameterChange(busIndex, slotIndex, paramIndex, it) },
                                 modifier = Modifier.weight(1f),
-                                steps = def.steps
+                                steps = def.steps,
+                                default = def.default
                             )
                         } else {
                             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
@@ -1,12 +1,13 @@
 package tf.monochrome.android.ui.mixer
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -55,21 +56,45 @@ fun VerticalFader(
     val haptic      = LocalHapticFeedback.current
     val prevInDetent = remember { mutableSetOf<Boolean>() }
 
+    // The gesture coroutine is keyed on Unit, so read the live gain/callback
+    // through updated-state holders instead of capturing first-composition
+    // values (same pattern as FLKnob).
+    val latestGainDb by rememberUpdatedState(gainDb)
+    val latestOnGainChange by rememberUpdatedState(onGainChange)
+
     Canvas(
         modifier = modifier
             .fillMaxHeight()
             .pointerInput(Unit) {
-                detectDragGestures { change, _ ->
-                    change.consume()
-                    val db = yToDb(change.position.y, size.height.toFloat())
-                    onGainChange(db)
-                    hapticAtUnity(db, prevInDetent, haptic)
-                }
-            }
-            .pointerInput(Unit) {
-                detectTapGestures { offset ->
-                    onGainChange(yToDb(offset.y, size.height.toFloat()))
-                }
+                // Vertical-only, delta-based dragging. The fader is the
+                // largest touch area of each strip inside the mixer's
+                // horizontally scrolling channel row: an omnidirectional
+                // detectDragGestures stole horizontal swipes (the row never
+                // scrolled) and the old absolute-Y mapping slammed the live
+                // bus gain to wherever the finger landed (up to +24 dB).
+                // detectVerticalDragGestures only claims vertical motion, so
+                // sideways swipes scroll the row; moving from the cap's
+                // current position keeps grabs jump-free. Tap-to-set is gone
+                // for the same reason — a stray tap was an instant gain jump.
+                var dragStartDb = 0f
+                var dragAccumPx = 0f
+                detectVerticalDragGestures(
+                    onDragStart = {
+                        dragStartDb = latestGainDb
+                        dragAccumPx = 0f
+                    },
+                    onVerticalDrag = { change, dragAmount ->
+                        change.consume()
+                        dragAccumPx += dragAmount
+                        val h = size.height.toFloat()
+                        if (h > 0f) {
+                            val startY = dbToY(dragStartDb, h)
+                            val db = yToDb((startY + dragAccumPx).coerceIn(0f, h), h)
+                            latestOnGainChange(db)
+                            hapticAtUnity(db, prevInDetent, haptic)
+                        }
+                    }
+                )
             }
     ) {
         val w = size.width

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/VerticalFader.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
+import tf.monochrome.android.ui.components.adjustableSemantics
 import kotlin.math.absoluteValue
 
 /**
@@ -65,6 +66,13 @@ fun VerticalFader(
     Canvas(
         modifier = modifier
             .fillMaxHeight()
+            .adjustableSemantics(
+                label = "Gain fader",
+                value = gainDb,
+                range = -60f..24f,
+                stateText = { "%.1f dB".format(it) },
+                onValueChange = onGainChange,
+            )
             .pointerInput(Unit) {
                 // Vertical-only, delta-based dragging. The fader is the
                 // largest touch area of each strip inside the mixer's

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/fxchain/FxCard.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/fxchain/FxCard.kt
@@ -215,7 +215,8 @@ private fun KnobGrid(
                         color = accent,
                         onValueChange = { onParam(paramIndex, it) },
                         modifier = Modifier.weight(1f),
-                        steps = def.steps
+                        steps = def.steps,
+                        default = def.default
                     )
                 } else {
                     Spacer(modifier = Modifier.weight(1f))
@@ -247,7 +248,8 @@ private fun Eq10BandKnobs(
                 color = accent,
                 onValueChange = { onParam(0, it) },
                 modifier = Modifier.weight(1f),
-                steps = def.steps
+                steps = def.steps,
+                default = def.default
             )
             Spacer(modifier = Modifier.weight(3f))
         }
@@ -274,7 +276,8 @@ private fun Eq10BandKnobs(
                     color = accent,
                     onValueChange = { onParam(paramIndex, it) },
                     modifier = Modifier.weight(1f),
-                    steps = def.steps
+                    steps = def.steps,
+                    default = def.default
                 )
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/CatalogNav.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/CatalogNav.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.navigation
 
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import tf.monochrome.android.domain.model.SourceType
 
@@ -13,13 +14,25 @@ import tf.monochrome.android.domain.model.SourceType
  * no-ops — we never navigate to a dead route.
  */
 
+/**
+ * Navigate only while the current back-stack entry is still RESUMED. A rapid
+ * double-tap fires two navigate() calls before the first destination settles;
+ * the second used to push a duplicate screen. After the first navigation the
+ * current entry leaves RESUMED, so the second tap is ignored here.
+ */
+fun NavController.navigateSafe(route: String) {
+    if (currentBackStackEntry?.lifecycle?.currentState?.isAtLeast(Lifecycle.State.RESUMED) == true) {
+        navigate(route)
+    }
+}
+
 /** Open the artist page appropriate to [sourceType]. */
 fun NavController.openArtist(sourceType: SourceType, artistId: Long) {
     val route = when (sourceType) {
         SourceType.LOCAL -> Screen.LocalArtistDetail.createRoute(artistId)
         else -> Screen.ArtistDetail.createRoute(artistId)
     }
-    navigate(route)
+    navigateSafe(route)
 }
 
 /**
@@ -32,10 +45,10 @@ fun NavController.openAlbum(albumId: String?) {
     when {
         albumId.startsWith("local_album_") -> {
             albumId.removePrefix("local_album_").toLongOrNull()
-                ?.let { navigate(Screen.LocalAlbumDetail.createRoute(it)) }
+                ?.let { navigateSafe(Screen.LocalAlbumDetail.createRoute(it)) }
         }
         albumId.startsWith("col_album_") -> Unit // no collection detail screen
-        else -> albumId.toLongOrNull()?.let { navigate(Screen.AlbumDetail.createRoute(it)) }
+        else -> albumId.toLongOrNull()?.let { navigateSafe(Screen.AlbumDetail.createRoute(it)) }
     }
 }
 
@@ -56,10 +69,10 @@ fun isNavigableAlbumId(albumId: String?): Boolean {
 
 /** Catalog-only artist navigation (for domain `Track` rows, which are TIDAL/Qobuz). */
 fun NavController.openCatalogArtist(artistId: Long) {
-    navigate(Screen.ArtistDetail.createRoute(artistId))
+    navigateSafe(Screen.ArtistDetail.createRoute(artistId))
 }
 
 /** Catalog-only album navigation (for domain `Track` rows). */
 fun NavController.openCatalogAlbum(albumId: Long) {
-    navigate(Screen.AlbumDetail.createRoute(albumId))
+    navigateSafe(Screen.AlbumDetail.createRoute(albumId))
 }

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
@@ -213,6 +214,14 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                 }
             }
         }
+    }
+
+    // Back on a non-first main tab returns the pager to Home instead of popping
+    // the nav out from under it. Previously back on the Library tab popped the
+    // NavController to Home while the pager stayed on Library — visually nothing
+    // happened, and the next back exited the app with Library still on screen.
+    BackHandler(enabled = isOnMainTab && pagerState.currentPage != 0) {
+        scope.launch { pagerState.animateScrollToPage(0) }
     }
 
     val themeBackground = MaterialTheme.colorScheme.background

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -112,7 +112,11 @@ sealed class Screen(val route: String) {
     data object Stats : Screen("stats")
     data object ListeningStats : Screen("listening_stats")
     data object FolderBrowser : Screen("folder/{folderPath}") {
-        fun createRoute(folderPath: String) = "folder/${java.net.URLEncoder.encode(folderPath, "UTF-8")}"
+        // Uri.encode (not URLEncoder) so spaces become %20 not '+', and every
+        // reserved char (incl. '/' and '%') is percent-encoded. Navigation
+        // decodes the argument exactly once when it reaches the destination,
+        // so the read site must NOT decode again.
+        fun createRoute(folderPath: String) = "folder/${android.net.Uri.encode(folderPath)}"
     }
     data object LocalAlbumDetail : Screen("local_album/{albumId}") {
         fun createRoute(albumId: Long) = "local_album/$albumId"
@@ -121,7 +125,7 @@ sealed class Screen(val route: String) {
         fun createRoute(artistId: Long) = "local_artist/$artistId"
     }
     data object LocalGenreDetail : Screen("local_genre/{genre}") {
-        fun createRoute(genre: String) = "local_genre/${java.net.URLEncoder.encode(genre, "UTF-8")}"
+        fun createRoute(genre: String) = "local_genre/${android.net.Uri.encode(genre)}"
     }
     data object Mixer : Screen("mixer")
     data object CarMode : Screen("car_mode")
@@ -403,9 +407,10 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                     route = Screen.FolderBrowser.route,
                     arguments = listOf(navArgument("folderPath") { type = NavType.StringType })
                 ) { backStackEntry ->
-                    val folderPath = java.net.URLDecoder.decode(
-                        backStackEntry.arguments?.getString("folderPath") ?: "", "UTF-8"
-                    )
+                    // Navigation already URL-decoded this once; decoding again
+                    // (the old URLDecoder call) crashed on folders containing
+                    // '%' and turned '+' into a space, opening the wrong folder.
+                    val folderPath = backStackEntry.arguments?.getString("folderPath") ?: ""
                     tf.monochrome.android.devedit.DevEditScreen("folder_browser") {
                         FolderBrowserScreen(
                             folderPath = folderPath,

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -577,6 +577,7 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                 onCancel = downloadCenter::cancel,
                 onCancelAll = downloadCenter::cancelAll,
                 onDismiss = { showDownloadsMonitor = false },
+                onRetry = downloadCenter::retry,
             )
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/onboarding/OnboardingViewModel.kt
@@ -92,6 +92,19 @@ class OnboardingViewModel @Inject constructor(
                 roots.forEach { countTracks(it) }
             }
         }
+        // This ViewModel is Activity-scoped, so after the user finishes once its
+        // _step stays at DONE. "Restart onboarding" flips onboarding_complete
+        // back to false — reset to WELCOME on that transition so the wizard
+        // actually reopens at the start instead of the final "all set" step.
+        viewModelScope.launch {
+            var wasComplete: Boolean? = null
+            preferences.onboardingComplete.collect { complete ->
+                if (wasComplete == true && !complete) {
+                    _step.value = OnboardingStep.WELCOME
+                }
+                wasComplete = complete
+            }
+        }
     }
 
     // ── Step navigation ─────────────────────────────────────────────

--- a/app/src/main/java/tf/monochrome/android/ui/oxford/OxfordScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/oxford/OxfordScreen.kt
@@ -81,6 +81,13 @@ private fun OxfordFader(
     var dragOriginValue by remember { mutableStateOf(value) }
     var dragAccumPx by remember { mutableStateOf(0f) }
 
+    // The gesture coroutine is keyed on valueRange only, so its lambdas would
+    // otherwise capture the first-composition `value`/`onValueChange` — every
+    // drag after the first would seed from that stale origin and snap the
+    // fader back. Same updated-state fix as FLKnob.
+    val latestValue by rememberUpdatedState(value)
+    val latestOnValueChange by rememberUpdatedState(onValueChange)
+
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Canvas(
             modifier = Modifier
@@ -88,7 +95,7 @@ private fun OxfordFader(
                 .pointerInput(valueRange) {
                     detectDragGestures(
                         onDragStart = {
-                            dragOriginValue = value
+                            dragOriginValue = latestValue
                             dragAccumPx = 0f
                         },
                         onDrag = { change, drag ->
@@ -100,7 +107,7 @@ private fun OxfordFader(
                                 val delta = -(dragAccumPx / h) * span
                                 val next = (dragOriginValue + delta)
                                     .coerceIn(valueRange.start, valueRange.endInclusive)
-                                onValueChange(next)
+                                latestOnValueChange(next)
                             }
                         }
                     )

--- a/app/src/main/java/tf/monochrome/android/ui/oxford/OxfordScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/oxford/OxfordScreen.kt
@@ -179,18 +179,27 @@ private fun LedMeter(
 
     var heldL by remember { mutableStateOf(minDb) }
     var heldR by remember { mutableStateOf(minDb) }
-    var lastTick by remember { mutableStateOf(0L) }
 
     val dbL = if (peakL > 1e-6f) 20f * log10(peakL) else minDb
     val dbR = if (peakR > 1e-6f) 20f * log10(peakR) else minDb
+    // Read the latest levels inside the frame loop below without restarting it.
+    val latestDbL by rememberUpdatedState(dbL)
+    val latestDbR by rememberUpdatedState(dbR)
 
-    LaunchedEffect(dbL, dbR) {
-        val now = System.nanoTime()
-        val dtSec = if (lastTick == 0L) 0f else (now - lastTick) / 1_000_000_000f
-        lastTick = now
-        val decayDb = DECAY_DB_PER_SEC * dtSec
-        heldL = max(dbL, heldL - decayDb).coerceIn(minDb, maxDb + 3f)
-        heldR = max(dbR, heldR - decayDb).coerceIn(minDb, maxDb + 3f)
+    // Decay on every frame, not only when the level changes. Keying the old
+    // effect on (dbL, dbR) meant that once playback stopped and the levels went
+    // flat, the effect never ran again and the held peak stayed lit forever.
+    LaunchedEffect(Unit) {
+        var lastTick = 0L
+        while (true) {
+            withFrameNanos { now ->
+                val dtSec = if (lastTick == 0L) 0f else (now - lastTick) / 1_000_000_000f
+                lastTick = now
+                val decayDb = DECAY_DB_PER_SEC * dtSec
+                heldL = max(latestDbL, heldL - decayDb).coerceIn(minDb, maxDb + 3f)
+                heldR = max(latestDbR, heldR - decayDb).coerceIn(minDb, maxDb + 3f)
+            }
+        }
     }
 
     Canvas(modifier = modifier) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
@@ -122,7 +122,10 @@ private fun SyncedLyrics(
     // Find current line based on the Bluetooth-adjusted playback position.
     LaunchedEffect(position, syncDelayMs) {
         val newIndex = lines.indexOfLast { it.timeMs <= position - syncDelayMs }
-        if (newIndex != currentLineIndex && newIndex >= 0) {
+        // Allow -1 through: seeking back before the first lyric must clear the
+        // highlight, not leave the previous line lit. The auto-scroll effect
+        // already ignores negative indices.
+        if (newIndex != currentLineIndex) {
             currentLineIndex = newIndex
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LyricsSheet.kt
@@ -2,6 +2,7 @@ package tf.monochrome.android.ui.player
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -130,9 +132,22 @@ private fun SyncedLyrics(
         }
     }
 
-    // Auto-scroll to current line
+    // Track the last time the user dragged the list, so auto-scroll backs off
+    // while they're reading ahead instead of yanking the list to the current
+    // line on every timestamp change.
+    var lastUserScrollMs by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(listState.interactionSource) {
+        listState.interactionSource.interactions.collect { interaction ->
+            if (interaction is DragInteraction.Start) {
+                lastUserScrollMs = System.currentTimeMillis()
+            }
+        }
+    }
+
+    // Auto-scroll to current line, unless the user scrolled in the last few
+    // seconds.
     LaunchedEffect(currentLineIndex) {
-        if (currentLineIndex >= 0) {
+        if (currentLineIndex >= 0 && System.currentTimeMillis() - lastUserScrollMs > 4_000L) {
             listState.animateScrollToItem(
                 index = currentLineIndex,
                 scrollOffset = -200 // Offset to center the line

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -55,7 +54,6 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.NavController
-import kotlinx.coroutines.delay
 import tf.monochrome.android.domain.model.NowPlayingViewMode
 import tf.monochrome.android.domain.model.SourceType
 import tf.monochrome.android.ui.navigation.Screen
@@ -128,7 +126,10 @@ fun MainPlayerRoute(
     var showPresetSheet by rememberSaveable { mutableStateOf(false) }
     var showSpeedSheet by rememberSaveable { mutableStateOf(false) }
     var showSleepSheet by rememberSaveable { mutableStateOf(false) }
-    var sleepMinutes by rememberSaveable { mutableIntStateOf(0) }
+    // Sleep timer lives in PlayerViewModel (shared, nav-host-scoped) so the
+    // countdown keeps running when this destination leaves composition.
+    val sleepMinutes by playerViewModel.sleepTimerMinutes.collectAsState()
+    val sleepRemainingMs by playerViewModel.sleepTimerRemainingMs.collectAsState()
 
     // Expanded lyrics: the SAME hero lyric surface grows to full-bleed while
     // MainPlayerScreen collapses the player chrome — no separate overlay.
@@ -140,16 +141,6 @@ fun MainPlayerRoute(
         if (viewMode != NowPlayingViewMode.LYRICS || !lyricsSynced) lyricsExpanded = false
     }
     BackHandler(enabled = lyricsExpanded) { lyricsExpanded = false }
-
-    // Self-contained sleep timer: pause playback once the chosen interval
-    // elapses, then reset. Re-keys (and restarts) whenever the user changes it.
-    LaunchedEffect(sleepMinutes) {
-        if (sleepMinutes > 0) {
-            delay(sleepMinutes * 60_000L)
-            if (playerViewModel.isPlaying.value) playerViewModel.togglePlayPause()
-            sleepMinutes = 0
-        }
-    }
 
     LaunchedEffect(isPlaying) { playerViewModel.setVisualizerPlaybackPaused(!isPlaying) }
 
@@ -213,10 +204,12 @@ fun MainPlayerRoute(
             onDismiss = { showSpeedSheet = false },
         )
     }
+    val sleepRemainingMinutes = ((sleepRemainingMs + 59_999) / 60_000).toInt()
     if (showSleepSheet) {
         SleepTimerSheet(
             activeMinutes = sleepMinutes,
-            onSelect = { sleepMinutes = it },
+            remainingMinutes = sleepRemainingMinutes,
+            onSelect = { playerViewModel.setSleepTimer(it) },
             onDismiss = { showSleepSheet = false },
         )
     }
@@ -245,7 +238,8 @@ fun MainPlayerRoute(
         outputLabel = "Default",
         soundLabel = "AutoEQ",
         speedLabel = String.format(Locale.US, "%.2fx", playbackSpeed),
-        sleepTimerLabel = if (sleepMinutes > 0) "$sleepMinutes min" else "Off",
+        sleepTimerLabel = if (sleepMinutes > 0) "$sleepRemainingMinutes min" else "Off",
+        sleepTimerActive = sleepMinutes > 0,
         queueLabel = queueLabel,
         albumColors = AlbumColors(animatedDominant, albumColors.vibrant),
         visualizerActive = viewMode == NowPlayingViewMode.VISUALIZER,
@@ -628,6 +622,7 @@ private fun SpeedSheet(
 @Composable
 private fun SleepTimerSheet(
     activeMinutes: Int,
+    remainingMinutes: Int,
     onSelect: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -652,7 +647,7 @@ private fun SleepTimerSheet(
             }
             Text(
                 text = if (activeMinutes > 0) {
-                    "Playback will pause in $activeMinutes minutes."
+                    "Playback will pause in $remainingMinutes minute${if (remainingMinutes == 1) "" else "s"}."
                 } else {
                     "Sleep timer is off."
                 },

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -600,7 +600,9 @@ private fun SpeedSheet(
                     FilterChip(
                         selected = kotlin.math.abs(speed - preset) < 0.01f,
                         onClick = { onSpeedChange(preset) },
-                        label = { Text(String.format(Locale.US, "%.2gx", preset)) },
+                        // %.2g rendered 1.25 as "1.2"; use a trimmed decimal so
+                        // the chip label matches the value it actually sets.
+                        label = { Text(String.format(Locale.US, if (preset == preset.toInt().toFloat()) "%.1fx" else "%.2fx", preset)) },
                     )
                 }
             }
@@ -618,7 +620,7 @@ private fun SpeedSheet(
                             "Pitch shifts with speed (vinyl-style)"
                         },
                         style = MaterialTheme.typography.bodySmall,
-                        color = Color.White.copy(alpha = 0.6f),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Switch(
@@ -665,7 +667,7 @@ private fun SleepTimerSheet(
                     "Sleep timer is off."
                 },
                 style = MaterialTheme.typography.bodySmall,
-                color = Color.White.copy(alpha = 0.6f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -75,6 +75,7 @@ fun MainPlayerRoute(
     val queue by playerViewModel.queue.collectAsState()
     val currentIndex by playerViewModel.currentIndex.collectAsState()
     val isPlaying by playerViewModel.isPlaying.collectAsState()
+    val isBuffering by playerViewModel.isBuffering.collectAsState()
     val positionMs by playerViewModel.positionMs.collectAsState()
     val durationMs by playerViewModel.durationMs.collectAsState()
     val shuffleEnabled by playerViewModel.shuffleEnabled.collectAsState()
@@ -143,6 +144,17 @@ fun MainPlayerRoute(
     BackHandler(enabled = lyricsExpanded) { lyricsExpanded = false }
 
     LaunchedEffect(isPlaying) { playerViewModel.setVisualizerPlaybackPaused(!isPlaying) }
+
+    // Surface stream-resolution failures (offline / dead instance) that the
+    // ViewModel now reports instead of silently looping.
+    val playbackError by playerViewModel.playbackError.collectAsState()
+    val playbackErrorContext = androidx.compose.ui.platform.LocalContext.current
+    LaunchedEffect(playbackError) {
+        playbackError?.let {
+            android.widget.Toast.makeText(playbackErrorContext, it, android.widget.Toast.LENGTH_SHORT).show()
+            playerViewModel.clearPlaybackError()
+        }
+    }
 
     val lyricsFx by playerViewModel.lyricsFx.collectAsState()
     val playerGlass by playerViewModel.playerGlass.collectAsState()
@@ -226,6 +238,7 @@ fun MainPlayerRoute(
         channelBadge = currentUnified?.channelBadge ?: currentTrack?.channelBadge,
         isThxSpatialAudio = currentUnified?.isThxSpatialAudio ?: currentTrack?.isThxSpatialAudio ?: false,
         isPlaying = isPlaying,
+        isBuffering = isBuffering,
         positionMs = positionMs,
         durationMs = durationMs,
         progress = if (durationMs > 0) positionMs.toFloat() / durationMs.toFloat() else 0f,

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -114,9 +115,13 @@ fun MainPlayerRoute(
     val showNpSpectrum = spectrumAnalyzerEnabled && spectrumShowOnNowPlaying
 
     if (showNpSpectrum) {
-        DisposableEffect(Unit) {
+        // Tie the FFT tap to the STARTED lifecycle, not just composition, so it
+        // releases when the app is backgrounded (the Visualizer/Audio effect
+        // otherwise kept sampling and draining battery while off-screen) and
+        // re-acquires on return.
+        LifecycleStartEffect(Unit) {
             playerViewModel.acquireSpectrum()
-            onDispose { playerViewModel.releaseSpectrum() }
+            onStopOrDispose { playerViewModel.releaseSpectrum() }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -91,6 +91,7 @@ data class MainPlayerUiState(
     val channelBadge: String? = null,
     val isThxSpatialAudio: Boolean = false,
     val isPlaying: Boolean,
+    val isBuffering: Boolean = false,
     val positionMs: Long,
     val durationMs: Long,
     val progress: Float,
@@ -404,6 +405,7 @@ fun MainPlayerScreen(
                         onPrevious = onPrevious,
                         onPlayPause = onPlayPause,
                         onNext = onNext,
+                        isBuffering = state.isBuffering,
                     )
                 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -104,6 +104,7 @@ data class MainPlayerUiState(
     val soundLabel: String,
     val speedLabel: String,
     val sleepTimerLabel: String,
+    val sleepTimerActive: Boolean = false,
     val queueLabel: String,
     val albumColors: AlbumColors,
     val visualizerActive: Boolean,
@@ -411,6 +412,7 @@ fun MainPlayerScreen(
                     PlayerActionDock(
                         accent = accent,
                         lyricsActive = state.viewMode == NowPlayingViewMode.LYRICS,
+                        timerActive = state.sleepTimerActive,
                         onLyrics = onLyrics,
                         onTimer = onTimer,
                         onMixer = onMixer,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerActionDock.kt
@@ -59,6 +59,7 @@ private val DockItemVerticalPadding = 10.dp
 fun PlayerActionDock(
     accent: Color,
     lyricsActive: Boolean,
+    timerActive: Boolean,
     onLyrics: () -> Unit,
     onTimer: () -> Unit,
     onMixer: () -> Unit,
@@ -134,7 +135,7 @@ fun PlayerActionDock(
         // Transparent overlay: labels + tap targets, one weighted slot per hole.
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = DockRowVerticalPadding)) {
             DockLabel(Modifier.weight(1f), "Lyrics", icons[0], glassTint, lyricsActive, sources[0], onLyrics)
-            DockLabel(Modifier.weight(1f), "Timer", icons[1], glassTint, false, sources[1], onTimer)
+            DockLabel(Modifier.weight(1f), "Timer", icons[1], glassTint, timerActive, sources[1], onTimer)
             DockLabel(Modifier.weight(1f), "Mixer/FX", icons[2], glassTint, false, sources[2], onMixer)
             DockLabel(Modifier.weight(1f), "Playlist", icons[3], glassTint, false, sources[3], onPlaylist)
         }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerDesignTokens.kt
@@ -116,13 +116,19 @@ fun rememberAlbumColors(imageUrl: String?): AlbumColors {
 fun rememberDominantColor(imageUrl: String?): Color = rememberAlbumColors(imageUrl).dominant
 
 /** Vertical gradient wash derived from the album art, fading into pure black. */
-fun dynamicPlayerBackground(color: Color): Brush = Brush.verticalGradient(
-    colors = listOf(
-        color.copy(alpha = 0.5f),
-        color.copy(alpha = 0.2f),
-        PlayerDesignTokens.BackgroundBlack
+fun dynamicPlayerBackground(color: Color): Brush {
+    // Darken the album color before the top stop so the hardcoded-white player
+    // chrome (chevron, output/speed chips) keeps adequate contrast even on a
+    // bright cover, instead of washing out to ~3:1 white-on-light.
+    val wash = androidx.compose.ui.graphics.lerp(color, Color.Black, 0.5f)
+    return Brush.verticalGradient(
+        colors = listOf(
+            wash.copy(alpha = 0.5f),
+            wash.copy(alpha = 0.2f),
+            PlayerDesignTokens.BackgroundBlack
+        )
     )
-)
+}
 
 /** Soft radial glow behind the hero, tinted by the current album color. */
 @Composable

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -623,12 +624,14 @@ private fun HeroCoverArt(
             ) {
                 HeroIconButton(
                     icon = if (spectrumEnabled) Icons.Default.Equalizer else Icons.Default.Album,
+                    contentDescription = if (spectrumEnabled) "Show album art" else "Show spectrum",
                     enabled = interactive,
                     onClick = { onToggleShowSpectrum(); showControls() },
                 )
                 if (spectrumEnabled) {
                     HeroIconButton(
                         icon = Icons.Default.Speed,
+                        contentDescription = "Spectrum speed",
                         enabled = interactive,
                         onClick = { spectrumSpeed = spectrumSpeed.next(); showControls() },
                     )
@@ -663,6 +666,7 @@ private fun HeroCoverArt(
                 HeroIconButton(
                     modifier = Modifier.align(Alignment.BottomEnd).padding(10.dp),
                     icon = Icons.Default.GraphicEq,
+                    contentDescription = "Open visualizer",
                     enabled = interactive,
                     onClick = { onEnterVisualizer(); showControls() },
                 )
@@ -675,12 +679,16 @@ private fun HeroCoverArt(
 @Composable
 private fun HeroIconButton(
     icon: ImageVector,
+    contentDescription: String,
     enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
         modifier = modifier
+            // 32dp glass disc, but reserve the 48dp accessibility minimum so
+            // the icon-only overlay control is actually hittable.
+            .minimumInteractiveComponentSize()
             .size(32.dp)
             .clip(CircleShape)
             .clickable(enabled = enabled, onClick = onClick)
@@ -690,7 +698,7 @@ private fun HeroIconButton(
         contentColor = Color.White,
     ) {
         Box(contentAlignment = Alignment.Center) {
-            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(16.dp))
+            Icon(imageVector = icon, contentDescription = contentDescription, modifier = Modifier.size(16.dp))
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.player
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Spring
@@ -298,6 +299,10 @@ private fun VisualizerHero(
             showOverlay = false
         }
     }
+    // In fullscreen the system bars are hidden and the exit button lives in
+    // the auto-hiding overlay — without this, Back pops the whole player and
+    // (fullscreen being a persisted pref) reopening lands right back here.
+    BackHandler(enabled = isFullscreen) { onToggleFullscreen() }
     Surface(
         // Outside fullscreen the visualizer is locked to the album-art aspect
         // ratio so its dimensions match the cover artwork exactly.

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerHero.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -292,12 +293,14 @@ private fun VisualizerHero(
     onToggleShowSpectrum: () -> Unit,
     onExitVisualizer: () -> Unit,
 ) {
+    // Keyed on an interaction counter so each tap restarts the 2s countdown
+    // (a tap just before the deadline used to give a near-zero window).
     var showOverlay by remember { mutableStateOf(true) }
-    LaunchedEffect(showOverlay) {
-        if (showOverlay) {
-            delay(2000)
-            showOverlay = false
-        }
+    var overlayInteraction by remember { mutableIntStateOf(0) }
+    LaunchedEffect(overlayInteraction) {
+        showOverlay = true
+        delay(2000)
+        showOverlay = false
     }
     // In fullscreen the system bars are hidden and the exit button lives in
     // the auto-hiding overlay — without this, Back pops the whole player and
@@ -318,7 +321,7 @@ private fun VisualizerHero(
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
-                    onClick = { showOverlay = true },
+                    onClick = { overlayInteraction++ },
                 )
         ) {
             if (visualizerCompact) {
@@ -550,12 +553,16 @@ private fun HeroCoverArt(
 
     // Controls show briefly on tap, then disappear quickly. When idle there are
     // no tags/labels on the art at all — the buttons are small and icon-only.
+    // Keyed on an interaction counter (bumped by showControls()) so every tap
+    // RESTARTS the 1.2s countdown — controls used to fade 1.2s after first
+    // appearing even while the user was actively cycling a button.
     var controlsVisible by remember { mutableStateOf(true) }
-    LaunchedEffect(controlsVisible) {
-        if (controlsVisible) {
-            delay(1200)
-            controlsVisible = false
-        }
+    var controlsInteraction by remember { mutableIntStateOf(0) }
+    val showControls = { controlsInteraction++ }
+    LaunchedEffect(controlsInteraction) {
+        controlsVisible = true
+        delay(1200)
+        controlsVisible = false
     }
     val controlsAlpha by animateFloatAsState(
         targetValue = if (controlsVisible) 1f else 0f,
@@ -570,7 +577,7 @@ private fun HeroCoverArt(
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
-            ) { controlsVisible = true }
+            ) { showControls() }
     ) {
         CoverImage(
             url = track?.coverUrl,
@@ -617,13 +624,13 @@ private fun HeroCoverArt(
                 HeroIconButton(
                     icon = if (spectrumEnabled) Icons.Default.Equalizer else Icons.Default.Album,
                     enabled = interactive,
-                    onClick = { onToggleShowSpectrum(); controlsVisible = true },
+                    onClick = { onToggleShowSpectrum(); showControls() },
                 )
                 if (spectrumEnabled) {
                     HeroIconButton(
                         icon = Icons.Default.Speed,
                         enabled = interactive,
-                        onClick = { spectrumSpeed = spectrumSpeed.next(); controlsVisible = true },
+                        onClick = { spectrumSpeed = spectrumSpeed.next(); showControls() },
                     )
                 }
             }
@@ -657,7 +664,7 @@ private fun HeroCoverArt(
                     modifier = Modifier.align(Alignment.BottomEnd).padding(10.dp),
                     icon = Icons.Default.GraphicEq,
                     enabled = interactive,
-                    onClick = { onEnterVisualizer(); controlsVisible = true },
+                    onClick = { onEnterVisualizer(); showControls() },
                 )
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
@@ -151,7 +151,10 @@ internal fun GlassProgressTube(
                         onSeek(f)
                     },
                     onDragEnd = { dragging = false; onSeekFinished(seekTarget) },
-                    onDragCancel = { dragging = false },
+                    // Commit on cancel too — otherwise the parent stayed in
+                    // seek mode and the bar/time froze at the last finger
+                    // position until the next seek.
+                    onDragCancel = { dragging = false; onSeekFinished(seekTarget) },
                     onHorizontalDrag = { change, _ ->
                         val f = (change.position.x / size.width).coerceIn(0f, 1f)
                         seekTarget = f
@@ -211,6 +214,9 @@ private fun PlainSlider(
 ) {
     val interaction = remember { MutableInteractionSource() }
     val dragged by interaction.collectIsDraggedAsState()
+    // Hold the live drag value: onValueChangeFinished(fraction) committed the
+    // composition-captured (stale) fraction, so a tap-to-seek snapped back.
+    var latestSeek by remember { mutableFloatStateOf(fraction) }
     val thumbSize by animateDpAsState(
         targetValue = if (dragged) 18.dp else PlayerDesignTokens.ProgressThumbSize,
         label = "progressThumb",
@@ -222,8 +228,8 @@ private fun PlainSlider(
     )
     Slider(
         value = fraction.coerceIn(0f, 1f),
-        onValueChange = onSeek,
-        onValueChangeFinished = { onSeekFinished(fraction) },
+        onValueChange = { latestSeek = it; onSeek(it) },
+        onValueChangeFinished = { onSeekFinished(latestSeek) },
         modifier = Modifier.fillMaxWidth(),
         interactionSource = interaction,
         colors = colors,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerProgress.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import tf.monochrome.android.ui.components.adjustableSemantics
+import kotlin.math.roundToInt
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.cos
@@ -135,6 +137,13 @@ internal fun GlassProgressTube(
         modifier = modifier
             .fillMaxWidth()
             .height(34.dp)
+            .adjustableSemantics(
+                label = "Seek",
+                value = frac,
+                range = 0f..1f,
+                stateText = { "${(it * 100).roundToInt()}%" },
+                onValueChange = { onSeek(it); onSeekFinished(it) },
+            )
             .pointerInput(Unit) {
                 detectTapGestures { pos ->
                     val f = (pos.x / size.width).coerceIn(0f, 1f)

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -57,6 +57,7 @@ fun PlayerTransportControls(
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
     modifier: Modifier = Modifier,
+    isBuffering: Boolean = false,
 ) {
     val glass = LocalPlayerGlass.current
     // Button glass tint: a custom colour chosen in the Studio, or the album
@@ -132,6 +133,15 @@ fun PlayerTransportControls(
                 ) {
                     drawGlassPlayPauseDisc(isPlaying = isPlaying, fill = tint)
                 }
+            }
+            // Buffering ring: without this the play glyph stays static while a
+            // stream loads, so the tap looks dead in a streaming-first app.
+            if (isBuffering) {
+                androidx.compose.material3.CircularProgressIndicator(
+                    modifier = Modifier.fillMaxSize(),
+                    color = tint,
+                    strokeWidth = 2.dp,
+                )
             }
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerTransportControls.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import tf.monochrome.android.R
+import tf.monochrome.android.ui.components.buttonSemantics
 
 /**
  * Primary transport row: previous · play/pause · next. The icons are solid glyph
@@ -119,6 +120,10 @@ fun PlayerTransportControls(
                         interactionSource = interactionSource,
                         indication = null,
                         onClick = onPlayPause,
+                    )
+                    .buttonSemantics(
+                        label = if (isPlaying) "Pause" else "Play",
+                        state = if (isBuffering) "Buffering" else null,
                     ),
                 contentAlignment = Alignment.Center,
             ) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -553,11 +553,27 @@ class PlayerViewModel @Inject constructor(
     }
 
     fun removeFromQueue(index: Int) {
+        val wasCurrent = index == queueManager.currentQueueIndex
         queueManager.removeFromQueue(index)
+        // Deleting the playing track slid the next one into its slot, but the
+        // player is still on the old audio — resolve & play the new current so
+        // the UI and audio don't desync (or stop if the queue drained).
+        if (wasCurrent) {
+            if (queueManager.currentTrack.value != null) resolveAndPlay()
+            else mediaController?.stop()
+        }
     }
 
     fun removeSelectedFromQueue(indices: Set<Int>) {
+        val playingId = queueManager.currentTrack.value?.id
         queueManager.removeMany(indices)
+        // If the track that was playing got removed, re-sync the player to the
+        // new current track (removeMany keeps the current track when it survives,
+        // so this only fires when it was actually deleted).
+        if (queueManager.currentTrack.value?.id != playingId) {
+            if (queueManager.currentTrack.value != null) resolveAndPlay()
+            else mediaController?.stop()
+        }
     }
 
     fun moveQueueItem(fromIndex: Int, toIndex: Int) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
@@ -309,27 +310,36 @@ class PlayerViewModel @Inject constructor(
                         // Start fetching lyrics
                         _isLyricsLoading.value = true
                         _currentLyrics.value = null
-                        
-                        launch {
-                            // Qobuz tracks must skip the TIDAL /lyrics lookup —
-                            // a Qobuz id on TIDAL resolves to a different song,
-                            // so its (synced) lyrics would never match. The
-                            // resolved source is the authoritative signal;
-                            // qobuzIdRegistry is a backstop.
-                            val skipTidal = unifiedTrackRegistry[track.id]?.sourceType ==
-                                tf.monochrome.android.domain.model.SourceType.QOBUZ ||
-                                qobuzIdRegistry.isQobuzTrack(track.id)
-                            // Pass the full Track so the repository can fall
-                            // back to LRCLib (track + artist + album +
-                            // duration) when TIDAL returns no lyrics.
-                            _currentLyrics.value =
-                                repository.getLyrics(track.id, track, skipTidal = skipTidal).getOrNull()
-                            _isLyricsLoading.value = false
-                        }
 
-                        // Observe liked status
-                        libraryRepository.isFavoriteTrack(track.id).collectLatest { isLiked ->
-                            _isCurrentTrackLiked.value = isLiked
+                        // coroutineScope so BOTH children are children of this
+                        // collectLatest emission — a track change cancels the
+                        // in-flight lyrics fetch too. Previously the lyrics
+                        // `launch` bound to the outer viewModelScope coroutine
+                        // and survived, so a slow fetch for a skipped track
+                        // could overwrite the current track's lyrics.
+                        coroutineScope {
+                            launch {
+                                // Qobuz tracks must skip the TIDAL /lyrics lookup —
+                                // a Qobuz id on TIDAL resolves to a different song,
+                                // so its (synced) lyrics would never match. The
+                                // resolved source is the authoritative signal;
+                                // qobuzIdRegistry is a backstop.
+                                val skipTidal = unifiedTrackRegistry[track.id]?.sourceType ==
+                                    tf.monochrome.android.domain.model.SourceType.QOBUZ ||
+                                    qobuzIdRegistry.isQobuzTrack(track.id)
+                                // Pass the full Track so the repository can fall
+                                // back to LRCLib (track + artist + album +
+                                // duration) when TIDAL returns no lyrics.
+                                _currentLyrics.value =
+                                    repository.getLyrics(track.id, track, skipTidal = skipTidal).getOrNull()
+                                _isLyricsLoading.value = false
+                            }
+                            // Observe liked status
+                            launch {
+                                libraryRepository.isFavoriteTrack(track.id).collectLatest { isLiked ->
+                                    _isCurrentTrackLiked.value = isLiked
+                                }
+                            }
                         }
                     } else {
                         _currentLyrics.value = null

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -11,6 +11,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -93,6 +94,47 @@ class PlayerViewModel @Inject constructor(
     // --- Player state (observed from MediaController) ---
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+
+    // --- Sleep timer ---
+    // Owned here (this ViewModel is created at the nav-host level and shared,
+    // so it outlives the player destination) rather than in a LaunchedEffect
+    // on the player screen: the effect died with the composable, silently
+    // discarding the timer whenever the user collapsed the player or opened
+    // another screen — playback then never paused.
+    private val _sleepTimerMinutes = MutableStateFlow(0)
+    val sleepTimerMinutes: StateFlow<Int> = _sleepTimerMinutes.asStateFlow()
+
+    private val _sleepTimerRemainingMs = MutableStateFlow(0L)
+    val sleepTimerRemainingMs: StateFlow<Long> = _sleepTimerRemainingMs.asStateFlow()
+
+    private var sleepTimerJob: Job? = null
+
+    /**
+     * Arm the sleep timer for [minutes] (restarting if already armed, so
+     * re-selecting the same duration begins a fresh countdown), or cancel
+     * with 0. Pauses playback when the countdown reaches zero.
+     */
+    fun setSleepTimer(minutes: Int) {
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        val m = minutes.coerceAtLeast(0)
+        _sleepTimerMinutes.value = m
+        _sleepTimerRemainingMs.value = m * 60_000L
+        if (m == 0) return
+        sleepTimerJob = viewModelScope.launch {
+            val endAt = System.currentTimeMillis() + m * 60_000L
+            while (true) {
+                val left = endAt - System.currentTimeMillis()
+                if (left <= 0) break
+                _sleepTimerRemainingMs.value = left
+                delay(minOf(1_000L, left))
+            }
+            if (_isPlaying.value) togglePlayPause()
+            _sleepTimerMinutes.value = 0
+            _sleepTimerRemainingMs.value = 0L
+            sleepTimerJob = null
+        }
+    }
 
     private val _positionMs = MutableStateFlow(0L)
     val positionMs: StateFlow<Long> = _positionMs.asStateFlow()

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -151,6 +151,14 @@ class PlayerViewModel @Inject constructor(
     private val _isBuffering = MutableStateFlow(false)
     val isBuffering: StateFlow<Boolean> = _isBuffering.asStateFlow()
 
+    // Surfaced to the player UI when a track can't be resolved/streamed. Also
+    // used to break the resolve→fail→skip→resolve loop that otherwise ran
+    // forever under repeat modes (offline / dead instance).
+    private val _playbackError = MutableStateFlow<String?>(null)
+    val playbackError: StateFlow<String?> = _playbackError.asStateFlow()
+    private var consecutiveResolveFailures = 0
+    fun clearPlaybackError() { _playbackError.value = null }
+
     // --- Active Track Meta (Lyrics / Liked) ---
     private val _isCurrentTrackLiked = MutableStateFlow(false)
     val isCurrentTrackLiked: StateFlow<Boolean> = _isCurrentTrackLiked.asStateFlow()
@@ -754,7 +762,7 @@ class PlayerViewModel @Inject constructor(
                     unifiedTrackRegistry.put(track.id, unifiedTrack)
                     val resolved = streamResolver.resolveUnifiedTrack(unifiedTrack)
                     if (!resolved.isPlayable) {
-                        skipToNext()
+                        handleResolveFailure()
                         return@launch
                     }
                     mediaController?.let { mc ->
@@ -762,11 +770,12 @@ class PlayerViewModel @Inject constructor(
                         mc.prepare()
                         mc.play()
                     }
+                    onResolveSucceeded()
                 } else {
                     // Legacy API path
                     val (mediaItem, _) = streamResolver.resolveMediaItem(track)
                     if (mediaItem == null) {
-                        skipToNext()
+                        handleResolveFailure()
                         return@launch
                     }
                     mediaController?.let { mc ->
@@ -774,12 +783,39 @@ class PlayerViewModel @Inject constructor(
                         mc.prepare()
                         mc.play()
                     }
+                    onResolveSucceeded()
                 }
             } catch (_: Exception) {
-                // On error skip to next
-                skipToNext()
+                handleResolveFailure()
             }
         }
+    }
+
+    private fun onResolveSucceeded() {
+        consecutiveResolveFailures = 0
+        _playbackError.value = null
+    }
+
+    /**
+     * A track failed to resolve/stream. Advance to the next track, but stop —
+     * and surface an error — rather than looping forever: never auto-skip
+     * under RepeatMode.ONE, and bail once a full queue's worth of tracks have
+     * failed in a row (offline / dead streaming instance).
+     */
+    private fun handleResolveFailure() {
+        consecutiveResolveFailures++
+        val queueSize = queueManager.queue.value.size.coerceAtLeast(1)
+        if (repeatMode.value == RepeatMode.ONE) {
+            _playbackError.value = "Couldn't play this track."
+            consecutiveResolveFailures = 0
+            return
+        }
+        if (consecutiveResolveFailures >= queueSize) {
+            _playbackError.value = "Couldn't play these tracks. Check your connection."
+            consecutiveResolveFailures = 0
+            return
+        }
+        skipToNext()
     }
 
     /**

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -946,9 +946,17 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    fun createPlaylist(name: String, description: String? = null) {
+    fun createPlaylist(
+        name: String,
+        description: String? = null,
+        initialTracks: List<Track> = emptyList(),
+    ) {
         viewModelScope.launch {
-            libraryRepository.createPlaylist(name, description)
+            // Use the id the repository returns so tracks stashed from an
+            // "Add to playlist → New Playlist" flow actually land in the new
+            // playlist instead of being silently dropped.
+            val id = libraryRepository.createPlaylist(name, description)
+            initialTracks.forEach { libraryRepository.addTrackToPlaylist(id, it) }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/player/QueueSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/QueueSheet.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DragHandle
@@ -44,7 +47,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -52,9 +54,31 @@ import androidx.compose.ui.zIndex
 import tf.monochrome.android.domain.model.Track
 import tf.monochrome.android.ui.components.CoverImage
 import tf.monochrome.android.ui.theme.MonoDimens
-import kotlin.math.roundToInt
+import kotlin.math.abs
 
 private val QueueRowHeight = 64.dp
+
+/**
+ * Maps an in-progress reorder drag to a drop index using the list's real
+ * laid-out item geometry. The old math divided the accumulated pixel offset by
+ * a fixed row height, which landed a slot off wherever rows weren't uniform (the
+ * taller now-playing row and its section labels). Picking the item whose centre
+ * is nearest the dragged row's projected centre is height-agnostic.
+ */
+private fun dropTargetIndex(
+    listState: LazyListState,
+    fromIndex: Int,
+    dragOffsetY: Float,
+    lastIndex: Int,
+): Int {
+    val info = listState.layoutInfo
+    val dragged = info.visibleItemsInfo.firstOrNull { it.index == fromIndex } ?: return fromIndex
+    val draggedCenter = dragged.offset + dragged.size / 2f + dragOffsetY
+    val target = info.visibleItemsInfo.minByOrNull {
+        abs((it.offset + it.size / 2f) - draggedCenter)
+    }?.index ?: fromIndex
+    return target.coerceIn(0, lastIndex)
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -80,7 +104,20 @@ fun QueueSheet(
     // gesture, which keeps the pointerInput lambda alive for its duration.
     var draggingIndex by remember { mutableStateOf<Int?>(null) }
     var dragOffsetY by remember { mutableStateOf(0f) }
-    val rowHeightPx = with(LocalDensity.current) { QueueRowHeight.toPx() }
+    val listState = rememberLazyListState()
+
+    // Stable per-row keys so reorder/delete/radio-append animate the right rows
+    // and don't scramble per-row state. A queue can hold the same track twice,
+    // and LazyColumn keys must be unique, so duplicate ids get an occurrence
+    // suffix; the common (no-duplicate) case keys straight by track id.
+    val itemKeys = remember(queue) {
+        val counts = HashMap<Long, Int>()
+        queue.map { track ->
+            val n = counts[track.id] ?: 0
+            counts[track.id] = n + 1
+            if (n == 0) track.id.toString() else "${track.id}#$n"
+        }
+    }
 
     fun exitSelection() {
         selectionMode = false
@@ -202,101 +239,112 @@ fun QueueSheet(
                     modifier = Modifier.padding(24.dp)
                 )
             } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    // Now Playing header
-                    if (currentTrack != null) {
-                        item {
-                            Text(
-                                text = "Now Playing",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(bottom = 8.dp)
-                            )
-                        }
-                    }
-
-                    itemsIndexed(queue) { index, track ->
+                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                    itemsIndexed(queue, key = { index, _ -> itemKeys[index] }) { index, track ->
                         val isCurrent = index == currentIndex
                         val isDragging = index == draggingIndex
 
-                        Box(
-                            modifier = Modifier
-                                .zIndex(if (isDragging) 1f else 0f)
-                                .graphicsLayer {
-                                    translationY = if (isDragging) dragOffsetY else 0f
-                                }
-                        ) {
-                            QueueTrackItem(
-                                track = track,
-                                isCurrentTrack = isCurrent,
-                                selectionMode = selectionMode,
-                                isSelected = index in selectedIndices,
-                                isDragging = isDragging,
-                                onClick = {
-                                    if (selectionMode) {
-                                        selectedIndices =
-                                            if (index in selectedIndices) selectedIndices - index
-                                            else selectedIndices + index
-                                        if (selectedIndices.isEmpty()) selectionMode = false
-                                    } else {
-                                        playerViewModel.skipToQueueIndex(index)
+                        // One Column per row so the "Now Playing" / "Up Next"
+                        // labels stack with the row instead of overlapping it.
+                        Column {
+                            // "Now Playing" sits directly above the actual current
+                            // track — it used to be a fixed header pinned to the
+                            // top of the list, which was wrong whenever the current
+                            // track wasn't the first one.
+                            if (isCurrent) {
+                                Text(
+                                    text = "Now Playing",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(bottom = 8.dp)
+                                )
+                            }
+
+                            Box(
+                                modifier = Modifier
+                                    .zIndex(if (isDragging) 1f else 0f)
+                                    .graphicsLayer {
+                                        translationY = if (isDragging) dragOffsetY else 0f
                                     }
-                                },
-                                onLongClick = {
-                                    if (!selectionMode) menuIndex = index
-                                },
-                                dragHandleModifier = Modifier.pointerInput(index) {
-                                    detectDragGesturesAfterLongPress(
-                                        onDragStart = {
-                                            draggingIndex = index
-                                            dragOffsetY = 0f
-                                        },
-                                        onDragEnd = {
-                                            val from = draggingIndex
-                                            if (from != null) {
-                                                val target = (from + (dragOffsetY / rowHeightPx).roundToInt())
-                                                    .coerceIn(0, queue.lastIndex)
-                                                if (target != from) {
-                                                    playerViewModel.moveQueueItem(from, target)
-                                                }
-                                            }
-                                            draggingIndex = null
-                                            dragOffsetY = 0f
-                                        },
-                                        onDragCancel = {
-                                            draggingIndex = null
-                                            dragOffsetY = 0f
-                                        },
-                                        onDrag = { change, dragAmount ->
-                                            change.consume()
-                                            dragOffsetY += dragAmount.y
+                            ) {
+                                QueueTrackItem(
+                                    track = track,
+                                    isCurrentTrack = isCurrent,
+                                    selectionMode = selectionMode,
+                                    isSelected = index in selectedIndices,
+                                    isDragging = isDragging,
+                                    onClick = {
+                                        if (selectionMode) {
+                                            selectedIndices =
+                                                if (index in selectedIndices) selectedIndices - index
+                                                else selectedIndices + index
+                                            if (selectedIndices.isEmpty()) selectionMode = false
+                                        } else {
+                                            playerViewModel.skipToQueueIndex(index)
                                         }
-                                    )
-                                }
-                            )
+                                    },
+                                    onLongClick = {
+                                        // A long-press that started a reorder drag
+                                        // must not also pop the context menu.
+                                        if (!selectionMode && draggingIndex == null) menuIndex = index
+                                    },
+                                    dragHandleModifier = Modifier.pointerInput(index) {
+                                        detectDragGesturesAfterLongPress(
+                                            onDragStart = {
+                                                draggingIndex = index
+                                                dragOffsetY = 0f
+                                                // Close any menu the row's own
+                                                // long-press may have just opened.
+                                                menuIndex = null
+                                            },
+                                            onDragEnd = {
+                                                val from = draggingIndex
+                                                if (from != null) {
+                                                    val target = dropTargetIndex(
+                                                        listState, from, dragOffsetY, queue.lastIndex
+                                                    )
+                                                    if (target != from) {
+                                                        playerViewModel.moveQueueItem(from, target)
+                                                    }
+                                                }
+                                                draggingIndex = null
+                                                dragOffsetY = 0f
+                                            },
+                                            onDragCancel = {
+                                                draggingIndex = null
+                                                dragOffsetY = 0f
+                                            },
+                                            onDrag = { change, dragAmount ->
+                                                change.consume()
+                                                dragOffsetY += dragAmount.y
+                                            }
+                                        )
+                                    }
+                                )
 
-                            QueueTrackMenu(
-                                expanded = menuIndex == index,
-                                onDismiss = { menuIndex = null },
-                                onPlayNext = { playerViewModel.playQueueItemNext(index) },
-                                onStartRadio = { playerViewModel.startRadioFrom(track) },
-                                onSelect = {
-                                    selectionMode = true
-                                    selectedIndices = setOf(index)
-                                },
-                                onDelete = { playerViewModel.removeFromQueue(index) }
-                            )
-                        }
+                                QueueTrackMenu(
+                                    expanded = menuIndex == index,
+                                    onDismiss = { menuIndex = null },
+                                    onPlayNext = { playerViewModel.playQueueItemNext(index) },
+                                    onStartRadio = { playerViewModel.startRadioFrom(track) },
+                                    onSelect = {
+                                        selectionMode = true
+                                        selectedIndices = setOf(index)
+                                    },
+                                    onDelete = { playerViewModel.removeFromQueue(index) }
+                                )
+                            }
 
-                        // Divider after current track
-                        if (isCurrent && index < queue.size - 1) {
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = "Up Next",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(vertical = 8.dp)
-                            )
+                            // Divider after the current track.
+                            if (isCurrent && index < queue.size - 1) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = "Up Next",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(vertical = 8.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -390,7 +438,10 @@ private fun QueueTrackItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(QueueRowHeight)
+            // heightIn(min=) rather than a fixed height so the two text lines
+            // aren't clipped at large font scale; the drop-target math reads
+            // real laid-out geometry, so a taller row no longer misplaces drops.
+            .heightIn(min = QueueRowHeight)
             .graphicsLayer { alpha = if (isDragging) 0.85f else 1f }
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             .padding(vertical = 8.dp),

--- a/app/src/main/java/tf/monochrome/android/ui/player/QueueSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/QueueSheet.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -456,7 +457,10 @@ private fun QueueTrackItem(
             imageVector = Icons.Default.DragHandle,
             contentDescription = "Reorder",
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            // 24dp glyph, but the drag pointer node wraps the 48dp minimum
+            // touch target — this is the sheet's only reorder affordance.
             modifier = dragHandleModifier
+                .minimumInteractiveComponentSize()
                 .padding(start = 12.dp)
                 .size(24.dp)
         )

--- a/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableIntStateOf
@@ -76,7 +77,11 @@ fun VisualizerComponent(
     repository: ProjectMEngineRepository? = null
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "projectm-shell")
-    val travel by infiniteTransition.animateFloat(
+    // Kept as State (no `by`) and passed down as State so the per-frame value is
+    // read inside the child Canvas draw scopes. Reading it here in composition
+    // recomposed the whole visualizer — including the ProjectM AndroidView —
+    // every single frame.
+    val travel = infiniteTransition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
         animationSpec = infiniteRepeatable(
@@ -88,7 +93,7 @@ fun VisualizerComponent(
         ),
         label = "travel"
     )
-    val pulse by infiniteTransition.animateFloat(
+    val pulse = infiniteTransition.animateFloat(
         initialValue = 0.88f,
         targetValue = 1.12f,
         animationSpec = infiniteRepeatable(
@@ -194,13 +199,15 @@ fun VisualizerComponent(
 
 @Composable
 private fun AmbientGlowLayer(
-    travel: Float,
-    pulse: Float,
+    travel: State<Float>,
+    pulse: State<Float>,
     alpha: Float
 ) {
     Canvas(modifier = Modifier.fillMaxSize()) {
         val w = size.width
         val h = size.height
+        val travel = travel.value
+        val pulse = pulse.value
 
         drawCircle(
             brush = Brush.radialGradient(
@@ -251,10 +258,12 @@ private fun SpectrumWaveLayer(
     isPlaying: Boolean,
     intensity: Float,
     alpha: Float,
-    travel: Float
+    travel: State<Float>
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "spectrum-lines")
-    val phase by infiniteTransition.animateFloat(
+    // State (no `by`), read in the draw scope below so the per-frame phase +
+    // travel animate via redraw instead of recomposing this layer each frame.
+    val phase = infiniteTransition.animateFloat(
         initialValue = 0f,
         targetValue = (2f * PI).toFloat(),
         animationSpec = infiniteRepeatable(
@@ -268,6 +277,8 @@ private fun SpectrumWaveLayer(
     )
 
     Canvas(modifier = Modifier.fillMaxSize()) {
+        val phase = phase.value
+        val travel = travel.value
         val width = size.width
         val height = size.height
         val centerY = height * 0.56f
@@ -403,7 +414,7 @@ private fun ProjectMStatusOverlay(
 private fun TouchWaveformOverlay(
     audioBus: ProjectMAudioBus,
     alpha: Float,
-    travel: Float,
+    travel: State<Float>,
     modifier: Modifier = Modifier
 ) {
     val touchPoints = remember { mutableStateMapOf<Long, Offset>() }
@@ -442,9 +453,10 @@ private fun TouchWaveformOverlay(
                 }
             }
     ) {
-        // Read travel to force continuous redraws while fingers are down
+        // Read travel (in the draw scope) to force continuous redraws while
+        // fingers are down, without recomposing the overlay each frame.
         @Suppress("UNUSED_EXPRESSION")
-        travel
+        travel.value
 
         if (touchPoints.isEmpty()) return@Canvas
         val samples = audioBus.peekSamples() ?: return@Canvas

--- a/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/VisualizerComponent.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -424,7 +425,16 @@ private fun TouchWaveformOverlay(
                             if (change.pressed) {
                                 active[change.id.value] = change.position
                             }
-                            change.consume()
+                            // Consume only movement while drawing. Consuming
+                            // down/up too made every tap invisible to the
+                            // hero's tap-to-show-controls clickable, so once
+                            // the overlay auto-hid the user could never bring
+                            // the visualizer controls (incl. exit-fullscreen)
+                            // back. Moves stay consumed so drawing waveforms
+                            // doesn't scroll/drag any ancestor.
+                            if (change.pressed && change.positionChanged()) {
+                                change.consume()
+                            }
                         }
                         touchPoints.clear()
                         touchPoints.putAll(active)

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -84,12 +85,21 @@ fun ProfileScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
+    // Sign-in form state hoisted here (survives the isSigningIn spinner swap)
+    // so a failed attempt doesn't wipe what the user typed.
+    var authEmail by rememberSaveable { mutableStateOf("") }
+    var authPassword by rememberSaveable { mutableStateOf("") }
+    var authIsSignUp by rememberSaveable { mutableStateOf(false) }
+
     // Refresh user when screen resumes (handles OAuth callback from browser)
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 viewModel.refreshUser()
+                // Clear a stuck "Signing in…" spinner if the user returned from
+                // the OAuth Custom Tab without completing it.
+                viewModel.onScreenResumed()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -157,6 +167,12 @@ fun ProfileScreen(
                         isLoading = false,
                         errorMessage = errorMessage,
                         successMessage = successMessage,
+                        email = authEmail,
+                        onEmailChange = { authEmail = it },
+                        password = authPassword,
+                        onPasswordChange = { authPassword = it },
+                        isSignUp = authIsSignUp,
+                        onIsSignUpChange = { authIsSignUp = it },
                         onSignInWithGoogle = {
                             viewModel.signInWithGoogle(context)
                         },
@@ -277,14 +293,21 @@ private fun SignedOutView(
     isLoading: Boolean,
     errorMessage: String?,
     successMessage: String?,
+    email: String,
+    onEmailChange: (String) -> Unit,
+    password: String,
+    onPasswordChange: (String) -> Unit,
+    isSignUp: Boolean,
+    onIsSignUpChange: (Boolean) -> Unit,
     onSignInWithGoogle: () -> Unit,
     onSignInWithEmail: (String, String) -> Unit,
     onSignUpWithEmail: (String, String) -> Unit,
     onClearError: () -> Unit
 ) {
-    var email by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
-    var isSignUp by remember { mutableStateOf(false) }
+    // email / password / isSignUp are hoisted to ProfileScreen so a failed
+    // sign-in (which flips isSigningIn true then false, remounting this view)
+    // no longer wipes the form the user just typed. passwordVisible is local —
+    // resetting the reveal toggle on remount is harmless.
     var passwordVisible by remember { mutableStateOf(false) }
 
     tf.monochrome.android.devedit.DevEditable("signin_header", Modifier.fillMaxWidth()) {
@@ -362,7 +385,7 @@ private fun SignedOutView(
     // Email field
     OutlinedTextField(
         value = email,
-        onValueChange = { email = it; onClearError() },
+        onValueChange = { onEmailChange(it); onClearError() },
         label = { Text("Email") },
         leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) },
         singleLine = true,
@@ -376,7 +399,7 @@ private fun SignedOutView(
     // Password field
     OutlinedTextField(
         value = password,
-        onValueChange = { password = it; onClearError() },
+        onValueChange = { onPasswordChange(it); onClearError() },
         label = { Text("Password") },
         leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
         trailingIcon = {
@@ -428,7 +451,7 @@ private fun SignedOutView(
     // Switch back to sign-in mode after successful account creation
     LaunchedEffect(successMessage) {
         if (successMessage != null && isSignUp) {
-            isSignUp = false
+            onIsSignUpChange(false)
         }
     }
 
@@ -454,7 +477,7 @@ private fun SignedOutView(
 
     Spacer(modifier = Modifier.height(8.dp))
 
-    TextButton(onClick = { isSignUp = !isSignUp; onClearError() }) {
+    TextButton(onClick = { onIsSignUpChange(!isSignUp); onClearError() }) {
         Text(
             if (isSignUp) "Already have an account? Sign In" else "Don't have an account? Sign Up",
             style = MaterialTheme.typography.bodySmall

--- a/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/profile/ProfileViewModel.kt
@@ -71,6 +71,15 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Called when the Profile screen returns to the foreground. If a Google
+     * OAuth flow was launched but the user came back without completing it (no
+     * deep-link callback), clear the otherwise-permanent "Signing in…" spinner.
+     */
+    fun onScreenResumed() {
+        authManager.cancelPendingSignInIfNoCallback()
+    }
+
     fun signInWithEmail(email: String, password: String) {
         viewModelScope.launch {
             authManager.signInWithEmail(email, password)

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchScreen.kt
@@ -31,6 +31,7 @@ fun SearchScreen(
     val showSourceFilter by viewModel.showSourceFilter.collectAsState()
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val endReached by viewModel.endReached.collectAsState()
+    val searchError by viewModel.searchError.collectAsState()
     val searchHistory by viewModel.searchHistory.collectAsState()
     val favoriteTrackIds by playerViewModel.favoriteTrackIds.collectAsState()
     val libraryPlaylists by playerViewModel.playlists.collectAsState()
@@ -65,6 +66,8 @@ fun SearchScreen(
             onLoadMore = viewModel::loadMore,
             isLoadingMore = isLoadingMore,
             endReached = endReached,
+            searchError = searchError,
+            onRetry = viewModel::submitSearch,
             emptyContent = {
                 SearchHistoryContent(
                     history = searchHistory,

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -50,10 +50,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import tf.monochrome.android.data.db.entity.UserPlaylistEntity
@@ -309,6 +314,28 @@ fun SearchResultsContent(
             val artistsRowState = rememberLazyListState()
             val albumsRowState = rememberLazyListState()
 
+            // These horizontal result rows live inside the Home/Library
+            // HorizontalPager. Left as-is, a horizontal swipe on a row (or any
+            // swipe once the row is at its edge / too short to scroll) leaks up
+            // and flips the pager to the other tab. Swallow the leftover
+            // horizontal scroll + fling here so the pager never sees it; the
+            // vertical component is left untouched so the outer list still
+            // scrolls.
+            val swallowHorizontal = remember {
+                object : NestedScrollConnection {
+                    override fun onPostScroll(
+                        consumed: Offset,
+                        available: Offset,
+                        source: NestedScrollSource,
+                    ): Offset = available.copy(y = 0f)
+
+                    override suspend fun onPostFling(
+                        consumed: Velocity,
+                        available: Velocity,
+                    ): Velocity = available.copy(y = 0f)
+                }
+            }
+
             // derivedStateOf only emits when the boolean flips, so the
             // LaunchedEffect re-runs once per page boundary, not once per
             // scroll pixel. PREFETCH thresholds picked to keep the list
@@ -355,6 +382,7 @@ fun SearchResultsContent(
                     item {
                         LazyRow(
                             state = artistsRowState,
+                            modifier = Modifier.nestedScroll(swallowHorizontal),
                             contentPadding = PaddingValues(horizontal = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
@@ -377,6 +405,7 @@ fun SearchResultsContent(
                     item {
                         LazyRow(
                             state = albumsRowState,
+                            modifier = Modifier.nestedScroll(swallowHorizontal),
                             contentPadding = PaddingValues(horizontal = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchUi.kt
@@ -226,6 +226,8 @@ fun SearchResultsContent(
     onLoadMore: (SearchViewModel.SearchPageType) -> Unit = {},
     isLoadingMore: Boolean = false,
     endReached: Boolean = false,
+    searchError: Boolean = false,
+    onRetry: () -> Unit = {},
 ) {
     var showContextMenuForTrack by remember { mutableStateOf<Track?>(null) }
     var showAddToPlaylistForTrack by remember { mutableStateOf<Track?>(null) }
@@ -340,8 +342,18 @@ fun SearchResultsContent(
             // LaunchedEffect re-runs once per page boundary, not once per
             // scroll pixel. PREFETCH thresholds picked to keep the list
             // looking continuous while not over-fetching.
+            //
+            // The vertical column carries tracks — except on the Playlists-only
+            // tab, where playlists ARE the vertical list. Paging TRACKS there
+            // loaded more (hidden) tracks and never advanced the playlists, so
+            // pick the page type that matches what the column is actually showing.
+            val columnPageType = if (selectedType == SearchViewModel.SearchTypeFilter.PLAYLISTS) {
+                SearchViewModel.SearchPageType.PLAYLISTS
+            } else {
+                SearchViewModel.SearchPageType.TRACKS
+            }
             PrefetchTrigger(columnState, threshold = TRACK_COL_PREFETCH) {
-                onLoadMore(SearchViewModel.SearchPageType.TRACKS)
+                onLoadMore(columnPageType)
             }
             PrefetchTrigger(artistsRowState, threshold = ROW_PREFETCH) {
                 onLoadMore(SearchViewModel.SearchPageType.ARTISTS)
@@ -482,12 +494,32 @@ fun SearchResultsContent(
 
                 if (tracks.isEmpty() && albums.isEmpty() && artists.isEmpty() && playlistResults.isEmpty()) {
                     item {
-                        Text(
-                            text = "No results found",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(24.dp)
-                        )
+                        if (searchError) {
+                            // Every backend failed (offline / all instances
+                            // down) — offer a retry instead of implying the
+                            // query genuinely has no matches.
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(12.dp),
+                            ) {
+                                Text(
+                                    text = "Couldn't reach search. Check your connection and try again.",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                TextButton(onClick = onRetry) { Text("Retry") }
+                            }
+                        } else {
+                            Text(
+                                text = "No results found",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(24.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -520,7 +552,15 @@ private fun PrefetchTrigger(
             total > 0 && last >= total - threshold
         }
     }
-    LaunchedEffect(shouldLoad) {
+    // Also key on the item count: when a page adds fewer items than the
+    // threshold, `shouldLoad` stays true and a plain LaunchedEffect(shouldLoad)
+    // would never re-run — paging stalled. Re-firing whenever the count grows
+    // keeps pulling pages until the tail moves out of range (loadMore itself
+    // no-ops once the type is exhausted or a page is already in flight).
+    val itemCount by remember(state) {
+        derivedStateOf { state.layoutInfo.totalItemsCount }
+    }
+    LaunchedEffect(shouldLoad, itemCount) {
         if (shouldLoad) onTrigger()
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/search/SearchViewModel.kt
@@ -122,11 +122,29 @@ class SearchViewModel @Inject constructor(
     private val _endReached = MutableStateFlow(false)
     val endReached: StateFlow<Boolean> = _endReached.asStateFlow()
 
+    // True when every backend for the current query failed — the UI shows an
+    // error state instead of the misleading "No results found".
+    private val _searchError = MutableStateFlow(false)
+    val searchError: StateFlow<Boolean> = _searchError.asStateFlow()
+
+    // Bumped on every new/reset query. A loadMore job captures the generation it
+    // was launched under and refuses to touch paging state or results once the
+    // generation has moved on — so a page in flight from the previous query
+    // can't append its results into (or falsely end) the new query's paging.
+    private var searchGeneration = 0
+
+    // One loadMore job per page type, so cancelling stale paging doesn't leave
+    // the other types' jobs running (the old single-job var only tracked the
+    // last one, letting survivors bleed results across queries).
+    private val loadMoreJobs = mutableMapOf<SearchPageType, Job>()
+
     private fun resetPaging() {
+        searchGeneration++
         tracksPage.reset(); albumsPage.reset(); artistsPage.reset(); playlistsPage.reset()
         _isLoadingMore.value = false
         _endReached.value = false
-        loadMoreJob?.cancel()
+        loadMoreJobs.values.forEach { it.cancel() }
+        loadMoreJobs.clear()
     }
 
     private val _query = MutableStateFlow("")
@@ -223,7 +241,6 @@ class SearchViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private var searchJob: Job? = null
-    private var loadMoreJob: Job? = null
 
     fun onQueryChange(newQuery: String) {
         _query.value = newQuery
@@ -233,6 +250,15 @@ class SearchViewModel @Inject constructor(
             clearResults()
             return
         }
+        // If there's nothing on screen yet, enter the searching state during the
+        // debounce window so it shows a spinner instead of flashing "No results
+        // found" before the request even starts. When results from the previous
+        // query are still showing, leave them up while the user refines — they
+        // aren't empty, so no flash — until performSearch swaps them.
+        val hasResults = _allTracks.value.isNotEmpty() || _allAlbums.value.isNotEmpty() ||
+            _allArtists.value.isNotEmpty() || _allPlaylists.value.isNotEmpty()
+        if (!hasResults) _isSearching.value = true
+        _searchError.value = false
         searchJob = viewModelScope.launch {
             kotlinx.coroutines.delay(SEARCH_DEBOUNCE_MS)
             performSearch(newQuery.trim())
@@ -277,6 +303,7 @@ class SearchViewModel @Inject constructor(
 
     private suspend fun performSearch(query: String) {
         _isSearching.value = true
+        _searchError.value = false
         val trimmedQuery = query.trim()
         // TIDAL, Qobuz, and the local/collection library all run in parallel.
         // Qobuz failures (instance unset, network error, schema mismatch) are
@@ -313,7 +340,11 @@ class SearchViewModel @Inject constructor(
 
         val qobuzAvailable = qobuzResult?.isSuccess == true
         if (searchResult.isFailure && unifiedResults == null && !qobuzAvailable) {
+            // Every backend failed (offline / all instances down). Distinguish
+            // this from a successful-but-empty search so the UI can offer a
+            // retry instead of a flat "No results found".
             clearResults()
+            _searchError.value = true
             _isSearching.value = false
             return
         }
@@ -405,9 +436,14 @@ class SearchViewModel @Inject constructor(
         if (q.isBlank()) return
         val state = pageFor(type)
         if (state.inFlight || state.done()) return
+        // Snapshot the query generation: if it changes while this page is in
+        // flight (the user edited the query), every write below is skipped so
+        // the stale page can neither append into nor prematurely end the new
+        // query's paging.
+        val gen = searchGeneration
         state.inFlight = true
         _isLoadingMore.value = true
-        loadMoreJob = viewModelScope.launch {
+        val job = viewModelScope.launch {
             try {
                 // --- TIDAL page (incremental offset paging) ---
                 if (!state.tidalEnd) {
@@ -422,6 +458,7 @@ class SearchViewModel @Inject constructor(
                         SearchPageType.PLAYLISTS ->
                             repository.searchPlaylists(q, offset, PAGE_SIZE).getOrDefault(emptyList())
                     }
+                    if (gen != searchGeneration) return@launch
                     if (tidalItems.size < PAGE_SIZE) state.tidalEnd = true
                     state.nextOffset = offset + PAGE_SIZE
                     appendPage(type, tidalItems, isQobuz = false, q = q)
@@ -435,6 +472,7 @@ class SearchViewModel @Inject constructor(
                     val qobuz = withTimeoutOrNull(QOBUZ_BUDGET_MS) {
                         runCatching { repository.searchQobuz(q, state.qobuzOffset) }.getOrNull()?.getOrNull()
                     }
+                    if (gen != searchGeneration) return@launch
                     val qItems: List<Any> = when (type) {
                         SearchPageType.TRACKS -> qobuz?.tracks ?: emptyList()
                         SearchPageType.ALBUMS -> qobuz?.albums ?: emptyList()
@@ -447,18 +485,30 @@ class SearchViewModel @Inject constructor(
                 } else if (type == SearchPageType.PLAYLISTS) {
                     state.qobuzEnd = true
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // A cancelled page (query changed) must NOT mark paging ended —
+                // that used to kill the new query's infinite scroll after page 1.
+                throw e
             } catch (_: Exception) {
-                // Swallow — a failed page just stops paging for this type.
-                state.tidalEnd = true
-                state.qobuzEnd = true
+                // A genuinely failed page just stops paging for this type.
+                if (gen == searchGeneration) {
+                    state.tidalEnd = true
+                    state.qobuzEnd = true
+                }
             } finally {
-                state.inFlight = false
-                _endReached.value = tracksPage.done() && albumsPage.done() &&
-                    artistsPage.done() && playlistsPage.done()
-                _isLoadingMore.value = tracksPage.inFlight || albumsPage.inFlight ||
-                    artistsPage.inFlight || playlistsPage.inFlight
+                // Only touch shared paging flags / the job map if we're still the
+                // current query — otherwise resetPaging already owns this state.
+                if (gen == searchGeneration) {
+                    state.inFlight = false
+                    _endReached.value = tracksPage.done() && albumsPage.done() &&
+                        artistsPage.done() && playlistsPage.done()
+                    _isLoadingMore.value = tracksPage.inFlight || albumsPage.inFlight ||
+                        artistsPage.inFlight || playlistsPage.inFlight
+                    loadMoreJobs.remove(type)
+                }
             }
         }
+        loadMoreJobs[type] = job
     }
 
     private fun currentCountFor(type: SearchPageType): Int = when (type) {
@@ -468,6 +518,10 @@ class SearchViewModel @Inject constructor(
         SearchPageType.PLAYLISTS -> _allPlaylists.value.size
     }
 
+    // Appends a fetched page, scoring only the NEW items and dropping ones
+    // already shown. The whole list used to be re-scored on every page, which
+    // reshuffled items the user had already scrolled past; keeping existing
+    // order and only ranking the fresh tail fixes that.
     private fun appendPage(type: SearchPageType, items: List<Any>, isQobuz: Boolean, q: String) {
         if (items.isEmpty()) return
         when (type) {
@@ -476,25 +530,37 @@ class SearchViewModel @Inject constructor(
                 val mapped = (items as List<Track>).map {
                     if (isQobuz) it.toQobuzUnifiedTrack() else it.toUnifiedTrack()
                 }
-                _allTracks.value = scoreTracks(q, _allTracks.value + mapped)
+                val existing = _allTracks.value
+                val seen = existing.mapTo(HashSet()) { it.id }
+                val fresh = scoreTracks(q, mapped).filterNot { it.id in seen }
+                _allTracks.value = existing + fresh
             }
             SearchPageType.ALBUMS -> {
                 @Suppress("UNCHECKED_CAST")
-                _allAlbums.value = scoreItems(q, (_allAlbums.value + (items as List<Album>)).distinctBy { it.id }) {
+                val existing = _allAlbums.value
+                val seen = existing.mapTo(HashSet()) { it.id }
+                val fresh = scoreItems(q, (items as List<Album>).distinctBy { it.id }) {
                     listOf(it.title, it.displayArtist)
-                }
+                }.filterNot { it.id in seen }
+                _allAlbums.value = existing + fresh
             }
             SearchPageType.ARTISTS -> {
                 @Suppress("UNCHECKED_CAST")
-                _allArtists.value = scoreItems(q, (_allArtists.value + (items as List<Artist>)).distinctBy { it.id }) {
+                val existing = _allArtists.value
+                val seen = existing.mapTo(HashSet()) { it.id }
+                val fresh = scoreItems(q, (items as List<Artist>).distinctBy { it.id }) {
                     listOf(it.name)
-                }
+                }.filterNot { it.id in seen }
+                _allArtists.value = existing + fresh
             }
             SearchPageType.PLAYLISTS -> {
                 @Suppress("UNCHECKED_CAST")
-                _allPlaylists.value = scoreItems(q, (_allPlaylists.value + (items as List<Playlist>)).distinctBy { it.uuid }) {
+                val existing = _allPlaylists.value
+                val seen = existing.mapTo(HashSet()) { it.uuid }
+                val fresh = scoreItems(q, (items as List<Playlist>).distinctBy { it.uuid }) {
                     listOfNotNull(it.title, it.creator?.name, it.description)
-                }
+                }.filterNot { it.uuid in seen }
+                _allPlaylists.value = existing + fresh
             }
         }
     }
@@ -505,6 +571,7 @@ class SearchViewModel @Inject constructor(
         _allArtists.value = emptyList()
         _allPlaylists.value = emptyList()
         _isSearching.value = false
+        _searchError.value = false
     }
 
     private fun scoreTracks(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -101,6 +101,7 @@ import tf.monochrome.android.domain.model.PlayerGlassPreset
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.domain.model.Track
 import tf.monochrome.android.ui.components.MiniPlayer
+import tf.monochrome.android.ui.components.buttonSemantics
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerActionDock
 import tf.monochrome.android.ui.player.GlassDropShadow
@@ -491,10 +492,16 @@ fun LyricsFxStudioScreen(
                         trailingIcon = {
                             Icon(
                                 Icons.Default.Share,
-                                contentDescription = "Manage ${saved.name}",
+                                contentDescription = null,
+                                // Chip height caps the target, but padding
+                                // before the click enlarges it past the bare
+                                // 16dp glyph, and the label/role make it a
+                                // findable button for TalkBack.
                                 modifier = Modifier
-                                    .size(16.dp)
-                                    .clickable { presetAction = saved },
+                                    .buttonSemantics(label = "Manage ${saved.name}")
+                                    .clickable { presetAction = saved }
+                                    .padding(4.dp)
+                                    .size(16.dp),
                             )
                         },
                         colors = FilterChipDefaults.filterChipColors(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -372,11 +373,13 @@ fun LyricsFxStudioScreen(
     val context = LocalContext.current
 
     // Which studio tab: 0 = Lyrics, 1 = Player Glass, 2 = Mini Player.
-    var selectedTab by remember { mutableStateOf(0) }
+    // rememberSaveable so it doesn't snap back to Lyrics after background
+    // process death.
+    var selectedTab by rememberSaveable { mutableStateOf(0) }
 
     // Preset save / import / share dialog state.
-    var showSaveDialog by remember { mutableStateOf(false) }
-    var showImportDialog by remember { mutableStateOf(false) }
+    var showSaveDialog by rememberSaveable { mutableStateOf(false) }
+    var showImportDialog by rememberSaveable { mutableStateOf(false) }
     var presetAction by remember { mutableStateOf<LyricsFxPreset?>(null) }
 
     // Re-list imported fonts whenever the custom-font toggle turns on, so a font

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -900,6 +900,7 @@ private fun PlayerGlassTab(
                     PlayerActionDock(
                         accent = accent,
                         lyricsActive = false,
+                        timerActive = false,
                         onLyrics = {},
                         onTimer = {},
                         onMixer = {},

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1251,14 +1251,16 @@ private fun ColorSwatch(label: String, color: Color, isCustom: Boolean, onClick:
                 .size(40.dp)
                 .clip(CircleShape)
                 .background(color)
-                .border(2.dp, Color.White.copy(alpha = 0.55f), CircleShape)
+                // Theme colors so the swatch labels/border stay visible on the
+                // White (light) theme (were hardcoded white → white-on-white).
+                .border(2.dp, MaterialTheme.colorScheme.outline, CircleShape)
                 .clickable(onClick = onClick),
         )
-        Text(label, style = MaterialTheme.typography.labelMedium, color = Color.White.copy(alpha = 0.85f))
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onBackground)
         Text(
             if (isCustom) "Custom" else "Current",
             style = MaterialTheme.typography.labelSmall,
-            color = Color.White.copy(alpha = 0.45f),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1522,13 +1522,17 @@ private fun DownloadsTab(viewModel: SettingsViewModel) {
         Spacer(modifier = Modifier.height(16.dp))
         SettingsGroupHeader("Download Folder")
 
-        val folderDisplay = downloadFolder?.let { folder ->
-            try {
-                val uri = folder.toUri()
-                val docFile = androidx.documentfile.provider.DocumentFile.fromTreeUri(context, uri)
-                docFile?.name ?: "Custom folder"
-            } catch (_: Exception) { "Custom folder" }
-        } ?: "Internal app storage (default)"
+        // remember so the DocumentFile ContentResolver lookup runs only when the
+        // folder actually changes, not on every recomposition of this screen.
+        val folderDisplay = remember(downloadFolder, context) {
+            downloadFolder?.let { folder ->
+                try {
+                    val uri = folder.toUri()
+                    val docFile = androidx.documentfile.provider.DocumentFile.fromTreeUri(context, uri)
+                    docFile?.name ?: "Custom folder"
+                } catch (_: Exception) { "Custom folder" }
+            } ?: "Internal app storage (default)"
+        }
 
         SettingItem(
             title = "Save location",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -340,7 +340,23 @@ private fun AppearanceTab(viewModel: SettingsViewModel) {
     val customFontUri by viewModel.customFontUri.collectAsState()
     val availableFonts by viewModel.availableFonts.collectAsState()
     var showThemeDropdown by remember { mutableStateOf(false) }
-    var fontScaleText by remember(fontScale) { mutableStateOf(String.format(Locale.US, "%.2f", fontScale)) }
+    // Plain local state + commit-on-Done/focus-loss (see the speed field for
+    // the same rationale): typing a precise scale no longer resets mid-entry
+    // and the whole app's type no longer jumps at each intermediate keystroke.
+    var fontScaleText by remember { mutableStateOf(String.format(Locale.US, "%.2f", fontScale)) }
+    var fontScaleFocused by remember { mutableStateOf(false) }
+    LaunchedEffect(fontScale) {
+        if (!fontScaleFocused) fontScaleText = String.format(Locale.US, "%.2f", fontScale)
+    }
+    val commitFontScale = {
+        val parsed = fontScaleText.toFloatOrNull()?.coerceIn(0.5f, 2.0f)
+        if (parsed != null) {
+            viewModel.setFontScale(parsed)
+            fontScaleText = String.format(Locale.US, "%.2f", parsed)
+        } else {
+            fontScaleText = String.format(Locale.US, "%.2f", fontScale)
+        }
+    }
 
     // File picker for .ttf font import
     val context = LocalContext.current
@@ -382,17 +398,17 @@ private fun AppearanceTab(viewModel: SettingsViewModel) {
                 )
                 OutlinedTextField(
                     value = fontScaleText,
-                    onValueChange = { newText ->
-                        fontScaleText = newText
-                        newText.toFloatOrNull()?.let { value ->
-                            if (value in 0.5f..2.0f) {
-                                viewModel.setFontScale(value)
-                            }
-                        }
-                    },
-                    modifier = Modifier.width(80.dp),
+                    onValueChange = { fontScaleText = it },
+                    modifier = Modifier
+                        .width(80.dp)
+                        .onFocusChanged {
+                            if (!it.isFocused && fontScaleFocused) commitFontScale()
+                            fontScaleFocused = it.isFocused
+                        },
                     textStyle = MaterialTheme.typography.bodyMedium,
-                    singleLine = true
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { commitFontScale() })
                 )
             }
             Text(
@@ -1008,7 +1024,25 @@ private fun AudioTab(viewModel: SettingsViewModel, navController: NavController)
     val preservePitch by viewModel.preservePitch.collectAsState()
     var showWifiDropdown by remember { mutableStateOf(false) }
     var showCellularDropdown by remember { mutableStateOf(false) }
-    var speedText by remember(playbackSpeed) { mutableStateOf(String.format(Locale.US, "%.2f", playbackSpeed)) }
+    // Plain local state (NOT keyed on playbackSpeed) so typing isn't reset by
+    // the value round-tripping back from the ViewModel; sync from external
+    // changes (slider/reset) only while the field is unfocused, and commit on
+    // Done / focus-loss instead of on every keystroke (which dropped playback
+    // to 0.01x mid-entry).
+    var speedText by remember { mutableStateOf(String.format(Locale.US, "%.2f", playbackSpeed)) }
+    var speedFocused by remember { mutableStateOf(false) }
+    LaunchedEffect(playbackSpeed) {
+        if (!speedFocused) speedText = String.format(Locale.US, "%.2f", playbackSpeed)
+    }
+    val commitSpeed = {
+        val parsed = speedText.toFloatOrNull()?.coerceIn(0.01f, 100f)
+        if (parsed != null) {
+            viewModel.setPlaybackSpeed(parsed)
+            speedText = String.format(Locale.US, "%.2f", parsed)
+        } else {
+            speedText = String.format(Locale.US, "%.2f", playbackSpeed)
+        }
+    }
 
     SettingsTabContent {
         SettingsGroupHeader("Streaming Quality")
@@ -1085,15 +1119,16 @@ private fun AudioTab(viewModel: SettingsViewModel, navController: NavController)
             )
             OutlinedTextField(
                 value = speedText,
-                onValueChange = { input ->
-                    speedText = input
-                    input.toFloatOrNull()?.let { parsed ->
-                        val clamped = parsed.coerceIn(0.01f, 100f)
-                        viewModel.setPlaybackSpeed(clamped)
-                    }
-                },
-                modifier = Modifier.width(80.dp),
+                onValueChange = { speedText = it },
+                modifier = Modifier
+                    .width(80.dp)
+                    .onFocusChanged {
+                        if (!it.isFocused && speedFocused) commitSpeed()
+                        speedFocused = it.isFocused
+                    },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { commitSpeed() }),
                 textStyle = MaterialTheme.typography.bodyMedium
             )
             Text("x", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -809,35 +810,25 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
             }
         }
         
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Mesh X: $meshX", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
-        Slider(
-            value = meshX.toFloat(),
-            onValueChange = { viewModel.setVisualizerMeshX(it.toInt()) },
+        IntSettingSlider(
+            value = meshX,
             valueRange = 8f..128f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerMeshX(it) },
+            label = { "Mesh X: $it" },
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Mesh Y: $meshY", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
-        Slider(
-            value = meshY.toFloat(),
-            onValueChange = { viewModel.setVisualizerMeshY(it.toInt()) },
+        IntSettingSlider(
+            value = meshY,
             valueRange = 8f..128f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerMeshY(it) },
+            label = { "Mesh Y: $it" },
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = if (vsyncEnabled) "Target FPS: $targetFps" else "Target FPS: $targetFps (vsync off)",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Slider(
-            value = targetFps.toFloat(),
-            onValueChange = { viewModel.setVisualizerTargetFps(it.toInt()) },
+        IntSettingSlider(
+            value = targetFps,
             valueRange = 30f..144f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerTargetFps(it) },
+            label = { if (vsyncEnabled) "Target FPS: $it" else "Target FPS: $it (vsync off)" },
         )
 
         SettingSwitchItem(
@@ -872,36 +863,26 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
             onClick = {}
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            "Preset Rotation: ${rotationSeconds}s",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        Slider(
-            value = rotationSeconds.toFloat(),
-            onValueChange = { viewModel.setVisualizerRotationSeconds(it.toInt()) },
+        IntSettingSlider(
+            value = rotationSeconds,
             valueRange = 5f..120f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerRotationSeconds(it) },
+            label = { "Preset Rotation: ${it}s" },
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Sensitivity: $sensitivity%", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
-        Text("Controls intensity (High = Epilepsy Warning)", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Slider(
-            value = sensitivity.toFloat(),
-            onValueChange = { viewModel.setVisualizerSensitivity(it.toInt()) },
+        IntSettingSlider(
+            value = sensitivity,
             valueRange = 0f..100f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerSensitivity(it) },
+            label = { "Sensitivity: $it%" },
+            subtitle = "Controls intensity (High = Epilepsy Warning)",
         )
-        
-        Spacer(modifier = Modifier.height(8.dp))
-        Text("Brightness: $brightness%", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
-        Slider(
-            value = brightness.toFloat(),
-            onValueChange = { viewModel.setVisualizerBrightness(it.toInt()) },
+
+        IntSettingSlider(
+            value = brightness,
             valueRange = 0f..100f,
-            modifier = Modifier.fillMaxWidth()
+            onCommit = { viewModel.setVisualizerBrightness(it) },
+            label = { "Brightness: $it%" },
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -913,6 +894,44 @@ private fun InterfaceTab(viewModel: SettingsViewModel, navController: NavControl
             onCheckedChange = { viewModel.setConfirmClearQueue(it) }
         )
     }
+}
+
+/**
+ * Integer settings slider that writes its value once, on release, instead of on
+ * every drag frame. A local float drives the label and thumb live; [onCommit]
+ * (a DataStore write) fires only from onValueChangeFinished. The local state is
+ * re-seeded whenever [value] changes externally so it stays in sync.
+ */
+@Composable
+private fun IntSettingSlider(
+    value: Int,
+    valueRange: ClosedFloatingPointRange<Float>,
+    onCommit: (Int) -> Unit,
+    label: (Int) -> String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+) {
+    var local by remember(value) { mutableFloatStateOf(value.toFloat()) }
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        label(local.toInt()),
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    if (subtitle != null) {
+        Text(
+            subtitle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Slider(
+        value = local,
+        onValueChange = { local = it },
+        onValueChangeFinished = { onCommit(local.toInt()) },
+        valueRange = valueRange,
+        modifier = modifier.fillMaxWidth(),
+    )
 }
 
 // ─── Tab 3: Scrobbling ─────────────────────────────────────────────────

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1694,16 +1694,48 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
         }
     }
 
+    // Export writes to a SAF-chosen file, not the clipboard: a large library's
+    // backup JSON exceeds the binder transaction limit and setPrimaryClip()
+    // hard-crashed exactly the users with the most data to protect.
+    var pendingExportJson by remember { mutableStateOf<String?>(null) }
+    val exportSaveLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.CreateDocument("application/json")
+    ) { uri ->
+        val json = pendingExportJson
+        pendingExportJson = null
+        if (uri != null && json != null) {
+            coroutineScope.launch(Dispatchers.IO) {
+                val ok = try {
+                    context.contentResolver.openOutputStream(uri)?.use { it.write(json.toByteArray()) }
+                    true
+                } catch (e: Exception) {
+                    false
+                }
+                withContext(Dispatchers.Main) {
+                    android.widget.Toast.makeText(
+                        context,
+                        if (ok) "Backup saved" else "Failed to save backup",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        }
+    }
+
     if (showClearAllDialog) {
         AlertDialog(
             onDismissRequest = { showClearAllDialog = false },
-            title = { Text("Reset All Data") },
-            text = { Text("This will clear all settings, cache, and local data. The app will restart in a clean state.") },
+            title = { Text("Reset Settings & Cache") },
+            // Reworded to match what clearAllData() actually does: it resets
+            // preferences and wipes the cache but leaves the Room library
+            // untouched, and the app does not restart. The old copy promised
+            // to clear "all local data" and restart, neither of which happened.
+            text = { Text("This resets all app settings and clears cached data. Your saved library, playlists, favorites, and downloads are kept.") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.clearAllData()
                     showClearAllDialog = false
-                }) { Text("Reset Everything", color = MaterialTheme.colorScheme.error) }
+                }) { Text("Reset", color = MaterialTheme.colorScheme.error) }
             },
             dismissButton = {
                 TextButton(onClick = { showClearAllDialog = false }) { Text("Cancel") }
@@ -1733,7 +1765,7 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
         ) {
             Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(modifier = Modifier.width(8.dp))
-            Text("Reset All Data")
+            Text("Reset Settings & Cache")
         }
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -1935,11 +1967,10 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedButton(onClick = {
                 viewModel.exportLibrary { json ->
-                    // Copy to clipboard or share
-                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                    val clip = android.content.ClipData.newPlainText("Monochrome Backup", json)
-                    clipboard.setPrimaryClip(clip)
-                    android.widget.Toast.makeText(context, "Backup copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
+                    // Stash the JSON, then let the user pick a destination file
+                    // (safe for any size, unlike the old clipboard copy).
+                    pendingExportJson = json
+                    exportSaveLauncher.launch("monochrome-backup.json")
                 }
             }) {
                 Text("Export JSON")
@@ -2048,7 +2079,10 @@ private fun LinkItem(label: String, url: String, context: android.content.Contex
         style = MaterialTheme.typography.bodyLarge,
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier
-            .clickable { context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri())) }
+            // Route through the guarded helper so a device with no browser
+            // (or a locked-down work profile) shows a toast instead of crashing
+            // with ActivityNotFoundException.
+            .clickable { openDonationUrl(context, url) }
             .padding(vertical = 10.dp)
     )
 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1787,13 +1787,29 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
         val isLoggedIn by viewModel.isLoggedIn.collectAsState()
         val userEmail by viewModel.userEmail.collectAsState()
 
+        var showSignOutDialog by remember { mutableStateOf(false) }
+        if (showSignOutDialog) {
+            AlertDialog(
+                onDismissRequest = { showSignOutDialog = false },
+                title = { Text("Sign out?") },
+                text = { Text("You'll stop syncing favorites and playlists across devices until you sign back in.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showSignOutDialog = false
+                        viewModel.logout()
+                    }) { Text("Sign Out", color = MaterialTheme.colorScheme.error) }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showSignOutDialog = false }) { Text("Cancel") }
+                }
+            )
+        }
         if (isLoggedIn) {
             SettingItem(
                 title = "Signed in as",
                 subtitle = userEmail ?: "Unknown",
-                onClick = {}
             )
-            OutlinedButton(onClick = { viewModel.logout() }) {
+            OutlinedButton(onClick = { showSignOutDialog = true }) {
                 Text("Sign Out")
             }
         } else {

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
@@ -120,7 +121,9 @@ fun SettingsScreen(
     initialTab: Int = 0,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    var selectedTab by remember { mutableIntStateOf(initialTab) }
+    // rememberSaveable so the selected settings tab survives background process
+    // death instead of snapping back to the first tab.
+    var selectedTab by rememberSaveable { mutableIntStateOf(initialTab) }
 
     // Toast one-shot ViewModel messages (font import, backup import, …) from
     // one always-composed collector, regardless of which tab is showing.
@@ -942,12 +945,12 @@ private fun ScrobblingTab(viewModel: SettingsViewModel) {
     val lbEnabled by viewModel.listenBrainzEnabled.collectAsState()
     val lbToken by viewModel.listenBrainzToken.collectAsState()
 
-    var showLastFmDialog by remember { mutableStateOf(false) }
-    var showLbDialog by remember { mutableStateOf(false) }
+    var showLastFmDialog by rememberSaveable { mutableStateOf(false) }
+    var showLbDialog by rememberSaveable { mutableStateOf(false) }
 
     if (showLastFmDialog) {
-        var sessionInput by remember { mutableStateOf("") }
-        var usernameInput by remember { mutableStateOf("") }
+        var sessionInput by rememberSaveable { mutableStateOf("") }
+        var usernameInput by rememberSaveable { mutableStateOf("") }
         AlertDialog(
             onDismissRequest = { showLastFmDialog = false },
             title = { Text("Last.fm") },
@@ -982,7 +985,7 @@ private fun ScrobblingTab(viewModel: SettingsViewModel) {
     }
 
     if (showLbDialog) {
-        var tokenInput by remember { mutableStateOf(lbToken ?: "") }
+        var tokenInput by rememberSaveable { mutableStateOf(lbToken ?: "") }
         AlertDialog(
             onDismissRequest = { showLbDialog = false },
             title = { Text("ListenBrainz Token") },

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -121,6 +121,15 @@ fun SettingsScreen(
 ) {
     var selectedTab by remember { mutableIntStateOf(initialTab) }
 
+    // Toast one-shot ViewModel messages (font import, backup import, …) from
+    // one always-composed collector, regardless of which tab is showing.
+    val messageContext = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.messages.collect { msg ->
+            android.widget.Toast.makeText(messageContext, msg, android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text("Settings") },
@@ -197,13 +206,11 @@ private fun EqualizerTab(navController: NavController, eqViewModel: EqViewModel 
         SettingItem(
             title = "Target Curve",
             subtitle = selectedTarget.label,
-            onClick = {}
         )
 
         SettingItem(
             title = "Headphone",
             subtitle = selectedHeadphone?.name ?: "None selected",
-            onClick = {}
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -923,12 +930,15 @@ private fun ScrobblingTab(viewModel: SettingsViewModel) {
                 }
             },
             confirmButton = {
-                TextButton(onClick = {
-                    if (sessionInput.isNotBlank() && usernameInput.isNotBlank()) {
+                TextButton(
+                    onClick = {
                         viewModel.setLastFmSession(sessionInput, usernameInput)
-                    }
-                    showLastFmDialog = false
-                }) { Text("Connect") }
+                        showLastFmDialog = false
+                    },
+                    // Disabled until both fields are filled, so Connect can't
+                    // silently close without connecting.
+                    enabled = sessionInput.isNotBlank() && usernameInput.isNotBlank()
+                ) { Text("Connect") }
             },
             dismissButton = {
                 TextButton(onClick = { showLastFmDialog = false }) { Text("Cancel") }
@@ -1425,8 +1435,7 @@ private fun DownloadsTab(viewModel: SettingsViewModel) {
             text = { Text("This will delete all downloaded tracks from your device. This action cannot be undone.") },
             confirmButton = {
                 TextButton(onClick = {
-                    val downloadDir = java.io.File(context.getExternalFilesDir(null), "downloads")
-                    downloadDir.deleteRecursively()
+                    viewModel.clearAllDownloads()
                     showClearDialog = false
                 }) { Text("Delete All", color = MaterialTheme.colorScheme.error) }
             },
@@ -1677,8 +1686,10 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
                     }
                     if (!content.isNullOrBlank()) {
                         withContext(Dispatchers.Main) {
+                            // Success/failure is reported by viewModel.messages
+                            // once the import actually finishes — not here,
+                            // where it fired even for a corrupt backup.
                             viewModel.importLibrary(content)
-                            android.widget.Toast.makeText(context, "Library imported", android.widget.Toast.LENGTH_SHORT).show()
                         }
                     } else {
                         withContext(Dispatchers.Main) {
@@ -1745,7 +1756,7 @@ private fun SystemTab(viewModel: SettingsViewModel, navController: NavController
 
     SettingsTabContent {
         SettingsGroupHeader("Storage")
-        SettingItem(title = "Cache Size", subtitle = cacheSize, onClick = {})
+        SettingItem(title = "Cache Size", subtitle = cacheSize)
         OutlinedButton(onClick = { viewModel.clearCache() }) {
             Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
             Spacer(modifier = Modifier.width(8.dp))
@@ -2118,12 +2129,14 @@ private fun SettingsGroupHeader(title: String) {
 }
 
 @Composable
-fun SettingItem(title: String, subtitle: String, onClick: () -> Unit) {
+fun SettingItem(title: String, subtitle: String, onClick: (() -> Unit)? = null) {
     tf.monochrome.android.devedit.DevEditable("item_${devSlug(title)}", Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                // Only clickable (with ripple) when there's an action — an
+                // empty onClick used to ripple like a picker but do nothing.
+                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(vertical = 12.dp)
         ) {
             Text(text = title, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -460,7 +460,7 @@ private fun AppearanceTab(viewModel: SettingsViewModel) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedButton(
-                        onClick = { fontPickerLauncher.launch(arrayOf("font/ttf", "application/x-font-ttf", "application/octet-stream")) },
+                        onClick = { fontPickerLauncher.launch(arrayOf("font/ttf", "font/otf", "application/x-font-ttf", "application/octet-stream")) },
                         modifier = Modifier.weight(1f)
                     ) {
                         Text("Add Font")
@@ -477,10 +477,10 @@ private fun AppearanceTab(viewModel: SettingsViewModel) {
                 }
             } else {
                 OutlinedButton(
-                    onClick = { fontPickerLauncher.launch(arrayOf("font/ttf", "application/x-font-ttf", "application/octet-stream")) },
+                    onClick = { fontPickerLauncher.launch(arrayOf("font/ttf", "font/otf", "application/x-font-ttf", "application/octet-stream")) },
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Import Custom Font (.ttf)")
+                    Text("Import Custom Font (.ttf / .otf)")
                 }
             }
         }
@@ -2238,13 +2238,19 @@ private fun LibrarySettingsTab(viewModel: SettingsViewModel) {
         }
 
         item {
+            val isScanning by viewModel.isScanning.collectAsState()
+            val scanContext = LocalContext.current
             OutlinedButton(
-                onClick = { viewModel.rescanLibrary() },
+                onClick = {
+                    viewModel.rescanLibrary()
+                    android.widget.Toast.makeText(scanContext, "Scanning library…", android.widget.Toast.LENGTH_SHORT).show()
+                },
+                enabled = !isScanning,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(8.dp))
-                Text("Rescan Library Now")
+                Text(if (isScanning) "Scanning…" else "Rescan Library Now")
             }
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -46,6 +46,7 @@ class SettingsViewModel @Inject constructor(
     private val spectrumAnalyzerTap: SpectrumAnalyzerTap,
     private val usbAudioRouter: tf.monochrome.android.audio.UsbAudioRouter,
     private val usbExclusiveController: tf.monochrome.android.audio.usb.UsbExclusiveController,
+    private val artworkRefreshDetector: tf.monochrome.android.data.local.scanner.ArtworkRefreshDetector,
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
@@ -549,6 +550,10 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             appContext.cacheDir.deleteRecursively()
             calculateCacheSize()
+            // The wipe just deleted cacheDir/artwork, which local tracks'
+            // Room rows point at. Rescan now so covers come back without
+            // waiting for the next app start (or a manual refresh).
+            runCatching { artworkRefreshDetector.refreshIfArtworkMissing() }
         }
     }
 
@@ -557,6 +562,7 @@ class SettingsViewModel @Inject constructor(
             preferences.clearAllData()
             appContext.cacheDir.deleteRecursively()
             calculateCacheSize()
+            runCatching { artworkRefreshDetector.refreshIfArtworkMissing() }
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -8,10 +8,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -48,12 +52,18 @@ class SettingsViewModel @Inject constructor(
     private val usbExclusiveController: tf.monochrome.android.audio.usb.UsbExclusiveController,
     private val artworkRefreshDetector: tf.monochrome.android.data.local.scanner.ArtworkRefreshDetector,
     private val scanCoordinator: tf.monochrome.android.data.local.scanner.ScanCoordinator,
+    private val downloadDao: tf.monochrome.android.data.db.dao.DownloadDao,
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
 
     /** True while any library scan is running — lets Settings disable the
      *  "Rescan Library Now" button and show progress. */
     val isScanning: StateFlow<Boolean> = scanCoordinator.isScanning
+
+    /** One-shot user-facing messages (import success/failure, etc.) that the
+     *  Settings screen shows as a toast. */
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 4)
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
 
     /** Honest live status of the libusb exclusive-output path. */
     val usbExclusiveStatus: StateFlow<tf.monochrome.android.audio.usb.UsbExclusiveController.Status> =
@@ -309,8 +319,9 @@ class SettingsViewModel @Inject constructor(
                 }
                 loadFonts()
                 preferences.setCustomFontUri(destFile.absolutePath)
+                _messages.tryEmit("Font imported")
             } catch (_: Exception) {
-                // Font import failed silently
+                _messages.tryEmit("Couldn't import that font file")
             }
         }
     }
@@ -472,11 +483,51 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Delete every downloaded track — the actual files (SAF content:// or
+     * plain paths) AND the Room rows — off the main thread. The old dialog
+     * did a main-thread deleteRecursively() of only the default folder and
+     * never cleared the DB, so tracks stayed listed and failed to play.
+     */
+    fun clearAllDownloads() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val tracks = downloadDao.getDownloadedTracks().first()
+            var deleted = 0
+            for (t in tracks) {
+                try {
+                    if (t.filePath.startsWith("content://")) {
+                        androidx.documentfile.provider.DocumentFile
+                            .fromSingleUri(appContext, android.net.Uri.parse(t.filePath))?.delete()
+                    } else {
+                        val f = File(t.filePath)
+                        if (f.exists()) f.delete()
+                    }
+                } catch (_: Exception) { }
+                downloadDao.deleteDownloadedTrack(t.id)
+                deleted++
+            }
+            // Sweep any leftover files in the default downloads directory.
+            try {
+                File(appContext.getExternalFilesDir(null), "downloads").deleteRecursively()
+            } catch (_: Exception) { }
+            _messages.tryEmit(
+                if (deleted > 0) "Deleted $deleted download${if (deleted == 1) "" else "s"}"
+                else "No downloads to delete"
+            )
+        }
+    }
+
     fun importLibrary(jsonStr: String) {
         viewModelScope.launch {
             Log.d("ImportSync", "Starting library import...")
             val result = backupManager.importLibrary(jsonStr)
             Log.d("ImportSync", "Import result: $result")
+            if (result.isFailure) {
+                // Report the real outcome instead of the old unconditional
+                // "Library imported" success toast fired on a corrupt file.
+                _messages.tryEmit("Import failed: invalid backup file")
+                return@launch
+            }
             // Auto-sync to Supabase if signed in
             val profile = supabaseAuthManager.userProfile.value
             Log.d("ImportSync", "Current Supabase user: ${profile?.id} (${profile?.email})")
@@ -487,6 +538,7 @@ class SettingsViewModel @Inject constructor(
             } else {
                 Log.w("ImportSync", "Not signed in - skipping Supabase sync")
             }
+            _messages.tryEmit("Library imported")
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -454,13 +454,29 @@ class SettingsViewModel @Inject constructor(
     }
 
     // --- Library tab order ---
-    val libraryTabOrder: StateFlow<List<String>> = preferences.libraryTabOrder
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf("overview", "local", "playlists", "favorites", "downloads"))
+    // Backed by an in-memory MutableStateFlow (mirrored from prefs) rather than
+    // stateIn: moveLibraryTab used to read the prefs-backed StateFlow's .value,
+    // which lags the DataStore write, so rapid up/down taps all read the same
+    // stale order and lost or scrambled moves. The local flow updates
+    // synchronously so successive moves compound correctly.
+    private val _libraryTabOrder = MutableStateFlow(
+        listOf("overview", "local", "playlists", "favorites", "downloads")
+    )
+    val libraryTabOrder: StateFlow<List<String>> = _libraryTabOrder.asStateFlow()
 
-    fun setLibraryTabOrder(order: List<String>) { viewModelScope.launch { preferences.setLibraryTabOrder(order) } }
+    init {
+        viewModelScope.launch {
+            preferences.libraryTabOrder.collect { _libraryTabOrder.value = it }
+        }
+    }
+
+    fun setLibraryTabOrder(order: List<String>) {
+        _libraryTabOrder.value = order
+        viewModelScope.launch { preferences.setLibraryTabOrder(order) }
+    }
 
     fun moveLibraryTab(fromIndex: Int, toIndex: Int) {
-        val current = libraryTabOrder.value.toMutableList()
+        val current = _libraryTabOrder.value.toMutableList()
         if (fromIndex in current.indices && toIndex in current.indices) {
             val item = current.removeAt(fromIndex)
             current.add(toIndex, item)

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -614,15 +615,16 @@ class SettingsViewModel @Inject constructor(
     // --- System actions ---
     private fun calculateCacheSize() {
         viewModelScope.launch {
-            val cacheDir = appContext.cacheDir
-            val size = getDirSize(cacheDir)
+            // Recursive directory walk off the main thread — a large artwork
+            // cache otherwise froze the UI / triggered an ANR.
+            val size = withContext(Dispatchers.IO) { getDirSize(appContext.cacheDir) }
             _cacheSize.value = formatSize(size)
         }
     }
 
     fun clearCache() {
         viewModelScope.launch {
-            appContext.cacheDir.deleteRecursively()
+            withContext(Dispatchers.IO) { appContext.cacheDir.deleteRecursively() }
             calculateCacheSize()
             // The wipe just deleted cacheDir/artwork, which local tracks'
             // Room rows point at. Rescan now so covers come back without
@@ -633,8 +635,10 @@ class SettingsViewModel @Inject constructor(
 
     fun clearAllData() {
         viewModelScope.launch {
-            preferences.clearAllData()
-            appContext.cacheDir.deleteRecursively()
+            withContext(Dispatchers.IO) {
+                preferences.clearAllData()
+                appContext.cacheDir.deleteRecursively()
+            }
             calculateCacheSize()
             runCatching { artworkRefreshDetector.refreshIfArtworkMissing() }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsViewModel.kt
@@ -47,8 +47,13 @@ class SettingsViewModel @Inject constructor(
     private val usbAudioRouter: tf.monochrome.android.audio.UsbAudioRouter,
     private val usbExclusiveController: tf.monochrome.android.audio.usb.UsbExclusiveController,
     private val artworkRefreshDetector: tf.monochrome.android.data.local.scanner.ArtworkRefreshDetector,
+    private val scanCoordinator: tf.monochrome.android.data.local.scanner.ScanCoordinator,
     @ApplicationContext private val appContext: Context
 ) : ViewModel() {
+
+    /** True while any library scan is running — lets Settings disable the
+     *  "Rescan Library Now" button and show progress. */
+    val isScanning: StateFlow<Boolean> = scanCoordinator.isScanning
 
     /** Honest live status of the libusb exclusive-output path. */
     val usbExclusiveStatus: StateFlow<tf.monochrome.android.audio.usb.UsbExclusiveController.Status> =
@@ -432,8 +437,9 @@ class SettingsViewModel @Inject constructor(
     fun setMinTrackDuration(durationMs: Long) { viewModelScope.launch { preferences.setMinTrackDurationMs(durationMs) } }
     fun setBackgroundScanInterval(interval: String) { viewModelScope.launch { preferences.setBackgroundScanInterval(interval) } }
     fun rescanLibrary() {
-        // This triggers a scan via broadcast or direct call
-        // The actual scanning happens in LocalLibraryViewModel
+        // Route through the shared ScanCoordinator (the same guard the Library
+        // tab uses), so the button actually scans instead of no-op'ing.
+        viewModelScope.launch { scanCoordinator.runFullScan() }
     }
 
     // --- Library tab order ---

--- a/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsTab.kt
@@ -49,6 +49,7 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
     val plannerUrl by viewModel.plannerUrl.collectAsState()
     val plannerApiKey by viewModel.plannerApiKey.collectAsState()
     val connectionStatus by viewModel.connectionStatus.collectAsState()
+    val isTesting by viewModel.isTesting.collectAsState()
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -86,9 +87,10 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
 
             OutlinedButton(
                 onClick = viewModel::testConnection,
+                enabled = !isTesting,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Test connection")
+                Text(if (isTesting) "Testing…" else "Test connection")
             }
             connectionStatus?.let { status ->
                 Text(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsViewModel.kt
@@ -59,9 +59,18 @@ class RadioSettingsViewModel @Inject constructor(
         viewModelScope.launch { preferences.setRadioPlannerApiKey(key) }
     }
 
+    private var testJob: kotlinx.coroutines.Job? = null
+    private val _isTesting = MutableStateFlow(false)
+    val isTesting: StateFlow<Boolean> = _isTesting.asStateFlow()
+
     fun testConnection() {
+        // Cancel any in-flight test so a stale earlier result can't overwrite
+        // the current one, and expose isTesting so the button disables.
+        testJob?.cancel()
         _connectionStatus.value = "Testing…"
-        viewModelScope.launch {
+        testJob = viewModelScope.launch {
+            _isTesting.value = true
+            try {
             _connectionStatus.value = plannerClient.health().fold(
                 onSuccess = { health ->
                     buildString {
@@ -77,6 +86,9 @@ class RadioSettingsViewModel @Inject constructor(
                 },
                 onFailure = { "Connection failed: ${it.message}" }
             )
+            } finally {
+                _isTesting.value = false
+            }
         }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
@@ -59,10 +59,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
@@ -242,10 +244,16 @@ private fun StatsContent(
 
 @Composable
 private fun StaggerEntry(index: Int, content: @Composable () -> Unit) {
-    var visible by remember { mutableStateOf(false) }
+    // rememberSaveable + a guard so the entrance plays ONCE. LazyColumn retains
+    // saveable item state across scroll, so a section scrolling off and back no
+    // longer resets to invisible, replaying the animation and flashing a blank
+    // gap during the stagger delay.
+    var visible by rememberSaveable { mutableStateOf(false) }
     LaunchedEffectOnce {
-        kotlinx.coroutines.delay(60L * index + 40L)
-        visible = true
+        if (!visible) {
+            kotlinx.coroutines.delay(60L * index + 40L)
+            visible = true
+        }
     }
     AnimatedVisibility(
         visible = visible,
@@ -290,7 +298,10 @@ private fun HeroMinutesCard(state: StatsUiState) {
     val primary = MaterialTheme.colorScheme.primary
     val tertiary = MaterialTheme.colorScheme.tertiary
     val pulse = rememberInfiniteTransition(label = "hero-pulse")
-    val t by pulse.animateFloat(
+    // Keep the animated value as State (no `by`) and read it inside drawBehind,
+    // so the pulse animates in the draw phase instead of recomposing the whole
+    // hero card 60×/second.
+    val t = pulse.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
         animationSpec = infiniteRepeatable(
@@ -298,12 +309,6 @@ private fun HeroMinutesCard(state: StatsUiState) {
             repeatMode = RepeatMode.Reverse
         ),
         label = "pulse-t"
-    )
-    val bg = Brush.linearGradient(
-        colors = listOf(
-            primary.copy(alpha = 0.22f + 0.10f * t),
-            tertiary.copy(alpha = 0.18f + 0.10f * (1f - t)),
-        )
     )
 
     Card(
@@ -314,7 +319,17 @@ private fun HeroMinutesCard(state: StatsUiState) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(bg)
+                .drawBehind {
+                    val tv = t.value
+                    drawRect(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                primary.copy(alpha = 0.22f + 0.10f * tv),
+                                tertiary.copy(alpha = 0.18f + 0.10f * (1f - tv)),
+                            )
+                        )
+                    )
+                }
                 .padding(20.dp),
         ) {
             Column {

--- a/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
@@ -96,6 +96,13 @@ fun StatsScreen(
     val isRefreshing by viewModel.isRefreshing.collectAsState()
     val lastSyncedAt by viewModel.lastSyncedAt.collectAsState()
 
+    val statsMsgContext = androidx.compose.ui.platform.LocalContext.current
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.messages.collect { msg ->
+            android.widget.Toast.makeText(statsMsgContext, msg, android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text("Listening Stats") },

--- a/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/stats/StatsScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -507,7 +508,9 @@ private fun DayLineChart(data: List<DayAggregate>) {
     val ghost = color.copy(alpha = 0.0f)
     val maxV = (data.maxOfOrNull { it.playCount } ?: 1).coerceAtLeast(1)
     val minDay = data.first().dayEpoch
-    val maxDay = data.last().dayEpoch.coerceAtLeast(minDay + 1)
+    // No coerceAtLeast: a single day keeps span == 0 so the point centers at
+    // w/2 (the old +1 fudge drew a stray gradient wedge with no line).
+    val maxDay = data.last().dayEpoch
     val span = (maxDay - minDay).toFloat()
 
     val grow by animateFloatAsState(
@@ -523,6 +526,14 @@ private fun DayLineChart(data: List<DayAggregate>) {
     ) {
         val w = size.width
         val h = size.height
+        // A single data point can't stroke a line (moveTo with no lineTo) — draw
+        // a dot instead of the empty stroke + stray gradient wedge.
+        if (data.size < 2) {
+            val only = data.firstOrNull() ?: return@Canvas
+            val y = h - (only.playCount / maxV.toFloat()) * h * grow
+            drawCircle(color = color, radius = 6f, center = Offset(w / 2, y))
+            return@Canvas
+        }
         val path = Path()
         val fill = Path()
         data.forEachIndexed { i, d ->
@@ -774,12 +785,14 @@ private fun TopListRow(
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 color = MaterialTheme.colorScheme.onSurface
             )
             Text(
                 secondary,
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(Modifier.height(6.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/stats/StatsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/stats/StatsViewModel.kt
@@ -145,8 +145,13 @@ class StatsViewModel @Inject constructor(
             // Pad the range by 1 day so near-cutoff plays on other devices
             // aren't missed due to clock skew.
             val since = sinceFor(r).let { if (it > 0) it - 86_400_000L else 0L }
-            supabaseSync.pullPlayEventsSince(since)
-            _lastSyncedAt.value = System.currentTimeMillis()
+            // Only claim "Synced just now" when the pull actually succeeded —
+            // an offline/errored pull used to still stamp the sync time,
+            // falsely telling the user their cross-device history was current.
+            val pulled = supabaseSync.pullPlayEventsSince(since)
+            if (pulled != null) {
+                _lastSyncedAt.value = System.currentTimeMillis()
+            }
         } finally {
             _isRefreshing.value = false
         }

--- a/app/src/main/java/tf/monochrome/android/ui/stats/StatsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/stats/StatsViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
@@ -74,6 +77,10 @@ class StatsViewModel @Inject constructor(
     private val _lastSyncedAt = MutableStateFlow<Long?>(null)
     val lastSyncedAt: StateFlow<Long?> = _lastSyncedAt.asStateFlow()
 
+    /** One-shot messages for the Stats screen (e.g. "sign in to sync"). */
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 2)
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
+
     init {
         // Kick an initial refresh so the newly-redesigned Stats screen picks
         // up plays made on other devices. No-op if the user isn't signed in.
@@ -135,6 +142,11 @@ class StatsViewModel @Inject constructor(
 
     /** User-triggered refresh (pull-to-refresh gesture). */
     fun refresh() {
+        if (authManager.userProfile.value == null) {
+            // Explain the no-op instead of letting the spinner vanish silently.
+            _messages.tryEmit("Sign in to sync stats across devices")
+            return
+        }
         viewModelScope.launch { refreshFromCloudInternal(_range.value) }
     }
 

--- a/app/src/test/java/tf/monochrome/android/data/local/scanner/ArtworkRefreshDetectorTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/local/scanner/ArtworkRefreshDetectorTest.kt
@@ -1,0 +1,86 @@
+package tf.monochrome.android.data.local.scanner
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtworkRefreshDetectorTest {
+
+    private val cacheDir = "/data/user/0/tf.monochrome.android/cache/artwork"
+
+    @Test
+    fun `missing cache file is counted as evicted`() {
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf("$cacheDir/abc.jpg"),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { false },
+        )
+        assertEquals(1, evicted)
+    }
+
+    @Test
+    fun `intact cache files are not counted`() {
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf("$cacheDir/abc.jpg", "$cacheDir/def.jpg"),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { true },
+        )
+        assertEquals(0, evicted)
+    }
+
+    @Test
+    fun `missing sidecar outside the cache dir is ignored`() {
+        // cover.jpg on external storage: missing may just mean an unmounted
+        // SD card, which must never auto-trigger a (pruning) full scan.
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf("/storage/ABCD-1234/Music/Album/cover.jpg"),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { false },
+        )
+        assertEquals(0, evicted)
+    }
+
+    @Test
+    fun `sibling directory sharing the prefix is not matched`() {
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf("${cacheDir}_backup/abc.jpg"),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { false },
+        )
+        assertEquals(0, evicted)
+    }
+
+    @Test
+    fun `trailing slash on the cache dir path is normalized`() {
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf("$cacheDir/abc.jpg"),
+            artworkCacheDirPath = "$cacheDir/",
+            artworkFileExists = { false },
+        )
+        assertEquals(1, evicted)
+    }
+
+    @Test
+    fun `empty key list reports nothing evicted`() {
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = emptyList(),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { false },
+        )
+        assertEquals(0, evicted)
+    }
+
+    @Test
+    fun `mixed keys count only the evicted cache entries`() {
+        val gone = "$cacheDir/gone.jpg"
+        val evicted = ArtworkRefreshDetector.countEvictedArtwork(
+            cachedKeys = listOf(
+                gone,                                        // evicted → counted
+                "$cacheDir/present.jpg",                     // intact → skipped
+                "/storage/emulated/0/Music/x/cover.jpg",     // sidecar → skipped
+            ),
+            artworkCacheDirPath = cacheDir,
+            artworkFileExists = { it != gone },
+        )
+        assertEquals(1, evicted)
+    }
+}


### PR DESCRIPTION
## Summary

This branch started as a fix for local-file album art vanishing after cache eviction, and grew into a full remediation of the UI/UX audit. It clears the confirmed findings across eight priority tiers — correctness, feedback, gestures, accessibility, subsystems, state/lifecycle, performance, and reachability — on top of the original album-art fix.

**30 commits · 84 files · +2,767 / −738.** Every batch was compiled on CI (debug build + unit tests) before the next landed; the branch is green end to end.

---

## The original fix — local album art auto-restore

Embedded covers are extracted to `cacheDir/artwork` at scan time, but Android reaps that directory under storage pressure (and the in-app Clear-cache button wipes it), leaving Room rows pointing at vanished JPGs. Nothing re-triggered extraction without a manual Library refresh, so local files showed placeholders after every app reload.

- **`ArtworkRefreshDetector`**: on app start, probes the distinct artwork cache keys and kicks a scan if any cache file is gone. `needsReRead()` re-extracts art for exactly the broken rows, so an intact library passes through fast. Only keys inside our own cache dir are probed — a missing sidecar cover can just mean an unmounted SD card, which must never auto-trigger a pruning scan.
- Runs the same repair right after Settings → Clear cache / Clear all data, so covers come back without waiting for the next launch.
- `TagReader` recreates the artwork dir before writing a cover (the lazy `mkdirs` ran once per process, so a mid-process cache wipe silently failed every write).
- Unit tests for the eviction-detection logic.

---

## Audit remediation (P0–P7)

| Tier | Focus |
|---|---|
| **P0** | Crashes, silent data-loss, and a payment that could complete without saving the subscription |
| **P1** | Silent-error → Snackbar/toast feedback across import/save flows; destructive-action confirmations; hardcoded-white → theme colors (light-theme visibility); layout overflow / insets / large-font-scale clipping |
| **P2** | Gesture correctness (stale captures, touch-slop before consuming, relative drag) and commit-on-finish for sliders/seek bars |
| **P3** | Accessibility semantics (progress/adjustable/button/toggle) and 48dp touch targets on the custom Canvas controls — faders, knobs, seek tube, mute/solo, overlay buttons |
| **P4** | Subsystem reworks: search paging, queue reorder/delete, playlist CRUD, download failure states |
| **P5** | State preservation (`rememberSaveable`), back-handling, lifecycle scoping, live data, OAuth-cancel recovery, sign-in form retention |
| **P6** | Cut per-frame recompositions (animated values read in the draw phase) and moved recursive cache/dir IO off the main thread |
| **P7** | Reachability: mechanical fixes + wiring two fully-built-but-unreachable features |

### Subsystem highlights
- **Search paging** — reworked around a per-query generation token + per-type jobs: no cross-query result bleed, no dead infinite-scroll after page 1, no reshuffling of already-scrolled items; a total-backend-failure now shows an error + retry instead of "No results".
- **Queue** — deleting the currently playing track re-syncs the player to the new current track; reorder tracks the current index positionally (duplicate-safe); drop index is computed from real laid-out geometry; stable per-row keys; long-press no longer both starts a drag and opens the context menu.
- **Downloads** — failed downloads are surfaced with a retry action instead of vanishing; the aggregate progress ring stops jumping backwards when a download completes; the music-note fallback shows on a failed image load, not just a null URL.

### P7 product decisions (as agreed)
- **Wired up:** guided Measurement Upload (entry in the EQ screen) and recent-search history (now in the reachable Home search).
- **Left as dead code (not deleted):** Collections, Listening Stats, Car Mode, Material You.
- **Mechanical fixes:** Create-playlist button enabled on a valid name; "Restart onboarding" reopens at Welcome; OAuth cold-start deep-links handled from `onCreate`; local-row 48dp target; EQ live-spectrum layering; double-tap double-navigation guarded in the shared artist/album nav helpers.

---

## Deliberately deferred (documented in the commits, not dropped)

- **Player-route FFT-rate recompose** — needs `State<FloatArray>` threaded through the `PlayerHero → SpectrumOverlay` hierarchy plus on-device before/after profiling. (The visualizer half of this class was fixed in P6.)
- **`navigateSafe` on the remaining ~64 raw `navigate()` calls** — the 21 high-traffic artist/album navigations are done via the shared helpers.
- **Full context-menu parity for local album/artist rows and the queue long-press menu** — both need action callbacks (play-next / like / add-to-playlist / download / share) plumbed into those surfaces.
- **Car-mode-only items** — moot until that screen is given an entry point.

---

## Testing

The debug build + unit tests ran on CI for every batch and are green on the final commit. There is no Android SDK in the dev environment, so the gesture, TalkBack, and performance changes (P2/P3/P6) still warrant a pass on a real device — the individual commit messages flag which changes those are.