### PR TITLE
Per-ear AutoEQ, APO profile import, refined fitting engine (1.8.2)

### DIFF
--- a/.claude/skills/player-visuals-themes/SKILL.md
+++ b/.claude/skills/player-visuals-themes/SKILL.md
@@ -126,7 +126,7 @@ default (2 / 0 / 0).
 | Field | Range | Default | Visual effect |
 |---|---|---|---|
 | `enabled` | bool | true | Master button-glass toggle. **False = flat buttons.** |
-| `bodyOpacity` | 0.2..1 | 0.5 | Glass body see-through amount. Low = ghost/invisible-ink. |
+| `bodyOpacity` | 0..1 | 0.5 | Glass body see-through amount. Low = ghost/invisible-ink; 0 = body fully invisible (edges/rim remain). |
 | `refraction` | 0..0.4 | 0.16 | Bevel lensing of the backdrop. 0.4 + high depth/dispersion = diamond. |
 | `rimBrightness` | 0..2 | 1.3 | Lit specular rim brightness. |
 | `dispersion` | 0..2 | 1.2 | Chromatic aberration at edges. |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = "tf.monotrypt.android"
         minSdk = 26
         targetSdk = 36
-        versionCode = 181
-        versionName = "1.8.1"
+        versionCode = 182
+        versionName = "1.8.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
@@ -82,9 +82,25 @@ object AutoEqEngine {
         sampleRate: Float = DEFAULT_SAMPLE_RATE
     ): Float {
         if (!band.enabled) return 0f
-
-        val w0 = 2.0 * PI * band.freq.toDouble() / sampleRate.toDouble()
+        val c = coeffsFor(band, sampleRate)
         val phi = 2.0 * PI * freqHz.toDouble() / sampleRate.toDouble()
+        return magnitudeDb(c, cos(phi), cos(2.0 * phi)).toFloat()
+    }
+
+    /**
+     * Normalized RBJ coefficients for a band. Split out of the response
+     * calculation because they are FIXED per band — only the phase term varies
+     * per evaluation frequency. The refinement pass exploits this: coefficients
+     * once per candidate, then a transcendental-free magnitude per grid point
+     * against precomputed cos(φ)/cos(2φ) tables.
+     */
+    private class BiquadCoeffs(
+        val b0: Double, val b1: Double, val b2: Double,
+        val a1: Double, val a2: Double,
+    )
+
+    private fun coeffsFor(band: EqBand, sampleRate: Float): BiquadCoeffs {
+        val w0 = 2.0 * PI * band.freq.toDouble() / sampleRate.toDouble()
         val alpha = sin(w0) / (2.0 * band.q.toDouble())
         val A = 10.0.pow(band.gain.toDouble() / 40.0)
         val cosW0 = cos(w0)
@@ -122,18 +138,17 @@ object AutoEqEngine {
                 a2 = 1.0 - alpha / A
             }
         }
-
         val inv = 1.0 / a0
-        val b0n = b0 * inv; val b1n = b1 * inv; val b2n = b2 * inv
-        val a1n = a1 * inv; val a2n = a2 * inv
+        return BiquadCoeffs(b0 * inv, b1 * inv, b2 * inv, a1 * inv, a2 * inv)
+    }
 
-        val cp = cos(phi); val c2p = cos(2.0 * phi)
-        val num = b0n*b0n + b1n*b1n + b2n*b2n +
-                  2.0*(b0n*b1n + b1n*b2n)*cp + 2.0*b0n*b2n*c2p
-        val den = 1.0 + a1n*a1n + a2n*a2n +
-                  2.0*(a1n + a1n*a2n)*cp + 2.0*a2n*c2p
-
-        return (10.0 * log10(num / den)).toFloat()
+    /** |H| in dB at a grid point, given cos(φ) and cos(2φ). Pure arithmetic. */
+    private fun magnitudeDb(c: BiquadCoeffs, cp: Double, c2p: Double): Double {
+        val num = c.b0 * c.b0 + c.b1 * c.b1 + c.b2 * c.b2 +
+            2.0 * (c.b0 * c.b1 + c.b1 * c.b2) * cp + 2.0 * c.b0 * c.b2 * c2p
+        val den = 1.0 + c.a1 * c.a1 + c.a2 * c.a2 +
+            2.0 * (c.a1 + c.a1 * c.a2) * cp + 2.0 * c.a2 * c2p
+        return 10.0 * log10(num / den)
     }
 
     private fun interpolate(freq: Float, data: List<FrequencyPoint>): Float {
@@ -213,12 +228,7 @@ object AutoEqEngine {
                 }
 
                 // Priority weighting
-                val priority = when {
-                    freq < 300.0  -> 1.5
-                    freq < 4000.0 -> 1.0
-                    freq < 8000.0 -> 0.5
-                    else          -> 0.25
-                }
+                val priority = priorityWeight(freq)
 
                 val weightedAbs = abs(v * priority)
                 if (weightedAbs > abs(maxWeightedDev)) {
@@ -289,8 +299,146 @@ object AutoEqEngine {
             }
         }
 
+        // Cyclic refinement: the greedy loop froze each band at fit time, so
+        // early choices never adapt to later ones — exactly what starves
+        // low band counts. Re-fitting each band against the residual all the
+        // OTHERS leave lets a small stack cooperate like a jointly-optimized
+        // one.
+        refineBands(bands, error, minFrequency, maxFrequency, sampleRate)
+
         // Sort by frequency, re-index
         return bands.sortedBy { it.freq }.mapIndexed { idx, b -> b.copy(id = idx) }
+    }
+
+    private fun priorityWeight(freq: Double): Double = when {
+        freq < 300.0  -> 1.5
+        freq < 4000.0 -> 1.0
+        freq < 8000.0 -> 0.5
+        else          -> 0.25
+    }
+
+    /** Frequency-dependent boost/cut clamp shared by the greedy fit and refinement. */
+    private fun clampGain(g: Double, type: FilterType, freq: Double): Double {
+        val boostCap = when {
+            type == FilterType.LOWSHELF -> MAX_BOOST
+            type == FilterType.HIGHSHELF -> 4.0
+            freq > 6000.0 -> 3.0
+            freq > 3000.0 -> 6.0
+            else -> MAX_BOOST
+        }
+        return g.coerceIn(-MAX_CUT, boostCap)
+    }
+
+    /**
+     * Cyclic coordinate descent over the fitted stack (a few sweeps):
+     * for each band, remove its response from the residual, then re-fit it on
+     * what the OTHER bands actually leave behind — frequency and Q over a
+     * local log-grid (shelves keep their corner and slope; only their gain
+     * refits), gain in closed form by weighted least squares. The dB response
+     * of an RBJ filter is near-linear in its gain setting for the ranges used
+     * here, which is what makes the closed-form gain valid; candidates are
+     * still SCORED with the exact response, so the approximation only picks
+     * the search point, never the final answer. Bands another band fully
+     * absorbed (|gain| < 0.2 dB) are dropped rather than left as noise.
+     */
+    private fun refineBands(
+        bands: MutableList<EqBand>,
+        residual: MutableList<FrequencyPoint>,
+        minFrequency: Float,
+        maxFrequency: Float,
+        sampleRate: Float,
+        sweeps: Int = 4,
+    ) {
+        if (bands.isEmpty()) return
+        val n = residual.size
+
+        // Phase tables: cos(φ)/cos(2φ) per grid point, computed ONCE. Every
+        // candidate evaluation after this is pure arithmetic — the win that
+        // makes a wide candidate grid and multiple sweeps cost milliseconds.
+        val cp = DoubleArray(n)
+        val c2p = DoubleArray(n)
+        val weights = DoubleArray(n)
+        for (j in 0 until n) {
+            val phi = 2.0 * PI * residual[j].freq.toDouble() / sampleRate.toDouble()
+            cp[j] = cos(phi)
+            c2p[j] = cos(2.0 * phi)
+            val f = residual[j].freq.toDouble()
+            weights[j] = if (f < minFrequency || f > maxFrequency) 0.0 else priorityWeight(f)
+        }
+        val res = DoubleArray(n) { residual[it].gain.toDouble() }
+
+        var prevTotal = Double.MAX_VALUE
+        for (sweep in 0 until sweeps) {
+            for (k in bands.indices) {
+                val band = bands[k]
+                // Residual with band k's contribution removed.
+                val ck = coeffsFor(band, sampleRate)
+                val eWo = DoubleArray(n)
+                for (j in 0 until n) eWo[j] = res[j] - magnitudeDb(ck, cp[j], c2p[j])
+
+                // ±half-octave in frequency, 0.5–2× in Q — wide enough to walk
+                // out of a bad greedy seed over a few sweeps.
+                val freqCands: List<Float>
+                val qCands: List<Float>
+                if (band.type == FilterType.PEAKING) {
+                    freqCands = listOf(0.71f, 0.84f, 1f, 1.19f, 1.41f)
+                        .map { (band.freq * it).coerceIn(minFrequency, maxFrequency) }
+                        .distinct()
+                    qCands = listOf(0.5f, 0.7f, 1f, 1.4f, 2f)
+                        .map { (band.q * it).coerceIn(MIN_Q.toFloat(), MAX_Q.toFloat()) }
+                        .distinct()
+                } else {
+                    freqCands = listOf(band.freq)
+                    qCands = listOf(band.q)
+                }
+
+                var best = band
+                var bestScore = Double.MAX_VALUE
+                for (fc in freqCands) for (qc0 in qCands) {
+                    var qc = qc0
+                    if (band.type == FilterType.PEAKING && fc > 5000f && qc > 3f) qc = 3f
+
+                    // Closed-form gain from the +1 dB basis shape (RBJ dB
+                    // response is near-linear in gain at these ranges); the
+                    // exact response still does the scoring below.
+                    val cProbe = coeffsFor(band.copy(freq = fc, q = qc, gain = 1f), sampleRate)
+                    var num = 0.0
+                    var den = 1e-9
+                    for (j in 0 until n) {
+                        val sj = magnitudeDb(cProbe, cp[j], c2p[j])
+                        num += weights[j] * eWo[j] * sj
+                        den += weights[j] * sj * sj
+                    }
+                    var g = clampGain(-num / den, band.type, fc.toDouble())
+                    if (band.type == FilterType.PEAKING && g > 0.0 && qc > 2f) qc = 2f
+                    val cand = band.copy(freq = fc, q = qc, gain = g.toFloat())
+
+                    val cCand = coeffsFor(cand, sampleRate)
+                    var score = 0.0
+                    for (j in 0 until n) {
+                        val r = eWo[j] + magnitudeDb(cCand, cp[j], c2p[j])
+                        score += weights[j] * r * r
+                    }
+                    if (score < bestScore) {
+                        bestScore = score
+                        best = cand
+                    }
+                }
+
+                bands[k] = best
+                val cBest = coeffsFor(best, sampleRate)
+                for (j in 0 until n) res[j] = eWo[j] + magnitudeDb(cBest, cp[j], c2p[j])
+            }
+
+            // Converged? Stop early rather than burning identical sweeps.
+            var total = 0.0
+            for (j in 0 until n) total += weights[j] * res[j] * res[j]
+            if (prevTotal - total < prevTotal * 0.005) break
+            prevTotal = total
+        }
+
+        for (j in 0 until n) residual[j] = FrequencyPoint(residual[j].freq, res[j].toFloat())
+        bands.removeAll { abs(it.gain) < 0.2f }
     }
 
     /**

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
@@ -20,36 +20,33 @@ import kotlin.math.max
 object AutoEqEngine {
 
     /**
-     * Fractional-octave smoothing (the family squig.link/REW use): each point
-     * becomes a gaussian-weighted average of its neighbours within
-     * ±[octaves]/2 on the log-frequency axis. 0 (or too few points) returns
-     * the input untouched. Tames rig artefacts and narrow unit-to-unit jitter
-     * so the optimizer corrects the audible trend instead of burning bands on
-     * spikes that don't survive a reseat of the headphone.
+     * Measurement smoothing, ported verbatim from SeapEngine's graph tool
+     * (the `a7` helper): a triangular-weighted moving average whose window
+     * radius grows with the 0–100 % slider — radius = floor(percent / 2.5)
+     * POINTS, weights 1 − |offset|/(radius+1). Index-based on purpose:
+     * measurement files are log-spaced in frequency, so a point window IS an
+     * octave window, and matching SeapEngine exactly means a profile tuned
+     * there reproduces identically here. 0 % (or <3 points) is a no-op.
      */
     fun smoothCurve(
         points: List<FrequencyPoint>,
-        octaves: Float,
+        percent: Float,
     ): List<FrequencyPoint> {
-        if (octaves <= 0f || points.size < 3) return points
-        val logs = FloatArray(points.size) { kotlin.math.log2(points[it].freq) }
-        val half = octaves / 2f
-        val sigma = octaves / 4f
+        if (percent <= 0f || points.size < 3) return points
+        val radius = kotlin.math.max(1, (percent / 2.5f).toInt())
         val out = ArrayList<FrequencyPoint>(points.size)
-        var lo = 0
         for (i in points.indices) {
-            while (lo < points.size && logs[lo] < logs[i] - half) lo++
-            var j = lo
+            var sum = 0f
             var wSum = 0f
-            var vSum = 0f
-            while (j < points.size && logs[j] <= logs[i] + half) {
-                val d = (logs[j] - logs[i]) / sigma
-                val w = kotlin.math.exp(-0.5f * d * d)
-                wSum += w
-                vSum += w * points[j].gain
-                j++
+            for (c in -radius..radius) {
+                val j = i + c
+                if (j in points.indices) {
+                    val w = 1f - kotlin.math.abs(c).toFloat() / (radius + 1)
+                    sum += points[j].gain * w
+                    wSum += w
+                }
             }
-            out.add(FrequencyPoint(points[i].freq, if (wSum > 0f) vSum / wSum else points[i].gain))
+            out.add(FrequencyPoint(points[i].freq, sum / wSum))
         }
         return out
     }

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
@@ -17,6 +17,25 @@ import kotlin.math.max
  * AutoEqEngine — Headphone correction filter generator.
  * Greedy iterative algorithm matching the SeapEngine implementation.
  */
+/**
+ * How the correction stack is fitted.
+ *
+ * [PEAKING] — the classic greedy fit: every band is a bell, including at the
+ * frequency extremes.
+ *
+ * [SHELF_ENDS] — fits a low shelf and a high shelf FIRST, then bells on the
+ * residual. Engineering rationale: headphone deviations at the extremes are
+ * broad tilts (bass roll-off/boost, treble tilt), not resonances — a shelf
+ * matches that shape with one filter where bells leave ripple, extrapolates
+ * gracefully below/above the measurement's reliable range (rig bass data
+ * under ~40 Hz is seal-dependent noise), and carries no resonant overshoot
+ * into the preamp headroom budget.
+ */
+enum class AutoEqAlgorithm(val label: String) {
+    PEAKING("Peaking"),
+    SHELF_ENDS("Shelf ends"),
+}
+
 object AutoEqEngine {
 
     /**
@@ -143,7 +162,8 @@ object AutoEqEngine {
         maxFrequency: Float = 16000f,
         minFrequency: Float = 20f,
         @Suppress("UNUSED_PARAMETER") maxQ: Float = MAX_Q.toFloat(),
-        sampleRate: Float = DEFAULT_SAMPLE_RATE
+        sampleRate: Float = DEFAULT_SAMPLE_RATE,
+        algorithm: AutoEqAlgorithm = AutoEqAlgorithm.PEAKING,
     ): List<EqBand> {
         val offset = getNormalizationOffset(target) - getNormalizationOffset(measurement)
 
@@ -154,7 +174,28 @@ object AutoEqEngine {
 
         val bands = mutableListOf<EqBand>()
 
-        for (i in 0 until bandCount) {
+        if (algorithm == AutoEqAlgorithm.SHELF_ENDS) {
+            // Low shelf: corner at AutoEq's conventional 105 Hz, gain fitted to
+            // the mean error below it. Full ±12 range — bass boosts are the
+            // shelf's whole job.
+            fitEndShelf(
+                error, FilterType.LOWSHELF,
+                corner = 105f, regionLo = minFrequency, regionHi = 105f,
+                maxBoost = MAX_BOOST, sampleRate = sampleRate, id = bands.size,
+            )?.let(bands::add)
+            // High shelf: corner at 10 kHz (pulled down when the fit range
+            // ends earlier). Boost capped at 4 dB — the plateau spans the
+            // whole top octave, where measurement confidence and hearing-
+            // damage risk both argue for restraint; cuts keep the full range.
+            val hiCorner = kotlin.math.min(10_000f, maxFrequency * 0.75f)
+            fitEndShelf(
+                error, FilterType.HIGHSHELF,
+                corner = hiCorner, regionLo = hiCorner, regionHi = maxFrequency,
+                maxBoost = 4.0, sampleRate = sampleRate, id = bands.size,
+            )?.let(bands::add)
+        }
+
+        while (bands.size < bandCount) {
             var maxDev = 0.0
             var maxWeightedDev = 0.0
             var peakFreq = 1000.0
@@ -232,7 +273,7 @@ object AutoEqEngine {
             if (gain > 0.0 && q > 2.0) q = 2.0          // boost safety
 
             val newBand = EqBand(
-                id = i,
+                id = bands.size,
                 type = FilterType.PEAKING,
                 freq = peakFreq.toFloat(),
                 gain = gain.toFloat(),
@@ -250,5 +291,53 @@ object AutoEqEngine {
 
         // Sort by frequency, re-index
         return bands.sortedBy { it.freq }.mapIndexed { idx, b -> b.copy(id = idx) }
+    }
+
+    /**
+     * Fits one end shelf to the mean residual error over [regionLo, regionHi]
+     * and subtracts its real (RBJ) response from the error curve. Returns null
+     * when the region is empty or the fitted gain is below 1 dB — a broadband
+     * tilt under 1 dB sits at the just-noticeable difference, and residual
+     * sub-dB offsets also appear spuriously whenever midband normalization
+     * shifts the whole curve. Not worth a filter slot either way.
+     */
+    private fun fitEndShelf(
+        error: MutableList<FrequencyPoint>,
+        type: FilterType,
+        corner: Float,
+        regionLo: Float,
+        regionHi: Float,
+        maxBoost: Double,
+        sampleRate: Float,
+        id: Int,
+    ): EqBand? {
+        var sum = 0.0
+        var count = 0
+        for (p in error) {
+            if (p.freq in regionLo..regionHi) {
+                sum += p.gain
+                count++
+            }
+        }
+        if (count == 0) return null
+        var gain = -(sum / count)
+        if (gain > maxBoost) gain = maxBoost
+        if (gain < -MAX_CUT) gain = -MAX_CUT
+        if (abs(gain) < 1.0) return null
+
+        // Butterworth shoulder: monotonic, no corner overshoot to re-correct.
+        val band = EqBand(
+            id = id,
+            type = type,
+            freq = corner,
+            gain = gain.toFloat(),
+            q = 0.707f,
+            enabled = true,
+        )
+        for (j in error.indices) {
+            val response = calculateBiquadResponse(error[j].freq, band, sampleRate)
+            error[j] = FrequencyPoint(error[j].freq, error[j].gain + response)
+        }
+        return band
     }
 }

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
@@ -19,6 +19,41 @@ import kotlin.math.max
  */
 object AutoEqEngine {
 
+    /**
+     * Fractional-octave smoothing (the family squig.link/REW use): each point
+     * becomes a gaussian-weighted average of its neighbours within
+     * ±[octaves]/2 on the log-frequency axis. 0 (or too few points) returns
+     * the input untouched. Tames rig artefacts and narrow unit-to-unit jitter
+     * so the optimizer corrects the audible trend instead of burning bands on
+     * spikes that don't survive a reseat of the headphone.
+     */
+    fun smoothCurve(
+        points: List<FrequencyPoint>,
+        octaves: Float,
+    ): List<FrequencyPoint> {
+        if (octaves <= 0f || points.size < 3) return points
+        val logs = FloatArray(points.size) { kotlin.math.log2(points[it].freq) }
+        val half = octaves / 2f
+        val sigma = octaves / 4f
+        val out = ArrayList<FrequencyPoint>(points.size)
+        var lo = 0
+        for (i in points.indices) {
+            while (lo < points.size && logs[lo] < logs[i] - half) lo++
+            var j = lo
+            var wSum = 0f
+            var vSum = 0f
+            while (j < points.size && logs[j] <= logs[i] + half) {
+                val d = (logs[j] - logs[i]) / sigma
+                val w = kotlin.math.exp(-0.5f * d * d)
+                wSum += w
+                vSum += w * points[j].gain
+                j++
+            }
+            out.add(FrequencyPoint(points[i].freq, if (wSum > 0f) vSum / wSum else points[i].gain))
+        }
+        return out
+    }
+
     private const val MAX_BOOST = 12.0
     private const val MAX_CUT = 12.0
     private const val MIN_Q = 0.6

--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqProcessor.kt
@@ -44,10 +44,11 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
     private data class Snapshot(
         val enabled: Boolean,
         val preampLinear: Float,
-        val bands: Array<BandState>
+        val bandsL: Array<BandState>,
+        val bandsR: Array<BandState>
     )
 
-    private val stateRef = AtomicReference(Snapshot(false, 1f, emptyArray()))
+    private val stateRef = AtomicReference(Snapshot(false, 1f, emptyArray(), emptyArray()))
     private var appliedSnapshot: Snapshot? = null
 
     // Per-band biquad filter state (audio thread only, rebuilt when bands change)
@@ -55,19 +56,38 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
     private var filtersR = arrayOf<BiquadFilter>()
     private var sampleRate = 44100.0
 
-    fun applyBands(bands: List<EqBand>, preamp: Float, enabled: Boolean) {
+    /** Same curve on both ears. */
+    fun applyBands(bands: List<EqBand>, preamp: Float, enabled: Boolean) =
+        applyBands(bands, bands, preamp, enabled)
+
+    /**
+     * Independent curves per channel, for per-ear headphone calibration.
+     *
+     * The two lists may differ in length — a left calibration with 10 filters
+     * and a right with 8 is entirely normal — so the filter chains are built
+     * and run separately rather than index-locked to each other.
+     */
+    fun applyBands(
+        bandsL: List<EqBand>,
+        bandsR: List<EqBand>,
+        preamp: Float,
+        enabled: Boolean,
+    ) {
+        fun List<EqBand>.toStates() = map { band ->
+            BandState(
+                freq = band.freq,
+                gain = band.gain,
+                q = band.q,
+                type = band.type,
+                enabled = band.enabled
+            )
+        }.toTypedArray()
+
         val snap = Snapshot(
             enabled = enabled,
             preampLinear = if (preamp == 0f) 1f else 10f.pow(preamp / 20f),
-            bands = bands.map { band ->
-                BandState(
-                    freq = band.freq,
-                    gain = band.gain,
-                    q = band.q,
-                    type = band.type,
-                    enabled = band.enabled
-                )
-            }.toTypedArray()
+            bandsL = bandsL.toStates(),
+            bandsR = bandsR.toStates()
         )
         stateRef.set(snap)
     }
@@ -152,7 +172,8 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
         val snap = stateRef.get()
         if (snap.enabled) {
             if (snap !== appliedSnapshot) {
-                rebuildFilters(snap.bands)
+                filtersL = buildChain(snap.bandsL)
+                filtersR = buildChain(snap.bandsR)
                 appliedSnapshot = snap
             }
             applyEq(numFrames, snap.preampLinear)
@@ -229,26 +250,26 @@ class AutoEqProcessor @Inject constructor() : AudioProcessor {
                 scratchR[i] *= preampLinear
             }
         }
-        // Biquad bands
-        for (i in filtersL.indices) {
-            filtersL[i].processBlock(scratchL, numFrames)
-            filtersR[i].processBlock(scratchR, numFrames)
-        }
+        // Biquad bands. Indexed per channel, NOT off a shared range: the two
+        // chains hold different filter counts whenever the ears are calibrated
+        // separately, and driving both from filtersL.indices would walk off the
+        // end of the shorter one on the audio thread.
+        for (i in filtersL.indices) filtersL[i].processBlock(scratchL, numFrames)
+        for (i in filtersR.indices) filtersR[i].processBlock(scratchR, numFrames)
     }
 
-    private fun rebuildFilters(bands: Array<BandState>) {
+    private fun buildChain(bands: Array<BandState>): Array<BiquadFilter> {
         val active = bands.filter { it.enabled && it.gain != 0f }
-        filtersL = Array(active.size) { BiquadFilter() }
-        filtersR = Array(active.size) { BiquadFilter() }
+        val chain = Array(active.size) { BiquadFilter() }
         for ((i, band) in active.withIndex()) {
             val type = when (band.type) {
                 FilterType.LOWSHELF -> BiquadType.LOW_SHELF
                 FilterType.HIGHSHELF -> BiquadType.HIGH_SHELF
                 else -> BiquadType.PEAKING
             }
-            filtersL[i].configure(type, sampleRate, band.freq.toDouble(), band.q.toDouble(), band.gain.toDouble())
-            filtersR[i].configure(type, sampleRate, band.freq.toDouble(), band.q.toDouble(), band.gain.toDouble())
+            chain[i].configure(type, sampleRate, band.freq.toDouble(), band.q.toDouble(), band.gain.toDouble())
         }
+        return chain
     }
 
     // ── RBJ biquad (pure Kotlin, Transposed Direct Form II) ─────────────

--- a/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
@@ -105,8 +105,16 @@ class SquiglinkApi {
         withContext(Dispatchers.IO) { fetchChannel(host, fileName, channel) }
 
     private fun fetchChannel(host: String, fileName: String, channel: String): String? {
-        val name = URLEncoder.encode("$fileName $channel.txt", "UTF-8").replace("+", "%20")
-        return fetchUrl("$host/data/$name")
+        // Two live naming conventions. Single-sample instances publish
+        // "<name> L.txt"; multi-sample rigs number their sweeps with NO
+        // un-numbered alias — Listener's GRAS publishes only "<name> L1.txt" —
+        // so the first sample is the fallback. (Verified live: precog serves
+        // "… L.txt" and 404s "… L1.txt"; listener is the exact inverse.)
+        for (suffix in arrayOf(channel, "${channel}1")) {
+            val name = URLEncoder.encode("$fileName $suffix.txt", "UTF-8").replace("+", "%20")
+            fetchUrl("$host/data/$name")?.let { return it }
+        }
+        return null
     }
 
     fun clearCache() {

--- a/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
@@ -89,12 +89,25 @@ class SquiglinkApi {
     suspend fun fetchMeasurementText(host: String, fileName: String): String? =
         withContext(Dispatchers.IO) {
             for (channel in arrayOf("L", "R")) {
-                val name = URLEncoder.encode("$fileName $channel.txt", "UTF-8").replace("+", "%20")
-                val body = fetchUrl("$host/data/$name")
+                val body = fetchChannel(host, fileName, channel)
                 if (body != null) return@withContext body
             }
             null
         }
+
+    /**
+     * Fetch exactly ONE channel's FR text ("L" or "R"); null when that channel
+     * isn't published. No fallback on purpose — per-ear calibration needs to
+     * know the difference between "here is the right ear" and "here is
+     * whatever existed".
+     */
+    suspend fun fetchMeasurementChannelText(host: String, fileName: String, channel: String): String? =
+        withContext(Dispatchers.IO) { fetchChannel(host, fileName, channel) }
+
+    private fun fetchChannel(host: String, fileName: String, channel: String): String? {
+        val name = URLEncoder.encode("$fileName $channel.txt", "UTF-8").replace("+", "%20")
+        return fetchUrl("$host/data/$name")
+    }
 
     fun clearCache() {
         cachedHeadphones = null

--- a/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
+++ b/app/src/main/java/tf/monochrome/android/data/api/SquiglinkApi.kt
@@ -104,17 +104,69 @@ class SquiglinkApi {
     suspend fun fetchMeasurementChannelText(host: String, fileName: String, channel: String): String? =
         withContext(Dispatchers.IO) { fetchChannel(host, fileName, channel) }
 
-    private fun fetchChannel(host: String, fileName: String, channel: String): String? {
-        // Two live naming conventions. Single-sample instances publish
-        // "<name> L.txt"; multi-sample rigs number their sweeps with NO
-        // un-numbered alias — Listener's GRAS publishes only "<name> L1.txt" —
-        // so the first sample is the fallback. (Verified live: precog serves
-        // "… L.txt" and 404s "… L1.txt"; listener is the exact inverse.)
+    private fun fetchChannel(host: String, fileName: String, channel: String): String? =
+        fetchChannelWithSample(host, fileName, channel)?.first
+
+    /**
+     * Like [fetchMeasurementChannelText] but also reports WHICH sample file
+     * answered ("L" or "L1"), so the sample stepper knows its starting point.
+     *
+     * Two live naming conventions. Single-sample instances publish
+     * "<name> L.txt"; multi-sample rigs number their sweeps with NO
+     * un-numbered alias — Listener's GRAS publishes only "<name> L1.txt" —
+     * so the first sample is the fallback. (Verified live: precog serves
+     * "… L.txt" and 404s "… L1.txt"; listener is the exact inverse.)
+     */
+    suspend fun fetchMeasurementChannel(
+        host: String,
+        fileName: String,
+        channel: String,
+    ): Pair<String, String>? = withContext(Dispatchers.IO) {
+        fetchChannelWithSample(host, fileName, channel)
+    }
+
+    private fun fetchChannelWithSample(
+        host: String,
+        fileName: String,
+        channel: String,
+    ): Pair<String, String>? {
         for (suffix in arrayOf(channel, "${channel}1")) {
-            val name = URLEncoder.encode("$fileName $suffix.txt", "UTF-8").replace("+", "%20")
-            fetchUrl("$host/data/$name")?.let { return it }
+            fetchSampleUrl(host, fileName, suffix)?.let { return it to suffix }
         }
         return null
+    }
+
+    /** Fetch one exact sample file ("L2", "R3", …); null when not published. */
+    suspend fun fetchMeasurementSampleText(host: String, fileName: String, sample: String): String? =
+        withContext(Dispatchers.IO) { fetchSampleUrl(host, fileName, sample) }
+
+    /**
+     * Which sample files exist for a channel — probes "<name> L.txt" and
+     * "<name> L1..L6.txt" with HEAD requests (headers only, no body). Called
+     * lazily on first stepper use and cached by the caller, so browsing never
+     * pays for it.
+     */
+    suspend fun listSamples(host: String, fileName: String, channelPrefix: String): List<String> =
+        withContext(Dispatchers.IO) {
+            val candidates = listOf(channelPrefix) + (1..6).map { "$channelPrefix$it" }
+            candidates.filter { sampleExists(host, fileName, it) }
+        }
+
+    private fun fetchSampleUrl(host: String, fileName: String, sample: String): String? {
+        val name = URLEncoder.encode("$fileName $sample.txt", "UTF-8").replace("+", "%20")
+        return fetchUrl("$host/data/$name")
+    }
+
+    private fun sampleExists(host: String, fileName: String, sample: String): Boolean = try {
+        val name = URLEncoder.encode("$fileName $sample.txt", "UTF-8").replace("+", "%20")
+        val connection = (URL("$host/data/$name").openConnection() as java.net.HttpURLConnection).apply {
+            requestMethod = "HEAD"
+            connectTimeout = 8_000
+            readTimeout = 8_000
+        }
+        connection.responseCode == 200
+    } catch (_: Exception) {
+        false
     }
 
     fun clearCache() {

--- a/app/src/main/java/tf/monochrome/android/data/db/MusicDatabase.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/MusicDatabase.kt
@@ -68,7 +68,7 @@ import tf.monochrome.android.data.local.db.ScanStateEntity
         CollectionTrackArtistCrossRef::class,
         CollectionAlbumArtistCrossRef::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class MusicDatabase : RoomDatabase() {
@@ -122,6 +122,18 @@ abstract class MusicDatabase : RoomDatabase() {
                     "UPDATE local_tracks SET isDolbyAtmos = 1 " +
                         "WHERE title LIKE '%Dolby Atmos%' OR album LIKE '%Dolby Atmos%'"
                 )
+            }
+        }
+
+        /**
+         * v10 → v11: per-ear AutoEQ. Adds a nullable right-channel band list to
+         * saved EQ presets; NULL means a mono preset whose left list drives
+         * both ears, so every existing row stays valid as-is. A real migration
+         * so saved presets survive the upgrade.
+         */
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE eq_presets ADD COLUMN bandsRJson TEXT")
             }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/data/db/entity/Entities.kt
+++ b/app/src/main/java/tf/monochrome/android/data/db/entity/Entities.kt
@@ -181,6 +181,10 @@ data class EqPresetEntity(
     val name: String,
     val description: String = "",
     val bandsJson: String = "[]",  // Serialized List<EqBand>
+    // Right-channel bands for per-ear calibration; null = mono preset (the
+    // left list drives both ears). Nullable so every pre-v11 row is a valid
+    // mono preset with no data rewrite.
+    val bandsRJson: String? = null,
     val preamp: Float = 0f,
     val targetId: String = "",
     val targetName: String = "",

--- a/app/src/main/java/tf/monochrome/android/data/import_/ApoProfileParser.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/ApoProfileParser.kt
@@ -75,6 +75,9 @@ object ApoProfileParser {
     private val GAIN = keyword("Gain")
     private val Q = keyword("Q")
 
+    private val FILTER_TOKEN = Regex("(?i)Filter\\s*\\d+\\s*:")
+    private val PREAMP_TOKEN = Regex("(?i)Preamp\\s*:")
+
     /** Types with a direct [FilterType] equivalent. */
     private val PEAKING_CODES = setOf("PK", "PEQ", "EQ", "PEAKING")
     private val LOWSHELF_CODES = setOf("LS", "LSC", "LOWSHELF", "LSQ")
@@ -100,6 +103,7 @@ object ApoProfileParser {
         if (looksLikeMeasurementCsv(text)) {
             return ParsedEqProfile(looksLikeMeasurement = true)
         }
+        val prepared = ensureLineStructure(text)
 
         val warnings = mutableListOf<String>()
         val bands = mutableListOf<EqBand>()
@@ -109,7 +113,7 @@ object ApoProfileParser {
         var clampedGain = 0
         var clampedFreq = 0
 
-        for (raw in text.lineSequence()) {
+        for (raw in prepared.lineSequence()) {
             val line = raw.substringBefore('#').trim()
             if (line.isEmpty()) continue
 
@@ -143,7 +147,15 @@ object ApoProfileParser {
                 continue
             }
 
-            parseCsvBand(line, bands.size)?.let { bands += it }
+            parseCsvBand(line, bands.size)?.let { csv ->
+                // CSV rows go through the same clamp accounting as filter lines.
+                var b = csv
+                if (kotlin.math.abs(b.gain) > maxBandGainDb) {
+                    clampedGain++
+                    b = b.copy(gain = b.gain.coerceIn(-maxBandGainDb, maxBandGainDb))
+                }
+                bands += b
+            }
         }
 
         if (bands.isEmpty()) {
@@ -173,6 +185,24 @@ object ApoProfileParser {
         }
 
         return ParsedEqProfile(bands = bands, preamp = preamp, warnings = warnings)
+    }
+
+    /**
+     * Chat, web and PDF copies routinely strip a profile's newlines, gluing the
+     * comment header and every filter into one line — where the first '#'
+     * would swallow the whole text and zero filters would parse. When there
+     * are clearly more Filter tokens than lines, rebuild the structure by
+     * starting a fresh line at every Filter/Preamp token. Well-formed files
+     * are left untouched (their token count never exceeds their line count).
+     */
+    private fun ensureLineStructure(text: String): String {
+        val filters = FILTER_TOKEN.findAll(text).count()
+        if (filters <= 1) return text
+        val lines = text.count { it == '\n' } + 1
+        if (lines >= filters) return text
+        var rebuilt = FILTER_TOKEN.replace(text) { "\n" + it.value }
+        rebuilt = PREAMP_TOKEN.replace(rebuilt) { "\n" + it.value }
+        return rebuilt
     }
 
     private fun preampFor(bands: List<EqBand>): Float =

--- a/app/src/main/java/tf/monochrome/android/data/import_/ApoProfileParser.kt
+++ b/app/src/main/java/tf/monochrome/android/data/import_/ApoProfileParser.kt
@@ -1,0 +1,258 @@
+package tf.monochrome.android.data.import_
+
+import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.FilterType
+import kotlin.math.max
+
+/**
+ * Result of reading an EqualizerAPO-style parametric profile.
+ *
+ * [warnings] is the honest record of everything the parser changed or dropped.
+ * An EQ profile is invisible until it plays, and a silently mangled import is
+ * *audible* — so nothing is fixed up quietly; every clamp and skip is reported
+ * for the UI to show before the user commits.
+ */
+data class ParsedEqProfile(
+    val bands: List<EqBand> = emptyList(),
+    val preamp: Float = 0f,
+    val warnings: List<String> = emptyList(),
+    /**
+     * True when the text is an AutoEq *measurement* CSV (a frequency-response
+     * curve) rather than a filter list. Those are a legitimate thing to be
+     * handed — they're what AutoEq publishes alongside the PEQ file — and the
+     * app already imports them elsewhere, so this steers the caller there
+     * instead of failing with "no filters found".
+     */
+    val looksLikeMeasurement: Boolean = false,
+) {
+    val isEmpty: Boolean get() = bands.isEmpty()
+
+    /**
+     * Preamp that would just prevent the summed boost from clipping. Only a
+     * suggestion — files usually carry their own, and AutoEq's is computed
+     * against the full response rather than the naive peak used here.
+     */
+    val suggestedPreamp: Float
+        get() = -max(0f, bands.filter { it.enabled }.maxOfOrNull { it.gain } ?: 0f)
+}
+
+/**
+ * Parses EqualizerAPO `ParametricEQ.txt` profiles and simple band CSVs.
+ *
+ * This is the inverse of `buildParametricEqText` in EqualizerScreen, but is
+ * deliberately far more tolerant than that writer, because files reach users
+ * from many generators — AutoEq, oratory1990, Squiglink, Wavelet, Poweramp —
+ * and each has its own dialect:
+ *
+ *  - Type aliases: `PK`/`PEQ`/`EQ`, `LS`/`LSC`, `HS`/`HSC`.
+ *  - Slope-qualified shelves: `Filter 1: ON LSC 12 dB Fc 105 Hz ...`.
+ *  - `Filter 5: ON None` placeholders, which APO writes for unused slots.
+ *  - `OFF` filters, which are kept as disabled bands rather than dropped —
+ *    discarding them would silently renumber everything after them.
+ *  - EU locales writing `-2,9` instead of `-2.9`.
+ *
+ * Fields are located by keyword (`Fc`, `Gain`, `Q`) rather than by position,
+ * so a generator that reorders them still parses.
+ *
+ * Pure Kotlin with no Android dependencies, so the dialect handling above is
+ * covered by JVM unit tests rather than only being exercised on a device.
+ */
+object ApoProfileParser {
+
+    private val FILTER_LINE = Regex(
+        """^\s*Filter\s*(\d*)\s*:\s*(ON|OFF)?\s*([A-Za-z]+)""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val PREAMP_LINE = Regex(
+        """^\s*Preamp\s*:\s*([-+]?[\d.,]+)\s*dB""",
+        RegexOption.IGNORE_CASE,
+    )
+    private fun keyword(name: String) = Regex(
+        """\b$name\s+([-+]?[\d.,]+)""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val FC = keyword("Fc")
+    private val GAIN = keyword("Gain")
+    private val Q = keyword("Q")
+
+    /** Types with a direct [FilterType] equivalent. */
+    private val PEAKING_CODES = setOf("PK", "PEQ", "EQ", "PEAKING")
+    private val LOWSHELF_CODES = setOf("LS", "LSC", "LOWSHELF", "LSQ")
+    private val HIGHSHELF_CODES = setOf("HS", "HSC", "HIGHSHELF", "HSQ")
+
+    // Frequency bounds mirror EqLimits; duplicated as plain numbers to keep this
+    // parser free of UI-layer dependencies.
+    private const val MIN_FREQ = 20f
+    private const val MAX_FREQ = 20_000f
+    private const val MIN_Q = 0.05f
+    private const val MAX_Q = 20f
+
+    /**
+     * @param maxBandGainDb destination's per-band ceiling — the AutoEQ and
+     *   Parametric surfaces allow different amounts, and a profile imported
+     *   into the tighter one gets clamped (and warned about) rather than
+     *   being allowed to drive the biquad cascade into the limiter.
+     */
+    fun parse(text: String, maxBandGainDb: Float): ParsedEqProfile {
+        if (text.isBlank()) {
+            return ParsedEqProfile(warnings = listOf("The file is empty."))
+        }
+        if (looksLikeMeasurementCsv(text)) {
+            return ParsedEqProfile(looksLikeMeasurement = true)
+        }
+
+        val warnings = mutableListOf<String>()
+        val bands = mutableListOf<EqBand>()
+        var preamp = 0f
+        var sawPreamp = false
+        val unsupported = mutableListOf<String>()
+        var clampedGain = 0
+        var clampedFreq = 0
+
+        for (raw in text.lineSequence()) {
+            val line = raw.substringBefore('#').trim()
+            if (line.isEmpty()) continue
+
+            val preampMatch = PREAMP_LINE.find(line)
+            if (preampMatch != null) {
+                preamp = preampMatch.groupValues[1].toFloatOrNull2() ?: 0f
+                sawPreamp = true
+                continue
+            }
+
+            val header = FILTER_LINE.find(line)
+            if (header != null) {
+                parseFilterLine(header, line, bands.size)?.let { outcome ->
+                    when (outcome) {
+                        is FilterOutcome.Band -> {
+                            var b = outcome.band
+                            if (b.freq !in MIN_FREQ..MAX_FREQ) {
+                                clampedFreq++
+                                b = b.copy(freq = b.freq.coerceIn(MIN_FREQ, MAX_FREQ))
+                            }
+                            if (kotlin.math.abs(b.gain) > maxBandGainDb) {
+                                clampedGain++
+                                b = b.copy(gain = b.gain.coerceIn(-maxBandGainDb, maxBandGainDb))
+                            }
+                            bands += b.copy(q = b.q.coerceIn(MIN_Q, MAX_Q))
+                        }
+                        is FilterOutcome.Unsupported -> unsupported += outcome.label
+                        FilterOutcome.Placeholder -> Unit
+                    }
+                }
+                continue
+            }
+
+            parseCsvBand(line, bands.size)?.let { bands += it }
+        }
+
+        if (bands.isEmpty()) {
+            return ParsedEqProfile(
+                warnings = listOf(
+                    "No filters found. Expected EqualizerAPO lines like:\n" +
+                        "Filter 1: ON PK Fc 105 Hz Gain -2.9 dB Q 0.7"
+                )
+            )
+        }
+
+        if (unsupported.isNotEmpty()) {
+            warnings += "Skipped ${unsupported.size} unsupported " +
+                (if (unsupported.size == 1) "filter" else "filters") +
+                " (${unsupported.joinToString(", ")}) — only peaking and shelf filters apply here."
+        }
+        if (clampedGain > 0) {
+            warnings += "$clampedGain band gain(s) limited to ±${maxBandGainDb.toInt()} dB."
+        }
+        if (clampedFreq > 0) {
+            warnings += "$clampedFreq frequency(ies) clamped to 20 Hz–20 kHz."
+        }
+        if (!sawPreamp) {
+            warnings += "No preamp line — suggested ${"%.1f".format(preampFor(bands))} dB " +
+                "to keep the boost from clipping."
+            preamp = preampFor(bands)
+        }
+
+        return ParsedEqProfile(bands = bands, preamp = preamp, warnings = warnings)
+    }
+
+    private fun preampFor(bands: List<EqBand>): Float =
+        -max(0f, bands.filter { it.enabled }.maxOfOrNull { it.gain } ?: 0f)
+
+    private sealed interface FilterOutcome {
+        data class Band(val band: EqBand) : FilterOutcome
+        data class Unsupported(val label: String) : FilterOutcome
+        /** APO writes `None` for unused slots; not worth telling the user about. */
+        data object Placeholder : FilterOutcome
+    }
+
+    private fun parseFilterLine(
+        header: MatchResult,
+        line: String,
+        nextId: Int,
+    ): FilterOutcome? {
+        val enabled = !header.groupValues[2].equals("OFF", ignoreCase = true)
+        val code = header.groupValues[3].uppercase()
+        if (code == "NONE") return FilterOutcome.Placeholder
+
+        val type = when (code) {
+            in PEAKING_CODES -> FilterType.PEAKING
+            in LOWSHELF_CODES -> FilterType.LOWSHELF
+            in HIGHSHELF_CODES -> FilterType.HIGHSHELF
+            else -> return FilterOutcome.Unsupported(code)
+        }
+
+        val freq = FC.find(line)?.groupValues?.get(1)?.toFloatOrNull2() ?: return null
+        val gain = GAIN.find(line)?.groupValues?.get(1)?.toFloatOrNull2() ?: 0f
+        // Shelves without an explicit Q get the Butterworth default rather than
+        // 1.0 — a shelf at Q=1 overshoots visibly at the corner.
+        val defaultQ = if (type == FilterType.PEAKING) 1f else 0.707f
+        // `Q` also matches the "Q" inside nothing else on these lines, but a
+        // slope-qualified shelf ("LSC 12 dB") puts a bare number before Fc; the
+        // keyword search ignores it because it isn't preceded by Q.
+        val q = Q.find(line)?.groupValues?.get(1)?.toFloatOrNull2() ?: defaultQ
+
+        return FilterOutcome.Band(
+            EqBand(id = nextId, type = type, freq = freq, gain = gain, q = q, enabled = enabled)
+        )
+    }
+
+    /** `type,fc,gain,q` rows, header skipped. Order-sensitive by design — a bare CSV has no keywords to anchor on. */
+    private fun parseCsvBand(line: String, nextId: Int): EqBand? {
+        if (!line.contains(',')) return null
+        val cells = line.split(',').map { it.trim() }
+        if (cells.size < 4) return null
+        val type = when (cells[0].uppercase()) {
+            in PEAKING_CODES -> FilterType.PEAKING
+            in LOWSHELF_CODES -> FilterType.LOWSHELF
+            in HIGHSHELF_CODES -> FilterType.HIGHSHELF
+            else -> return null
+        }
+        val freq = cells[1].toFloatOrNull2() ?: return null
+        val gain = cells[2].toFloatOrNull2() ?: return null
+        val q = cells[3].toFloatOrNull2() ?: 1f
+        return EqBand(
+            id = nextId,
+            type = type,
+            freq = freq.coerceIn(MIN_FREQ, MAX_FREQ),
+            gain = gain,
+            q = q.coerceIn(MIN_Q, MAX_Q),
+        )
+    }
+
+    /**
+     * AutoEq publishes a frequency-response CSV next to the PEQ file, with a
+     * `frequency,raw,...` header. It's a curve, not filters — detected here so
+     * the caller can offer the measurement importer instead of reporting a
+     * parse failure on a perfectly valid file.
+     */
+    private fun looksLikeMeasurementCsv(text: String): Boolean {
+        val head = text.lineSequence().firstOrNull { it.isNotBlank() }?.lowercase() ?: return false
+        if (!head.contains(',')) return false
+        return head.contains("frequency") &&
+            (head.contains("raw") || head.contains("target") || head.contains("smoothed"))
+    }
+
+    /** Accepts EU decimal commas alongside dots. */
+    private fun String.toFloatOrNull2(): Float? =
+        replace(',', '.').trim().toFloatOrNull()
+}

--- a/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
+++ b/app/src/main/java/tf/monochrome/android/data/preferences/PreferencesManager.kt
@@ -230,6 +230,12 @@ class PreferencesManager @Inject constructor(
         private val EQ_TARGET_ID = stringPreferencesKey("eq_target_id")
         private val EQ_PREAMP = doublePreferencesKey("eq_preamp")
         private val EQ_BANDS_JSON = stringPreferencesKey("eq_bands_json")
+        // Per-ear AutoEQ: right-channel bands + the 2-channel switch. The R
+        // list persists even while the switch is off, so toggling stereo off
+        // and back on is non-destructive.
+        private val EQ_BANDS_R_JSON = stringPreferencesKey("eq_bands_r_json")
+        private val EQ_STEREO_MODE = booleanPreferencesKey("eq_stereo_mode")
+        private val EQ_MEASUREMENT_R_JSON = stringPreferencesKey("eq_measurement_r_json")
         private val EQ_CUSTOM_TARGETS_JSON = stringPreferencesKey("eq_custom_targets_json")
         private val EQ_SELECTED_HEADPHONE_ID = stringPreferencesKey("eq_selected_headphone_id")
         private val EQ_SELECTED_HEADPHONE_NAME = stringPreferencesKey("eq_selected_headphone_name")
@@ -328,6 +334,7 @@ class PreferencesManager @Inject constructor(
             EQ_ENABLED, EQ_ACTIVE_PRESET_ID, EQ_TARGET_ID, EQ_PREAMP, EQ_BANDS_JSON,
             EQ_CUSTOM_TARGETS_JSON, EQ_SELECTED_HEADPHONE_ID, EQ_SELECTED_HEADPHONE_NAME,
             EQ_UPLOADED_HEADPHONES_JSON, EQ_AUTO_PREAMP,
+            EQ_BANDS_R_JSON, EQ_STEREO_MODE,
             PARAM_EQ_ENABLED, PARAM_EQ_ACTIVE_PRESET_ID, PARAM_EQ_PREAMP, PARAM_EQ_BANDS_JSON,
             DSP_ENABLED, DSP_STATE_JSON, MIXER_CHANNEL_DYNAMIC,
             SCAN_ON_APP_OPEN, MIN_TRACK_DURATION_MS, BACKGROUND_SCAN_INTERVAL,
@@ -1025,6 +1032,8 @@ class PreferencesManager @Inject constructor(
     val eqPreamp: Flow<Double> = dataStore.data.map { it[EQ_PREAMP] ?: 0.0 }
     val eqAutoPreamp: Flow<Boolean> = dataStore.data.map { it[EQ_AUTO_PREAMP] ?: false }
     val eqBandsJson: Flow<String?> = dataStore.data.map { it[EQ_BANDS_JSON] }
+    val eqBandsRJson: Flow<String?> = dataStore.data.map { it[EQ_BANDS_R_JSON] }
+    val eqStereoMode: Flow<Boolean> = dataStore.data.map { it[EQ_STEREO_MODE] ?: false }
 
     /** System-wide AutoEQ master toggle (global output-mix effect). Off by default. */
     val systemWideAutoEqEnabled: Flow<Boolean> =
@@ -1084,6 +1093,20 @@ class PreferencesManager @Inject constructor(
         }
     }
 
+    suspend fun setEqBandsR(bandsJson: String?) {
+        dataStore.edit {
+            if (bandsJson != null) {
+                it[EQ_BANDS_R_JSON] = bandsJson
+            } else {
+                it.remove(EQ_BANDS_R_JSON)
+            }
+        }
+    }
+
+    suspend fun setEqStereoMode(enabled: Boolean) {
+        dataStore.edit { it[EQ_STEREO_MODE] = enabled }
+    }
+
     val eqCustomTargetsJson: Flow<String> = dataStore.data.map { it[EQ_CUSTOM_TARGETS_JSON] ?: "[]" }
     suspend fun setEqCustomTargets(json: String) {
         dataStore.edit { it[EQ_CUSTOM_TARGETS_JSON] = json }
@@ -1111,6 +1134,15 @@ class PreferencesManager @Inject constructor(
         dataStore.edit {
             if (json != null) it[EQ_MEASUREMENT_JSON] = json
             else it.remove(EQ_MEASUREMENT_JSON)
+        }
+    }
+
+    // Right-channel counterpart of the cached measurement, for 2-channel mode.
+    val eqMeasurementRJson: Flow<String?> = dataStore.data.map { it[EQ_MEASUREMENT_R_JSON] }
+    suspend fun setEqMeasurementRJson(json: String?) {
+        dataStore.edit {
+            if (json != null) it[EQ_MEASUREMENT_R_JSON] = json
+            else it.remove(EQ_MEASUREMENT_R_JSON)
         }
     }
 

--- a/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/EqRepository.kt
@@ -181,11 +181,27 @@ class EqRepository @Inject constructor(
             corrupted = true
             emptyList()
         }
+        // Same philosophy as bandsJson: a right channel that fails to decode
+        // must not silently fall back to mono — that would quietly change what
+        // the user hears in one ear. Mark the preset corrupted instead.
+        val bandsR = bandsRJson?.let { rJson ->
+            try {
+                json.decodeFromString<List<EqBand>>(rJson)
+            } catch (e: Exception) {
+                Log.e(
+                    "EqRepository",
+                    "Failed to decode R bands for preset '$id' (${e.javaClass.simpleName}: ${e.message})"
+                )
+                corrupted = true
+                null
+            }
+        }
         return EqPreset(
             id = id,
             name = name,
             description = description,
             bands = bands,
+            bandsR = bandsR,
             preamp = preamp,
             targetId = targetId,
             targetName = targetName,
@@ -208,6 +224,13 @@ class EqRepository @Inject constructor(
                 json.encodeToString(bands)
             } catch (e: Exception) {
                 "[]"
+            },
+            bandsRJson = bandsR?.let {
+                try {
+                    json.encodeToString(it)
+                } catch (e: Exception) {
+                    null
+                }
             },
             preamp = preamp,
             targetId = targetId,

--- a/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
@@ -60,6 +60,35 @@ class HeadphoneRepository @Inject constructor(
             else -> null
         }
 
+    /** Channel text + the sample name that actually answered ("L"/"L1"). */
+    suspend fun fetchMeasurementChannel(
+        measurement: AutoEqMeasurement,
+        channel: String,
+    ): Pair<String, String>? = when (measurement.target) {
+        "squiglink" -> squiglinkApi.fetchMeasurementChannel(
+            measurement.host, measurement.fileName, channel,
+        )
+        else -> null
+    }
+
+    /** One exact sample ("L2", "R3", …); squig.link only. */
+    suspend fun fetchMeasurementSampleText(measurement: AutoEqMeasurement, sample: String): String? =
+        when (measurement.target) {
+            "squiglink" -> squiglinkApi.fetchMeasurementSampleText(
+                measurement.host, measurement.fileName, sample,
+            )
+            else -> null
+        }
+
+    /** Published sample names for a channel prefix ("L" -> [L1, L2, …]); squig.link only. */
+    suspend fun listMeasurementSamples(measurement: AutoEqMeasurement, channelPrefix: String): List<String> =
+        when (measurement.target) {
+            "squiglink" -> squiglinkApi.listSamples(
+                measurement.host, measurement.fileName, channelPrefix,
+            )
+            else -> emptyList()
+        }
+
     private fun mergeByName(all: List<Headphone>): List<Headphone> =
         all.groupBy { it.name }.map { (name, group) ->
             Headphone(

--- a/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
+++ b/app/src/main/java/tf/monochrome/android/data/repository/HeadphoneRepository.kt
@@ -46,6 +46,20 @@ class HeadphoneRepository @Inject constructor(
         else -> autoEqApi.fetchMeasurementByPath(measurement.path, measurement.fileName).getOrNull()
     }
 
+    /**
+     * Fetch one specific channel ("L"/"R") of a measurement. Only squig.link
+     * publishes per-channel files; other sources return null and callers fall
+     * back to the single-file path. Null also means "this channel isn't
+     * published" — deliberately NOT papered over with the other channel.
+     */
+    suspend fun fetchMeasurementChannelText(measurement: AutoEqMeasurement, channel: String): String? =
+        when (measurement.target) {
+            "squiglink" -> squiglinkApi.fetchMeasurementChannelText(
+                measurement.host, measurement.fileName, channel,
+            )
+            else -> null
+        }
+
     private fun mergeByName(all: List<Headphone>): List<Headphone> =
         all.groupBy { it.name }.map { (name, group) ->
             Headphone(

--- a/app/src/main/java/tf/monochrome/android/di/DatabaseModule.kt
+++ b/app/src/main/java/tf/monochrome/android/di/DatabaseModule.kt
@@ -29,7 +29,7 @@ object DatabaseModule {
             MusicDatabase::class.java,
             "monochrome_db"
         )
-            .addMigrations(MusicDatabase.MIGRATION_8_9, MusicDatabase.MIGRATION_9_10)
+            .addMigrations(MusicDatabase.MIGRATION_8_9, MusicDatabase.MIGRATION_9_10, MusicDatabase.MIGRATION_10_11)
             // Retained as a safety net for any version gap without an explicit
             // migration; the THX (8→9) and Atmos (9→10) upgrades migrate in
             // place above.

--- a/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/Models.kt
@@ -581,6 +581,9 @@ data class EqPreset(
     val name: String,
     val description: String = "",
     val bands: List<EqBand> = emptyList(),
+    // Right-ear bands when the preset was saved in 2-channel mode; null = mono
+    // (bands drives both ears).
+    val bandsR: List<EqBand>? = null,
     val preamp: Float = 0f,
     val targetId: String = "",
     val targetName: String = "",

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -9,11 +9,11 @@ import kotlinx.serialization.json.Json
  * Liquid-glass parameters for the PLAYER chrome (the transport buttons) — the
  * same refractive-glass controls the lyrics have, but for the player. Tuned in
  * the Player Visuals Studio's "Player Glass" tab and persisted as one JSON blob.
- * Defaults reproduce the shipped look: a ghost-thin body pushed to maximum
- * refraction/dispersion/relief — deeply lensed pillowy glass with a bright
- * fringed rim, a tight mirror-polished glint over a light mist, a calm living
- * surface, a locked (tilt-free) key light high on the back-left, and the
- * deepest, softest drop shadow.
+ * Defaults reproduce the shipped look: a ghost-thin body at full refraction
+ * with heavy dispersion, a mirror-strong room reflection under a tight
+ * polished glint, a dim rim on a hairline edge, perfectly clear (unfrosted)
+ * glass at neutral relief, a calm living surface, a locked (tilt-free) key
+ * light at 215°, and a faint, tight drop shadow.
  */
 @Serializable
 data class PlayerGlassSettings(
@@ -24,19 +24,19 @@ data class PlayerGlassSettings(
     /** How hard the bevel lenses the backdrop. */
     val refraction: Float = 0.4f,
     /** Specular rim brightness (the lit glass edge). */
-    val rimBrightness: Float = 2f,
+    val rimBrightness: Float = 0.2633547f,
     /** Chromatic aberration at the refracting edges. */
-    val dispersion: Float = 2f,
+    val dispersion: Float = 1.8702691f,
     /** Bevel sample rings 1/2/3 → 5/9/13 taps per pixel (quality vs GPU cost). */
     val sampleRings: Int = 3,
     /** Bevel shoulder width (1 = neutral, higher = rounder, softer glass edge). */
     val roundness: Float = 2f,
     /** Profondeur / relief: 1 = neutral, higher = steeper, deeper 3D bevel. */
-    val depth: Float = 2f,
+    val depth: Float = 1.0025804f,
     /** Drop-shadow depth (darkness) under the round play button (0 = flat, 1 = deepest). */
-    val shadowDepth: Float = 1f,
+    val shadowDepth: Float = 0.20475428f,
     /** Environment ("room") reflection strength on the glass (0 = none, 2 = strong). */
-    val reflection: Float = 0.55f,
+    val reflection: Float = 2f,
     /** Highlight polish: 0 = soft/frosted-wide glint, 1 = tight mirror-polished. */
     val gloss: Float = 1f,
     /** Living-liquid surface motion: 0 = still glass, 1 = full shimmer/undulation. */
@@ -44,13 +44,13 @@ data class PlayerGlassSettings(
     /** How strongly device tilt moves the light/reflection (0 = static studio light). */
     val tiltReactivity: Float = 0f,
     /** Key-light direction in degrees (0..360) — where the highlights sit. */
-    val lightAngleDeg: Float = 280f,
+    val lightAngleDeg: Float = 215.1965f,
     /** Reflective rim width: 0 = thin crisp edge, 1 = broad glassy shoulder. */
-    val edgeWidth: Float = 0.89f,
+    val edgeWidth: Float = 0f,
     /** Frosted roughness: 0 = clear glass, 1 = misted/frosted. */
-    val frost: Float = 0.17f,
+    val frost: Float = 0f,
     /** Drop-shadow softness (blur/spread): 0 = tight, 1 = soft diffuse. */
-    val shadowSoftness: Float = 0.92f,
+    val shadowSoftness: Float = 0.01565171f,
     /** Drop-shadow tint: 0 = neutral black, 1 = full accent-tinted glow. */
     val shadowTint: Float = 0f,
     /** Button glass tint as an ARGB int; 0 = use the current album accent. */

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -73,7 +73,7 @@ data class PlayerGlassSettings(
         val d = DEFAULT
         fun Float.c(min: Float, max: Float, fb: Float) = if (isFinite()) coerceIn(min, max) else fb
         return copy(
-            bodyOpacity = bodyOpacity.c(0.2f, 1f, d.bodyOpacity),
+            bodyOpacity = bodyOpacity.c(0f, 1f, d.bodyOpacity),
             refraction = refraction.c(0f, 0.4f, d.refraction),
             rimBrightness = rimBrightness.c(0f, 2f, d.rimBrightness),
             dispersion = dispersion.c(0f, 2f, d.dispersion),

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -59,6 +59,15 @@ data class PlayerGlassSettings(
     val previewBg: Int = 0,
     /** Glass "thermometer" scrubber (tube + sine-bulge dot) vs a plain slider. */
     val progressGlass: Boolean = true,
+    /**
+     * Backdrop (Haze) frost blur radius in dp for surfaces that gaussian-blur
+     * what's behind them — the mini player bar, the player's audio-tools
+     * sheet, the nav pill. 0 disables the frost layer entirely. Distinct from
+     * [frost], which is the shader's surface roughness.
+     */
+    val hazeBlurDp: Float = 40f,
+    /** Strength multiplier on the frost layer's luminance-picked tint (0–2). */
+    val hazeTint: Float = 1f,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT
@@ -81,6 +90,8 @@ data class PlayerGlassSettings(
             frost = frost.c(0f, 1f, d.frost),
             shadowSoftness = shadowSoftness.c(0f, 1f, d.shadowSoftness),
             shadowTint = shadowTint.c(0f, 1f, d.shadowTint),
+            hazeBlurDp = hazeBlurDp.c(0f, 80f, d.hazeBlurDp),
+            hazeTint = hazeTint.c(0f, 2f, d.hazeTint),
         )
     }
 

--- a/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
+++ b/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
@@ -297,14 +297,26 @@ class PlaybackService : MediaSessionService() {
         // handling this app's audio, so tone works independent of the system-wide
         // toggle (and without double-processing when it IS on).
         serviceScope.launch {
+            // Seven sources exceeds combine's typed overloads (max 5), so this
+            // uses the vararg form and casts each slot back out by position.
             kotlinx.coroutines.flow.combine(
                 preferences.eqEnabled,
                 preferences.eqBandsJson,
+                preferences.eqBandsRJson,
+                preferences.eqStereoMode,
                 preferences.eqPreamp,
                 preferences.systemToneControls,
                 preferences.systemWideAutoEqEnabled,
-            ) { enabled, bandsJson, preamp, tone, systemWide ->
-                EqApply(enabled, bandsJson, preamp, tone, systemWide)
+            ) { v ->
+                EqApply(
+                    enabled = v[0] as Boolean,
+                    bandsJson = v[1] as String?,
+                    bandsRJson = v[2] as String?,
+                    stereo = v[3] as Boolean,
+                    preamp = v[4] as Double,
+                    tone = v[5] as tf.monochrome.android.domain.model.ToneControls,
+                    systemWide = v[6] as Boolean,
+                )
             }.collect { applyEqSettings(it) }
         }
 
@@ -678,6 +690,8 @@ class PlaybackService : MediaSessionService() {
     private data class EqApply(
         val enabled: Boolean,
         val bandsJson: String?,
+        val bandsRJson: String?,
+        val stereo: Boolean,
         val preamp: Double,
         val tone: tf.monochrome.android.domain.model.ToneControls,
         val systemWide: Boolean,
@@ -704,6 +718,8 @@ class PlaybackService : MediaSessionService() {
                     EqApply(
                         enabled = preferences.eqEnabled.first(),
                         bandsJson = preferences.eqBandsJson.first(),
+                        bandsRJson = preferences.eqBandsRJson.first(),
+                        stereo = preferences.eqStereoMode.first(),
                         preamp = preferences.eqPreamp.first(),
                         tone = preferences.systemToneControls.first(),
                         systemWide = preferences.systemWideAutoEqEnabled.first(),
@@ -730,15 +746,24 @@ class PlaybackService : MediaSessionService() {
                 return
             }
             val json = Json { ignoreUnknownKeys = true }
-            val autoBands = if (cfg.enabled && !cfg.bandsJson.isNullOrEmpty()) {
-                json.decodeFromString<List<EqBand>>(cfg.bandsJson)
-            } else {
-                emptyList()
-            }
-            val bands = autoBands + cfg.tone.toBands()
+            fun decode(bandsJson: String?): List<EqBand> =
+                if (cfg.enabled && !bandsJson.isNullOrEmpty()) {
+                    json.decodeFromString(bandsJson)
+                } else {
+                    emptyList()
+                }
+            val autoL = decode(cfg.bandsJson)
+            // 2-channel mode gives the right ear its own curve; with the switch
+            // off (or no R curve saved yet) the left list drives both ears.
+            val autoR = if (cfg.stereo) decode(cfg.bandsRJson).ifEmpty { autoL } else autoL
+            // Tone shelves are ear-agnostic: appended to both channels so
+            // bass/treble stay centred regardless of the calibration split.
+            val toneBands = cfg.tone.toBands()
+            val bandsL = autoL + toneBands
+            val bandsR = autoR + toneBands
             val preamp = if (cfg.enabled) cfg.preamp else 0.0
-            val active = bands.any { it.enabled }
-            autoEqProcessor.applyBands(bands, preamp.toFloat(), active)
+            val active = bandsL.any { it.enabled } || bandsR.any { it.enabled }
+            autoEqProcessor.applyBands(bandsL, bandsR, preamp.toFloat(), active)
         } catch (e: Exception) {
             // Gracefully handle EQ application errors
         }

--- a/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
@@ -221,11 +221,12 @@ fun MiniPlayer(
         // light themes and deepens it on dark ones, and Haze's default noise
         // adds the fine frosted grain.
         val profile = LocalPerformanceProfile.current
-        if (hazeState != null && profile.allowHazeBlur) {
+        if (hazeState != null && profile.allowHazeBlur && glass.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f)
+            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
+                            else Color.White.copy(alpha = 0.45f))
+                .let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
             Box(
                 Modifier
                     .matchParentSize()
@@ -233,7 +234,7 @@ fun MiniPlayer(
                         state = hazeState,
                         style = HazeStyle(
                             backgroundColor = frostBg,
-                            blurRadius = 40.dp,
+                            blurRadius = glass.hazeBlurDp.dp,
                             tints = listOf(HazeTint(frostTint)),
                         ),
                     )

--- a/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
@@ -120,11 +120,12 @@ fun SwipeToLibraryHint(
         //
         // backgroundColor and at least one tint must be REAL colours; a
         // Transparent background with an empty tint list silently no-ops.
-        if (hazeState != null && profile.allowHazeBlur) {
+        if (hazeState != null && profile.allowHazeBlur && glass.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f)
+            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
+                            else Color.White.copy(alpha = 0.45f))
+                .let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
             Box(
                 Modifier
                     .matchParentSize()
@@ -132,7 +133,7 @@ fun SwipeToLibraryHint(
                         state = hazeState,
                         style = HazeStyle(
                             backgroundColor = frostBg,
-                            blurRadius = 40.dp,
+                            blurRadius = glass.hazeBlurDp.dp,
                             tints = listOf(HazeTint(frostTint)),
                         ),
                     )

--- a/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
@@ -1,0 +1,215 @@
+package tf.monochrome.android.ui.components
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+import tf.monochrome.android.performance.LocalPerformanceProfile
+import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.playerGlass
+import kotlin.math.floor
+
+private val SlotSpacing = 8.dp
+private val SlotRadius = 2.5.dp
+/** Height of the tap target over the marks, independent of the slab's height. */
+private val TapTargetHeight = 26.dp
+
+private val HintPadding = 9.dp
+
+/** Span the marks occupy for [pageCount] slots, mark centre to mark centre plus the mark itself. */
+private fun marksWidth(pageCount: Int) =
+    SlotRadius * 2 + SlotSpacing * (pageCount - 1).coerceAtLeast(0)
+
+/** Width of the compact pill form for [pageCount] slots. */
+fun swipeHintPillWidth(pageCount: Int): Dp = HintPadding * 2 + marksWidth(pageCount)
+
+/** Height of the compact pill form. */
+val SwipeHintPillHeight = TapTargetHeight
+
+/**
+ * The app's page indicator, and the only thing on screen advertising that the
+ * pages are swipeable at all.
+ *
+ * The bottom `NavigationBar` is gone (its imports in `MonochromeNavHost` are
+ * dead) and Library's tab row with it, so horizontal swipes are the *only*
+ * route between Home, each Library section, and each local-library sub-tab —
+ * invisible gestures with nothing pointing at them. This is the glass header
+ * they hang off: one slot per page with a filled mark travelling between them.
+ *
+ * Sizing comes entirely from [modifier], so the same component works as a
+ * compact pill or as a full-bleed header bar. The marks are always centred
+ * horizontally in whatever bounds it's given; [markCentreY] places them
+ * vertically (default: centred), which is how a bar that spans the status bar
+ * still puts its marks on the app-bar's centre line. Only a mark-sized region
+ * is clickable, not the whole slab — a full-width bar that swallowed taps would
+ * fire on presses meant for the title beside it.
+ *
+ * Motion is a worm indicator: between any two adjacent slots the leading and
+ * trailing edges of the mark run on the same easing curve offset by half the
+ * travel, so the mark stretches across the gap at the midpoint and contracts
+ * into the destination slot. It's driven straight off the pager fraction rather
+ * than an animation clock, which is what makes it track a half-finished drag —
+ * including one the user abandons — and play identically when a tap drives the
+ * pager instead.
+ *
+ * Built from the same layers as the mini player rather than the `liquidGlass`
+ * modifier, so it reads as the same material: an optional Haze frost backdrop,
+ * an AGSL [playerGlass] slab over it, and the marks punched *out* of that slab
+ * with [BlendMode.DstOut] so they're see-through holes rather than painted
+ * glyphs. Callers must provide `LocalPlayerGlass` (the nav host hands it the
+ * same `miniPlayerGlass` settings the mini player gets) or the slab falls back
+ * to a flat tint. [hazeState] may be null when the bar is drawn *behind* the
+ * haze source — Haze can only blur content already drawn this frame — in which
+ * case the marks read against the slab's own tint instead of a blurred backdrop.
+ *
+ * [progressProvider] is the absolute page position across every page — 0f on
+ * Home, 1f on the local library, 2f on the next Library section and so on —
+ * passed as a lambda rather than a plain Float on purpose. The value changes
+ * every frame of a swipe; reading `currentPageOffsetFraction` in composition
+ * would recompose this subtree at 60–120 Hz for the whole gesture. Read inside
+ * `DrawScope` instead, it only re-runs draw.
+ */
+@Composable
+fun SwipeToLibraryHint(
+    pageCount: Int,
+    progressProvider: () -> Float,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(TapTargetHeight / 2),
+    markCentreY: Dp? = null,
+    onClickLabel: String? = null,
+    hazeState: HazeState? = null,
+) {
+    if (pageCount < 2) return
+
+    val glass = LocalPlayerGlass.current
+    val profile = LocalPerformanceProfile.current
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor)
+               else MaterialTheme.colorScheme.primary
+
+    Box(modifier = modifier.clip(shape)) {
+        // Frosted backdrop UNDER the slab, mirroring the mini player. The slab
+        // body can be nearly transparent (bodyOpacity bottoms out at 0.2), so
+        // without this the page behind reads through sharply. Skipped entirely
+        // when the caller passes no hazeState, and on LOW-tier devices.
+        //
+        // backgroundColor and at least one tint must be REAL colours; a
+        // Transparent background with an empty tint list silently no-ops.
+        if (hazeState != null && profile.allowHazeBlur) {
+            val frostBg = MaterialTheme.colorScheme.background
+            val isDark = frostBg.luminance() <= 0.5f
+            val frostTint = if (isDark) Color.Black.copy(alpha = 0.32f)
+                            else Color.White.copy(alpha = 0.45f)
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .hazeEffect(
+                        state = hazeState,
+                        style = HazeStyle(
+                            backgroundColor = frostBg,
+                            blurRadius = 40.dp,
+                            tints = listOf(HazeTint(frostTint)),
+                        ),
+                    )
+            )
+        }
+
+        // The glass slab with the marks carved out of it. One offscreen layer so
+        // the DstOut punch clears only the mark shapes, not the whole rectangle.
+        Canvas(
+            modifier = Modifier
+                .matchParentSize()
+                .playerGlass(tint = tint)
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+        ) {
+            drawRect(color = tint)
+
+            val cy = markCentreY?.toPx() ?: (size.height / 2f)
+            val r = SlotRadius.toPx()
+            val pitch = SlotSpacing.toPx()
+            // Centre the whole run of marks in whatever width we were given.
+            val runWidth = r * 2f + pitch * (pageCount - 1)
+            val firstSlot = (size.width - runWidth) / 2f + r
+            fun slotX(i: Int) = firstSlot + pitch * i
+
+            // Empty slots, punched softly so they read as dimmed rest positions.
+            repeat(pageCount) { i ->
+                drawCircle(Color.Black, radius = r, center = Offset(slotX(i), cy),
+                    alpha = 0.35f, blendMode = BlendMode.DstOut)
+            }
+
+            // ── Worm ────────────────────────────────────────────────────────
+            // At rest both edges sit on the same slot, so the shape below is a
+            // rounded rect exactly 2r wide and 2r tall — a dot, identical in
+            // size to the empty slots, just punched at full strength instead of
+            // dimmed. Mid-crossing the edges separate and it elongates into a
+            // pill, then collapses back to a dot on arrival.
+            //
+            // Only ever spans the pair of slots being crossed, so the stretch
+            // stays the same length whether there are 2 pages or 10. One edge
+            // clears the gap over the first half of the crossing, the other over
+            // the second half. min/max rather than assuming which edge leads:
+            // the same maths plays in reverse for a backwards swipe, and for a
+            // drag the user gives up on halfway and releases back.
+            val last = pageCount - 1
+            val p = progressProvider().coerceIn(0f, last.toFloat())
+            val from = floor(p).toInt().coerceIn(0, last)
+            val to = (from + 1).coerceAtMost(last)
+            val f = p - from
+            val headF = FastOutSlowInEasing.transform((f * 2f).coerceIn(0f, 1f))
+            val tailF = FastOutSlowInEasing.transform((f * 2f - 1f).coerceIn(0f, 1f))
+            val headX = lerp(slotX(from), slotX(to), headF)
+            val tailX = lerp(slotX(from), slotX(to), tailF)
+            val left = minOf(headX, tailX) - r
+            val right = maxOf(headX, tailX) + r
+            drawRoundRect(
+                color = Color.Black,
+                topLeft = Offset(left, cy - r),
+                size = Size(right - left, r * 2f),
+                cornerRadius = CornerRadius(r, r),
+                blendMode = BlendMode.DstOut,
+            )
+        }
+
+        // Tap target over the marks only. Sized and placed to match where the
+        // Canvas drew them, so a full-width slab doesn't steal presses aimed at
+        // the title or the action icons sharing this bar.
+        val tapWidth = marksWidth(pageCount) + 24.dp
+        Box(
+            modifier = Modifier
+                .align(if (markCentreY == null) Alignment.Center else Alignment.TopCenter)
+                .padding(
+                    if (markCentreY == null) PaddingValues(0.dp)
+                    else PaddingValues(top = (markCentreY - TapTargetHeight / 2).coerceAtLeast(0.dp))
+                )
+                .size(width = tapWidth, height = TapTargetHeight)
+                .clip(RoundedCornerShape(TapTargetHeight / 2))
+                .clickable(onClickLabel = onClickLabel, onClick = onClick)
+        )
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/eq/AutoEqHelpSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/AutoEqHelpSheet.kt
@@ -1,0 +1,134 @@
+package tf.monochrome.android.ui.eq
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * The "?" tutorial for the AutoEQ screen — same shape as the Oxford
+ * Inflator/Compressor instruction sheets: a bottom sheet of short
+ * heading + body sections, opened from a HelpOutline button in the header.
+ */
+private data class HelpSection(val heading: String, val body: String)
+
+private fun autoEqHelpSections(): List<HelpSection> = listOf(
+    HelpSection(
+        "What this does",
+        "AutoEQ measures how far your headphone's frequency response deviates " +
+            "from a target curve and builds a stack of correction filters that " +
+            "pull it onto the target. Pick your headphone from the database (or " +
+            "import a measurement) and the filters are computed for you.",
+    ),
+    HelpSection(
+        "Reading the graph",
+        "Blue is your headphone as measured; the dashed line is the target; the " +
+            "red filled curve is the corrected result — what you should hear. " +
+            "The shaded region between measurement and target is the error the " +
+            "correction mirrors. The axis is relative: 0 dB means \"unchanged\", " +
+            "+5 means five decibels louder than neutral. Tap a label in the " +
+            "legend to hide or show that curve.",
+    ),
+    HelpSection(
+        "Band dots",
+        "Each numbered dot is one filter, sitting on the corrected curve at its " +
+            "centre frequency. Green boosts, red cuts, grey is near-flat. Drag a " +
+            "dot to move its frequency and gain — a readout shows Hz, dB and Q " +
+            "while you drag. The numbers match the band list further down, where " +
+            "each band also has PEAK / LOW-S / HIGH-S type buttons.",
+    ),
+    HelpSection(
+        "2-channel (per-ear) calibration",
+        "Real units rarely measure identically left and right. Switch on " +
+            "2-channel calibration to give each ear its own measurement and its " +
+            "own correction. squig.link sources publish true L/R files, so " +
+            "selecting one measurement fills both ears in a single tap; the L|R " +
+            "chips above the graph choose which ear you're editing, and the " +
+            "other ear stays visible as a thin amber curve. Switching the toggle " +
+            "off is non-destructive — the right ear comes back when you " +
+            "re-enable it.",
+    ),
+    HelpSection(
+        "Importing profiles",
+        "\"Import EQ profile\" accepts EqualizerAPO / AutoEq ParametricEQ.txt " +
+            "files or pasted text — including profiles copied from chats or web " +
+            "pages with mangled line breaks. You get a preview of the curve, the " +
+            "filter count and any warnings before anything is saved or applied. " +
+            "In 2-channel mode a profile can target both ears or just one.",
+    ),
+    HelpSection(
+        "Preamp and headroom",
+        "Boosting frequencies eats headroom: without compensation the loudest " +
+            "peaks would clip. The preamp under the graph pulls overall level " +
+            "down to make room. Leave \"Automatic preamp\" on and it tracks the " +
+            "real summed peak of your filters (including the tone shelves) so " +
+            "clipping can't happen; switch it off to set the trade-off yourself.",
+    ),
+    HelpSection(
+        "Targets and presets",
+        "The target menu switches the goal curve (Harman is the safe default; " +
+            "custom targets can be imported). Save the current state as a preset " +
+            "to switch between headphones quickly — presets saved in 2-channel " +
+            "mode keep both ears. Export writes an EqualizerAPO-compatible " +
+            "ParametricEQ.txt you can use anywhere.",
+    ),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AutoEqHelpSheet(onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 4.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            Text(
+                text = "Precision AutoEQ",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Black,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Measurement-driven headphone correction — what the " +
+                    "curves mean and how to drive it.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+            )
+            Spacer(Modifier.height(18.dp))
+            val sections = autoEqHelpSections()
+            sections.forEachIndexed { i, section ->
+                Text(
+                    text = section.heading,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = section.body,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (i != sections.lastIndex) Spacer(Modifier.height(14.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqLimits.kt
@@ -3,19 +3,21 @@ package tf.monochrome.android.ui.eq
 /**
  * Shared range constants for the two EQ surfaces.
  *
- * AutoEQ bands are capped tighter so the algorithm's own per-band safeBoost
- * (12/6/3 dB depending on frequency) is the binding constraint. The Parametric
- * EQ is a tone-shaping tool and intentionally offers more range; callers are
- * responsible for communicating headroom risk to the user.
+ * Both surfaces now share the same ±24 dB per-band range: the AutoEQ
+ * *generator* stays conservative on its own (per-band safeBoost of 12/6/3 dB
+ * by frequency), but user edits and imported profiles are no longer clamped
+ * tighter than the Parametric surface — real-world APO exports carry >12 dB
+ * bands. Callers are responsible for communicating headroom risk to the user.
  */
 object EqLimits {
-    const val AUTOEQ_MAX_BAND_DB = 12f
+    const val AUTOEQ_MAX_BAND_DB = 24f
     const val PARAMETRIC_MAX_BAND_DB = 24f
     const val MIN_FREQ_HZ = 20f
     const val MAX_FREQ_HZ = 20000f
 
     // Total signal-path headroom for AutoEQ (band gain + preamp). Beyond this,
     // the biquad cascade drives the ReplayGain limiter into hard clipping at
-    // the band's resonant peak. Preamp is clamped against (TOTAL - peakBand).
-    const val AUTOEQ_MAX_TOTAL_DB = 24f
+    // the band's resonant peak. Preamp is clamped against (TOTAL - peakBand),
+    // so this sits one preamp-slider's travel above the band cap.
+    const val AUTOEQ_MAX_TOTAL_DB = 36f
 }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -802,74 +802,69 @@ class EqViewModel @Inject constructor(
     }
 
     /**
-     * Import a parsed EqualizerAPO profile: always saved as a custom preset,
-     * optionally applied immediately. [channel] narrows the apply to one ear
-     * (2-channel mode); null applies to both — and mirrors into R whenever an
-     * R list exists, so a stale right-ear curve can't survive a "both" import.
+     * Import parsed EqualizerAPO profiles from the L/R panes: always saved as
+     * ONE preset (right ear in bandsR when both panes were filled), optionally
+     * applied. A both-panes import switches 2-channel mode on — distinct
+     * per-ear stacks are meaningless without it. Preamp is shared, so the
+     * safer (more negative) of the two wins.
      */
     fun importApoProfile(
-        profile: tf.monochrome.android.data.import_.ParsedEqProfile,
+        left: tf.monochrome.android.data.import_.ParsedEqProfile?,
+        right: tf.monochrome.android.data.import_.ParsedEqProfile?,
         name: String,
-        channel: EqChannel?,
-        apply: Boolean,
+        apply: Boolean = true,
     ) {
+        val primary = left ?: right ?: return
         viewModelScope.launch {
             try {
                 // Re-id sequentially: band ids key the UI's selection and the
                 // file's own filter numbers may repeat or skip.
-                val bands = profile.bands.mapIndexed { i, b -> b.copy(id = i) }
+                val bandsL = primary.bands.mapIndexed { i, b -> b.copy(id = i) }
+                val bandsR = if (left != null && right != null) {
+                    right.bands.mapIndexed { i, b -> b.copy(id = i) }
+                } else null
+                val preamp = minOf(primary.preamp, right?.preamp ?: primary.preamp)
                 val preset = EqPreset(
                     id = "custom_preset_${System.currentTimeMillis()}",
                     name = name,
                     description = "Imported EqualizerAPO profile",
-                    bands = bands,
-                    preamp = profile.preamp,
+                    bands = bandsL,
+                    bandsR = bandsR,
+                    preamp = preamp,
                     isCustom = true,
                 )
                 eqRepository.savePreset(preset)
                 if (apply) {
-                    when (channel) {
-                        EqChannel.RIGHT -> {
-                            _currentBandsR.value = bands
-                            saveBandsRToPreferences(bands)
+                    _currentBands.value = bandsL
+                    saveBandsToPreferences(bandsL)
+                    if (bandsR != null) {
+                        _currentBandsR.value = bandsR
+                        saveBandsRToPreferences(bandsR)
+                        if (!_stereoMode.value) {
+                            _stereoMode.value = true
+                            preferences.setEqStereoMode(true)
                         }
-                        EqChannel.LEFT -> {
-                            _currentBands.value = bands
-                            saveBandsToPreferences(bands)
-                        }
-                        null -> {
-                            _currentBands.value = bands
-                            saveBandsToPreferences(bands)
-                            if (_currentBandsR.value.isNotEmpty()) {
-                                _currentBandsR.value = bands
-                                saveBandsRToPreferences(bands)
-                            }
-                        }
+                    } else if (_stereoMode.value && _currentBandsR.value.isNotEmpty()) {
+                        // Mono import while stereo is on: both ears follow it,
+                        // same rule as loading a mono preset.
+                        _currentBandsR.value = bandsL
+                        saveBandsRToPreferences(bandsL)
                     }
-                    if (channel == EqChannel.RIGHT) {
-                        // Right-only apply: the preset's bands landed on ONE
-                        // ear, so it is not "the active preset". Clearing the
-                        // persisted id makes restart restore from the raw
-                        // per-ear band prefs — exactly the state applied here.
-                        _activePreset.value = null
-                        preferences.setEqActivePreset(null)
-                    } else {
-                        _activePreset.value = preset
-                        preferences.setEqActivePreset(preset.id)
-                    }
+                    _activePreset.value = preset
+                    preferences.setEqActivePreset(preset.id)
                     // Auto-preamp recomputes from the bands on its own; only a
                     // manual preamp adopts the file's value.
                     if (!_autoPreamp.value) {
-                        _currentPreamp.value = profile.preamp
-                        preferences.setEqPreamp(profile.preamp.toDouble())
+                        _currentPreamp.value = preamp
+                        preferences.setEqPreamp(preamp.toDouble())
                     }
-                    // "Save & apply" means HEAR it — enabling here beats
-                    // silently importing into a bypassed EQ.
+                    // "Upload" means HEAR it — enabling beats silently
+                    // importing into a bypassed EQ.
                     if (!_eqEnabled.value) enableEq()
                 }
                 _error.value = null
             } catch (e: Exception) {
-                _error.value = "Failed to import profile: ${e.message}"
+                _error.value = "Failed to import profile: " + e.message
             }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -978,6 +978,61 @@ class EqViewModel @Inject constructor(
         } catch (_: Exception) { }
     }
 
+    /**
+     * Load a squig.link L/R measurement pair and compute BOTH ears' corrections
+     * in one go. Returns false when neither channel file exists (caller falls
+     * back to the single-file path). A missing single channel borrows the other
+     * ear's curve, and the labels say which file each ear actually got.
+     */
+    private suspend fun loadStereoPair(
+        measurement: tf.monochrome.android.domain.model.AutoEqMeasurement,
+    ): Boolean {
+        val lText = headphoneRepository.fetchMeasurementChannelText(measurement, "L")
+        val rText = headphoneRepository.fetchMeasurementChannelText(measurement, "R")
+        if (lText == null && rText == null) return false
+
+        val lParsed = lText?.let { EqDataParser.parseRawData(it) }.orEmpty()
+        val rParsed = rText?.let { EqDataParser.parseRawData(it) }.orEmpty()
+        val leftCurve = lParsed.ifEmpty { rParsed }
+        val rightCurve = rParsed.ifEmpty { lParsed }
+        if (leftCurve.isEmpty()) return false
+
+        val target = _selectedTarget.value.data
+        if (target.isEmpty()) {
+            // Handled here (error surfaced) — returning true stops the caller
+            // from re-fetching just to hit the same wall.
+            _error.value = "Target curve not available"
+            return true
+        }
+
+        fun compute(m: List<FrequencyPoint>) = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = m,
+            target = target,
+            bandCount = _bandCount.value,
+            maxFrequency = _maxFrequency.value,
+            sampleRate = _sampleRate.value,
+        )
+
+        _originalMeasurement.value = leftCurve
+        persistMeasurement(leftCurve)
+        _measurementLabelL.value = measurement.fileName +
+            (if (lParsed.isNotEmpty()) " L" else " R") + " · " + measurement.source
+        val bandsL = compute(leftCurve)
+        _currentBands.value = bandsL
+        saveBandsToPreferences(bandsL)
+
+        _originalMeasurementR.value = rightCurve
+        persistMeasurementR(rightCurve)
+        _measurementLabelR.value = measurement.fileName +
+            (if (rParsed.isNotEmpty()) " R" else " L") + " · " + measurement.source
+        val bandsR = compute(rightCurve)
+        _currentBandsR.value = bandsR
+        saveBandsRToPreferences(bandsR)
+
+        _error.value = null
+        return true
+    }
+
     private suspend fun persistMeasurementR(points: List<FrequencyPoint>) {
         try {
             val json = kotlinx.serialization.json.Json.encodeToString(
@@ -996,6 +1051,20 @@ class EqViewModel @Inject constructor(
             _isCalculating.value = true
             _error.value = null
 
+            // 2-channel mode + squig.link: the source publishes true per-ear
+            // files ("<name> L.txt"/"<name> R.txt"), so one selection from the
+            // primary picker fills BOTH ears with their own corrections.
+            if (channel == EqChannel.LEFT && _stereoMode.value &&
+                measurement.target == "squiglink" &&
+                measurement.rig != tf.monochrome.android.domain.model.MeasurementRig.UPLOADED
+            ) {
+                if (loadStereoPair(measurement)) {
+                    _isCalculating.value = false
+                    return
+                }
+                // Neither channel file exists — fall through to the generic path.
+            }
+
             // Uploaded measurements carry their FR data inline on the
             // Headphone — short-circuit the remote fetch.
             val parsed = if (measurement.rig == tf.monochrome.android.domain.model.MeasurementRig.UPLOADED) {
@@ -1004,7 +1073,17 @@ class EqViewModel @Inject constructor(
                     ?.data
                     ?: emptyList()
             } else {
-                val csvData = headphoneRepository.fetchMeasurementText(measurement)
+                // squig.link: prefer the exact channel file for the ear being
+                // loaded — the old L-then-R fallback handed the RIGHT picker
+                // the left ear's data whenever an L file existed.
+                val csvData = if (measurement.target == "squiglink") {
+                    val want = if (channel == EqChannel.RIGHT) "R" else "L"
+                    val other = if (channel == EqChannel.RIGHT) "L" else "R"
+                    headphoneRepository.fetchMeasurementChannelText(measurement, want)
+                        ?: headphoneRepository.fetchMeasurementChannelText(measurement, other)
+                } else {
+                    headphoneRepository.fetchMeasurementText(measurement)
+                }
                 if (csvData == null) {
                     _error.value = "Failed to fetch measurement"
                     _isCalculating.value = false

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -87,6 +87,22 @@ class EqViewModel @Inject constructor(
     private val _measurementLabelR = MutableStateFlow<String?>(null)
     val measurementLabelR: StateFlow<String?> = _measurementLabelR.asStateFlow()
 
+    // Sample stepping (squig.link publishes numbered sweeps: L1/L2/L3…).
+    // The loaded measurement is kept per ear so the ▲▼ stepper can re-fetch a
+    // different sample; the sample name drives the stepper's label and
+    // visibility (null = no steppable measurement loaded on that ear).
+    private var selectedMeasL: tf.monochrome.android.domain.model.AutoEqMeasurement? = null
+    private var selectedMeasR: tf.monochrome.android.domain.model.AutoEqMeasurement? = null
+    private val sampleListCache = mutableMapOf<String, List<String>>()
+    private val _measurementSampleL = MutableStateFlow<String?>(null)
+    val measurementSampleL: StateFlow<String?> = _measurementSampleL.asStateFlow()
+    private val _measurementSampleR = MutableStateFlow<String?>(null)
+    val measurementSampleR: StateFlow<String?> = _measurementSampleR.asStateFlow()
+
+    // Measurement smoothing (octave fraction; 0 = off). Session-scoped.
+    private val _smoothing = MutableStateFlow(0f)
+    val smoothing: StateFlow<Float> = _smoothing.asStateFlow()
+
     private val _currentPreamp = MutableStateFlow(0f)
     val currentPreamp: StateFlow<Float> = _currentPreamp.asStateFlow()
 
@@ -545,6 +561,120 @@ class EqViewModel @Inject constructor(
         _editChannel.value = channel
     }
 
+    /**
+     * Measurement smoothing in octave fractions (0 = off, up to 1/3 oct).
+     * Applied to the measurement JUST before the optimizer runs — raw curves
+     * stay stored, so stepping the slider re-derives corrections without
+     * re-fetching anything.
+     */
+    fun setSmoothing(fraction: Float) {
+        if (fraction == _smoothing.value) return
+        _smoothing.value = fraction
+        viewModelScope.launch {
+            val target = _selectedTarget.value.data
+            if (target.isEmpty()) return@launch
+            try {
+                _isCalculating.value = true
+                val l = _originalMeasurement.value
+                if (l.isNotEmpty()) {
+                    val bands = runEngine(l, target)
+                    _currentBands.value = bands
+                    saveBandsToPreferences(bands)
+                }
+                val r = _originalMeasurementR.value
+                if (r.isNotEmpty()) {
+                    val bands = runEngine(r, target)
+                    _currentBandsR.value = bands
+                    saveBandsRToPreferences(bands)
+                }
+            } finally {
+                _isCalculating.value = false
+            }
+        }
+    }
+
+    /**
+     * Single choke point for the optimizer: every path (database select,
+     * stereo pair, file import, sample stepping, manual re-run) funnels
+     * through here so smoothing is applied uniformly.
+     */
+    private fun runEngine(
+        measurement: List<FrequencyPoint>,
+        target: List<FrequencyPoint>,
+    ): List<EqBand> = AutoEqEngine.runAutoEqAlgorithm(
+        measurement = AutoEqEngine.smoothCurve(measurement, _smoothing.value),
+        target = target,
+        bandCount = _bandCount.value,
+        maxFrequency = _maxFrequency.value,
+        sampleRate = _sampleRate.value,
+    )
+
+    /**
+     * Step the loaded squig.link measurement to its next/previous published
+     * sample (L1 → L2 → …, wrapping) and recompute that ear's correction from
+     * the new sweep. Which samples exist is discovered once per
+     * measurement+channel with HEAD probes and cached for the session.
+     */
+    fun cycleMeasurementSample(channel: EqChannel, forward: Boolean) {
+        val meas = (if (channel == EqChannel.RIGHT) selectedMeasR else selectedMeasL) ?: return
+        val prefix = if (channel == EqChannel.RIGHT) "R" else "L"
+        viewModelScope.launch {
+            try {
+                _isCalculating.value = true
+                _error.value = null
+                val key = meas.host + "|" + meas.fileName + "|" + prefix
+                val samples = sampleListCache.getOrPut(key) {
+                    headphoneRepository.listMeasurementSamples(meas, prefix)
+                }
+                if (samples.size <= 1) {
+                    _error.value = "Only one " + prefix + " sample is published for this measurement"
+                    return@launch
+                }
+                val sampleFlow =
+                    if (channel == EqChannel.RIGHT) _measurementSampleR else _measurementSampleL
+                val idx = samples.indexOf(sampleFlow.value).coerceAtLeast(0)
+                val next = samples[(idx + if (forward) 1 else samples.size - 1) % samples.size]
+
+                val text = headphoneRepository.fetchMeasurementSampleText(meas, next)
+                if (text == null) {
+                    _error.value = "Failed to fetch sample " + next
+                    return@launch
+                }
+                val parsed = EqDataParser.parseRawData(text)
+                if (parsed.isEmpty()) {
+                    _error.value = "Failed to parse sample " + next
+                    return@launch
+                }
+                val target = _selectedTarget.value.data
+                if (target.isEmpty()) {
+                    _error.value = "Target curve not available"
+                    return@launch
+                }
+                val bands = runEngine(parsed, target)
+                val label = meas.fileName + " " + next + " · " + meas.source
+                if (channel == EqChannel.RIGHT) {
+                    _originalMeasurementR.value = parsed
+                    persistMeasurementR(parsed)
+                    _measurementLabelR.value = label
+                    _measurementSampleR.value = next
+                    _currentBandsR.value = bands
+                    saveBandsRToPreferences(bands)
+                } else {
+                    _originalMeasurement.value = parsed
+                    persistMeasurement(parsed)
+                    _measurementLabelL.value = label
+                    _measurementSampleL.value = next
+                    _currentBands.value = bands
+                    saveBandsToPreferences(bands)
+                }
+            } catch (e: Exception) {
+                _error.value = "Failed to switch sample: " + e.message
+            } finally {
+                _isCalculating.value = false
+            }
+        }
+    }
+
     private data class PreampSources(
         val bandsL: List<EqBand>,
         val bandsR: List<EqBand>,
@@ -803,13 +933,7 @@ class EqViewModel @Inject constructor(
                     return@launch
                 }
 
-                val bands = AutoEqEngine.runAutoEqAlgorithm(
-                    measurement = measurement,
-                    target = target,
-                    bandCount = _bandCount.value,
-                    maxFrequency = _maxFrequency.value,
-                    sampleRate = _sampleRate.value
-                )
+                val bands = runEngine(measurement, target)
 
                 _currentBands.value = bands
                 saveBandsToPreferences(bands)
@@ -987,12 +1111,12 @@ class EqViewModel @Inject constructor(
     private suspend fun loadStereoPair(
         measurement: tf.monochrome.android.domain.model.AutoEqMeasurement,
     ): Boolean {
-        val lText = headphoneRepository.fetchMeasurementChannelText(measurement, "L")
-        val rText = headphoneRepository.fetchMeasurementChannelText(measurement, "R")
-        if (lText == null && rText == null) return false
+        val lFetch = headphoneRepository.fetchMeasurementChannel(measurement, "L")
+        val rFetch = headphoneRepository.fetchMeasurementChannel(measurement, "R")
+        if (lFetch == null && rFetch == null) return false
 
-        val lParsed = lText?.let { EqDataParser.parseRawData(it) }.orEmpty()
-        val rParsed = rText?.let { EqDataParser.parseRawData(it) }.orEmpty()
+        val lParsed = lFetch?.first?.let { EqDataParser.parseRawData(it) }.orEmpty()
+        val rParsed = rFetch?.first?.let { EqDataParser.parseRawData(it) }.orEmpty()
         val leftCurve = lParsed.ifEmpty { rParsed }
         val rightCurve = rParsed.ifEmpty { lParsed }
         if (leftCurve.isEmpty()) return false
@@ -1005,26 +1129,27 @@ class EqViewModel @Inject constructor(
             return true
         }
 
-        fun compute(m: List<FrequencyPoint>) = AutoEqEngine.runAutoEqAlgorithm(
-            measurement = m,
-            target = target,
-            bandCount = _bandCount.value,
-            maxFrequency = _maxFrequency.value,
-            sampleRate = _sampleRate.value,
-        )
+        fun compute(m: List<FrequencyPoint>) = runEngine(m, target)
+
+        val lSample = if (lParsed.isNotEmpty()) lFetch!!.second else rFetch!!.second
+        val rSample = if (rParsed.isNotEmpty()) rFetch!!.second else lFetch!!.second
 
         _originalMeasurement.value = leftCurve
         persistMeasurement(leftCurve)
-        _measurementLabelL.value = measurement.fileName +
-            (if (lParsed.isNotEmpty()) " L" else " R") + " · " + measurement.source
+        _measurementLabelL.value =
+            measurement.fileName + " " + lSample + " · " + measurement.source
+        selectedMeasL = measurement
+        _measurementSampleL.value = lSample
         val bandsL = compute(leftCurve)
         _currentBands.value = bandsL
         saveBandsToPreferences(bandsL)
 
         _originalMeasurementR.value = rightCurve
         persistMeasurementR(rightCurve)
-        _measurementLabelR.value = measurement.fileName +
-            (if (rParsed.isNotEmpty()) " R" else " L") + " · " + measurement.source
+        _measurementLabelR.value =
+            measurement.fileName + " " + rSample + " · " + measurement.source
+        selectedMeasR = measurement
+        _measurementSampleR.value = rSample
         val bandsR = compute(rightCurve)
         _currentBandsR.value = bandsR
         saveBandsRToPreferences(bandsR)
@@ -1067,6 +1192,7 @@ class EqViewModel @Inject constructor(
 
             // Uploaded measurements carry their FR data inline on the
             // Headphone — short-circuit the remote fetch.
+            var sampleUsed: String? = null
             val parsed = if (measurement.rig == tf.monochrome.android.domain.model.MeasurementRig.UPLOADED) {
                 _uploadedHeadphones.value
                     .firstOrNull { it.name == measurement.fileName }
@@ -1079,8 +1205,10 @@ class EqViewModel @Inject constructor(
                 val csvData = if (measurement.target == "squiglink") {
                     val want = if (channel == EqChannel.RIGHT) "R" else "L"
                     val other = if (channel == EqChannel.RIGHT) "L" else "R"
-                    headphoneRepository.fetchMeasurementChannelText(measurement, want)
-                        ?: headphoneRepository.fetchMeasurementChannelText(measurement, other)
+                    val hit = headphoneRepository.fetchMeasurementChannel(measurement, want)
+                        ?: headphoneRepository.fetchMeasurementChannel(measurement, other)
+                    sampleUsed = hit?.second
+                    hit?.first
                 } else {
                     headphoneRepository.fetchMeasurementText(measurement)
                 }
@@ -1097,15 +1225,20 @@ class EqViewModel @Inject constructor(
                 return
             }
 
-            val label = measurement.fileName + " · " + measurement.source
+            val label = measurement.fileName +
+                (sampleUsed?.let { " " + it } ?: "") + " · " + measurement.source
             if (channel == EqChannel.RIGHT) {
                 _originalMeasurementR.value = parsed
                 persistMeasurementR(parsed)
                 _measurementLabelR.value = label
+                selectedMeasR = if (sampleUsed != null) measurement else null
+                _measurementSampleR.value = sampleUsed
             } else {
                 _originalMeasurement.value = parsed
                 persistMeasurement(parsed)
                 _measurementLabelL.value = label
+                selectedMeasL = if (sampleUsed != null) measurement else null
+                _measurementSampleL.value = sampleUsed
             }
 
             val target = _selectedTarget.value.data
@@ -1115,13 +1248,7 @@ class EqViewModel @Inject constructor(
                 return
             }
 
-            val bands = AutoEqEngine.runAutoEqAlgorithm(
-                measurement = parsed,
-                target = target,
-                bandCount = _bandCount.value,
-                maxFrequency = _maxFrequency.value,
-                sampleRate = _sampleRate.value,
-            )
+            val bands = runEngine(parsed, target)
             if (channel == EqChannel.RIGHT) {
                 _currentBandsR.value = bands
                 saveBandsRToPreferences(bands)
@@ -1175,13 +1302,7 @@ class EqViewModel @Inject constructor(
                             return@collect
                         }
 
-                        val bands = AutoEqEngine.runAutoEqAlgorithm(
-                            measurement = measurement,
-                            target = target,
-                            bandCount = _bandCount.value,
-                            maxFrequency = _maxFrequency.value,
-                            sampleRate = _sampleRate.value
-                        )
+                        val bands = runEngine(measurement, target)
 
                         _currentBands.value = bands
                         saveBandsToPreferences(bands)
@@ -1280,13 +1401,7 @@ class EqViewModel @Inject constructor(
             try {
                 _isCalculating.value = true
                 _error.value = null
-                val bands = AutoEqEngine.runAutoEqAlgorithm(
-                    measurement = measurement,
-                    target = target,
-                    bandCount = _bandCount.value,
-                    maxFrequency = _maxFrequency.value,
-                    sampleRate = _sampleRate.value
-                )
+                val bands = runEngine(measurement, target)
                 if (editRight) {
                     _currentBandsR.value = bands
                     saveBandsRToPreferences(bands)
@@ -1324,10 +1439,14 @@ class EqViewModel @Inject constructor(
                     _originalMeasurementR.value = measurement
                     persistMeasurementR(measurement)
                     _measurementLabelR.value = "Imported file"
+                    selectedMeasR = null
+                    _measurementSampleR.value = null
                 } else {
                     _originalMeasurement.value = measurement
                     persistMeasurement(measurement)
                     _measurementLabelL.value = "Imported file"
+                    selectedMeasL = null
+                    _measurementSampleL.value = null
                 }
 
                 val target = _selectedTarget.value.data
@@ -1337,13 +1456,7 @@ class EqViewModel @Inject constructor(
                     return@launch
                 }
 
-                val bands = AutoEqEngine.runAutoEqAlgorithm(
-                    measurement = measurement,
-                    target = target,
-                    bandCount = _bandCount.value,
-                    maxFrequency = _maxFrequency.value,
-                    sampleRate = _sampleRate.value
-                )
+                val bands = runEngine(measurement, target)
 
                 if (channel == EqChannel.RIGHT) {
                     _currentBandsR.value = bands

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import tf.monochrome.android.audio.eq.AutoEqEngine
 import tf.monochrome.android.audio.eq.EqDataParser
@@ -112,6 +115,41 @@ class EqViewModel @Inject constructor(
     fun setAlgorithm(algorithm: tf.monochrome.android.audio.eq.AutoEqAlgorithm) {
         _algorithm.value = algorithm
     }
+
+    // ONE mutation job at a time. AutoEq presses, sample steps and measurement
+    // loads cancel-and-replace each other; the join guarantees the previous
+    // job's writes (and its finally) fully complete before the next starts, so
+    // per-ear state can never end up torn across two sources.
+    private var fitJob: Job? = null
+
+    private fun launchFit(block: suspend CoroutineScope.() -> Unit) {
+        val previous = fitJob
+        fitJob = viewModelScope.launch {
+            previous?.cancelAndJoin()
+            block()
+        }
+    }
+
+    /**
+     * Fit settings snapshotted ONCE per user action and threaded through every
+     * per-ear fit of that action — a slider moved mid-computation must never
+     * leave the two ears corrected at different settings.
+     */
+    private data class FitSettings(
+        val smoothing: Float,
+        val bandCount: Int,
+        val maxFrequency: Float,
+        val sampleRate: Float,
+        val algorithm: tf.monochrome.android.audio.eq.AutoEqAlgorithm,
+    )
+
+    private fun fitSettings() = FitSettings(
+        _smoothing.value,
+        _bandCount.value,
+        _maxFrequency.value,
+        _sampleRate.value,
+        _algorithm.value,
+    )
 
     private val _currentPreamp = MutableStateFlow(0f)
     val currentPreamp: StateFlow<Float> = _currentPreamp.asStateFlow()
@@ -528,7 +566,13 @@ class EqViewModel @Inject constructor(
         // The slider is disabled while automatic preamp owns the value; this
         // guard is belt-and-braces against a race on the toggle.
         if (_autoPreamp.value) return
-        val peakBand = _currentBands.value.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f
+        // The shared preamp guards BOTH ears' headroom — clamp against the
+        // hotter one, exactly as applyAutoPreamp does.
+        val peakL = _currentBands.value.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f
+        val peakR = if (_stereoMode.value) {
+            _currentBandsR.value.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f
+        } else 0f
+        val peakBand = maxOf(peakL, peakR)
         val headroom = (EqLimits.AUTOEQ_MAX_TOTAL_DB - peakBand).coerceAtLeast(0f)
         val clamped = preamp.coerceIn(-headroom, headroom)
         _currentPreamp.value = clamped
@@ -589,14 +633,15 @@ class EqViewModel @Inject constructor(
     private suspend fun runEngine(
         measurement: List<FrequencyPoint>,
         target: List<FrequencyPoint>,
+        settings: FitSettings,
     ): List<EqBand> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
         AutoEqEngine.runAutoEqAlgorithm(
-            measurement = AutoEqEngine.smoothCurve(measurement, _smoothing.value),
+            measurement = AutoEqEngine.smoothCurve(measurement, settings.smoothing),
             target = target,
-            bandCount = _bandCount.value,
-            maxFrequency = _maxFrequency.value,
-            sampleRate = _sampleRate.value,
-            algorithm = _algorithm.value,
+            bandCount = settings.bandCount,
+            maxFrequency = settings.maxFrequency,
+            sampleRate = settings.sampleRate,
+            algorithm = settings.algorithm,
         )
     }
 
@@ -609,17 +654,25 @@ class EqViewModel @Inject constructor(
     fun cycleMeasurementSample(channel: EqChannel, forward: Boolean) {
         val meas = (if (channel == EqChannel.RIGHT) selectedMeasR else selectedMeasL) ?: return
         val prefix = if (channel == EqChannel.RIGHT) "R" else "L"
-        viewModelScope.launch {
+        launchFit {
             try {
                 _isCalculating.value = true
                 _error.value = null
                 val key = meas.host + "|" + meas.fileName + "|" + prefix
-                val samples = sampleListCache.getOrPut(key) {
-                    headphoneRepository.listMeasurementSamples(meas, prefix)
+                // Cache only non-empty lists: sampleExists maps network
+                // failures to false, so an empty result usually means the
+                // probe couldn't reach the server, not that no samples exist —
+                // caching it would kill the stepper for the whole session.
+                val samples = sampleListCache[key]
+                    ?: headphoneRepository.listMeasurementSamples(meas, prefix)
+                        .also { if (it.isNotEmpty()) sampleListCache[key] = it }
+                if (samples.isEmpty()) {
+                    _error.value = "Couldn't reach the measurement server — try again"
+                    return@launchFit
                 }
-                if (samples.size <= 1) {
+                if (samples.size == 1) {
                     _error.value = "Only one " + prefix + " sample is published for this measurement"
-                    return@launch
+                    return@launchFit
                 }
                 val sampleFlow =
                     if (channel == EqChannel.RIGHT) _measurementSampleR else _measurementSampleL
@@ -629,19 +682,19 @@ class EqViewModel @Inject constructor(
                 val text = headphoneRepository.fetchMeasurementSampleText(meas, next)
                 if (text == null) {
                     _error.value = "Failed to fetch sample " + next
-                    return@launch
+                    return@launchFit
                 }
                 val parsed = EqDataParser.parseRawData(text)
                 if (parsed.isEmpty()) {
                     _error.value = "Failed to parse sample " + next
-                    return@launch
+                    return@launchFit
                 }
                 val target = _selectedTarget.value.data
                 if (target.isEmpty()) {
                     _error.value = "Target curve not available"
-                    return@launch
+                    return@launchFit
                 }
-                val bands = runEngine(parsed, target)
+                val bands = runEngine(parsed, target, fitSettings())
                 val label = meas.fileName + " " + next + " · " + meas.source
                 if (channel == EqChannel.RIGHT) {
                     _originalMeasurementR.value = parsed
@@ -814,11 +867,25 @@ class EqViewModel @Inject constructor(
                 val bandsR = if (left != null && right != null) {
                     right.bands.mapIndexed { i, b -> b.copy(id = i) }
                 } else null
-                val preamp = minOf(primary.preamp, right?.preamp ?: primary.preamp)
+                // Never trust a file with the headroom budget: clamp exactly
+                // as the manual slider does, against the hotter ear's peak. An
+                // unbounded file preamp would otherwise reach the audio path
+                // directly — and the import force-enables the EQ.
+                val rawPreamp = minOf(primary.preamp, right?.preamp ?: primary.preamp)
+                val peak = maxOf(
+                    bandsL.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f,
+                    bandsR?.maxOfOrNull { kotlin.math.abs(it.gain) } ?: 0f,
+                )
+                val headroom = (EqLimits.AUTOEQ_MAX_TOTAL_DB - peak).coerceAtLeast(0f)
+                val preamp = rawPreamp.coerceIn(-headroom, headroom)
                 val preset = EqPreset(
                     id = "custom_preset_${System.currentTimeMillis()}",
                     name = name,
                     description = "Imported EqualizerAPO profile",
+                    // Restart restores the active preset's target; an empty id
+                    // would silently reset the user's target choice to Harman.
+                    targetId = _selectedTarget.value.id,
+                    targetName = _selectedTarget.value.label,
                     bands = bandsL,
                     bandsR = bandsR,
                     preamp = preamp,
@@ -898,7 +965,7 @@ class EqViewModel @Inject constructor(
      * @param bandCount Number of EQ bands to generate (typically 10)
      */
     fun calculateAutoEq(measurementCsv: String) {
-        viewModelScope.launch {
+        launchFit {
             try {
                 _isCalculating.value = true
                 _error.value = null
@@ -907,7 +974,7 @@ class EqViewModel @Inject constructor(
                 if (measurement.isEmpty()) {
                     _error.value = "Failed to parse measurement data"
                     _isCalculating.value = false
-                    return@launch
+                    return@launchFit
                 }
 
                 _originalMeasurement.value = measurement
@@ -916,10 +983,10 @@ class EqViewModel @Inject constructor(
                 if (target.isEmpty()) {
                     _error.value = "Target curve not available"
                     _isCalculating.value = false
-                    return@launch
+                    return@launchFit
                 }
 
-                val bands = runEngine(measurement, target)
+                val bands = runEngine(measurement, target, fitSettings())
 
                 _currentBands.value = bands
                 saveBandsToPreferences(bands)
@@ -1072,7 +1139,7 @@ class EqViewModel @Inject constructor(
         channel: EqChannel = EqChannel.LEFT,
     ) {
         _selectedHeadphone.value = headphone
-        viewModelScope.launch {
+        launchFit {
             preferences.setEqSelectedHeadphone(headphone.id, headphone.name)
             loadHeadphonePresetForMeasurement(measurement, channel)
         }
@@ -1115,7 +1182,8 @@ class EqViewModel @Inject constructor(
             return true
         }
 
-        suspend fun compute(m: List<FrequencyPoint>) = runEngine(m, target)
+        val settings = fitSettings()
+        suspend fun compute(m: List<FrequencyPoint>) = runEngine(m, target, settings)
 
         val lSample = if (lParsed.isNotEmpty()) lFetch!!.second else rFetch!!.second
         val rSample = if (rParsed.isNotEmpty()) rFetch!!.second else lFetch!!.second
@@ -1234,7 +1302,7 @@ class EqViewModel @Inject constructor(
                 return
             }
 
-            val bands = runEngine(parsed, target)
+            val bands = runEngine(parsed, target, fitSettings())
             if (channel == EqChannel.RIGHT) {
                 _currentBandsR.value = bands
                 saveBandsRToPreferences(bands)
@@ -1288,7 +1356,7 @@ class EqViewModel @Inject constructor(
                             return@collect
                         }
 
-                        val bands = runEngine(measurement, target)
+                        val bands = runEngine(measurement, target, fitSettings())
 
                         _currentBands.value = bands
                         saveBandsToPreferences(bands)
@@ -1366,35 +1434,42 @@ class EqViewModel @Inject constructor(
     }
 
     fun runAutoEq() {
-        // Reprocess is explicit: the smoothing slider only previews, and this
-        // button re-derives corrections at the current settings — for EVERY
-        // ear that has a measurement, so a smoothing change can't leave the
-        // two ears computed at different settings.
-        val measL = _originalMeasurement.value
-        val measR = if (_stereoMode.value) _originalMeasurementR.value else emptyList<FrequencyPoint>()
-        if (measL.isEmpty() && measR.isEmpty()) {
-            _error.value = "No headphone measurement loaded"
-            return
-        }
-        val target = _selectedTarget.value.data
-        if (target.isEmpty()) {
-            _error.value = "Target curve not available"
-            return
-        }
-        viewModelScope.launch {
+        if (_isCalculating.value) return
+        launchFit {
             try {
                 _isCalculating.value = true
                 _error.value = null
+                // Reprocess is explicit: the smoothing slider only previews,
+                // and this press re-derives EVERY ear that has a measurement.
+                // Measurements and settings are read INSIDE the serialized job
+                // — reading them at press time raced an in-flight sample step,
+                // fitting an ear from a measurement it no longer shows.
+                val settings = fitSettings()
+                val measL = _originalMeasurement.value
+                val measR =
+                    if (_stereoMode.value) _originalMeasurementR.value
+                    else emptyList<FrequencyPoint>()
+                if (measL.isEmpty() && measR.isEmpty()) {
+                    _error.value = "No headphone measurement loaded"
+                    return@launchFit
+                }
+                val target = _selectedTarget.value.data
+                if (target.isEmpty()) {
+                    _error.value = "Target curve not available"
+                    return@launchFit
+                }
                 if (measL.isNotEmpty()) {
-                    val bands = runEngine(measL, target)
+                    val bands = runEngine(measL, target, settings)
                     _currentBands.value = bands
                     saveBandsToPreferences(bands)
                 }
                 if (measR.isNotEmpty()) {
-                    val bands = runEngine(measR, target)
+                    val bands = runEngine(measR, target, settings)
                     _currentBandsR.value = bands
                     saveBandsRToPreferences(bands)
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _error.value = "AutoEQ calculation failed: " + e.message
             } finally {
@@ -1409,7 +1484,7 @@ class EqViewModel @Inject constructor(
      * Import measurement from raw file contents (read by UI via ContentResolver)
      */
     fun importMeasurementData(rawData: String, channel: EqChannel = EqChannel.LEFT) {
-        viewModelScope.launch {
+        launchFit {
             try {
                 _isCalculating.value = true
                 _error.value = null
@@ -1418,10 +1493,16 @@ class EqViewModel @Inject constructor(
                 if (measurement.isEmpty()) {
                     _error.value = "Failed to parse measurement file"
                     _isCalculating.value = false
-                    return@launch
+                    return@launchFit
                 }
 
                 if (channel == EqChannel.RIGHT) {
+                    if (!_stereoMode.value) {
+                        // A right-ear import is meaningless with 2-channel off:
+                        // the data would be neither audible nor visible.
+                        _stereoMode.value = true
+                        preferences.setEqStereoMode(true)
+                    }
                     _originalMeasurementR.value = measurement
                     persistMeasurementR(measurement)
                     _measurementLabelR.value = "Imported file"
@@ -1439,10 +1520,10 @@ class EqViewModel @Inject constructor(
                 if (target.isEmpty()) {
                     _error.value = "Target curve not available"
                     _isCalculating.value = false
-                    return@launch
+                    return@launchFit
                 }
 
-                val bands = runEngine(measurement, target)
+                val bands = runEngine(measurement, target, fitSettings())
 
                 if (channel == EqChannel.RIGHT) {
                     _currentBandsR.value = bands

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -63,6 +63,30 @@ class EqViewModel @Inject constructor(
     private val _currentBands = MutableStateFlow<List<EqBand>>(emptyList())
     val currentBands: StateFlow<List<EqBand>> = _currentBands.asStateFlow()
 
+    // ── 2-channel (per-ear) calibration ────────────────────────────────
+    private val _stereoMode = MutableStateFlow(false)
+    val stereoMode: StateFlow<Boolean> = _stereoMode.asStateFlow()
+
+    // Right-ear bands. Only applied while stereo mode is on, but retained
+    // across the toggle so switching off and back on is non-destructive.
+    private val _currentBandsR = MutableStateFlow<List<EqBand>>(emptyList())
+    val currentBandsR: StateFlow<List<EqBand>> = _currentBandsR.asStateFlow()
+
+    private val _originalMeasurementR = MutableStateFlow<List<FrequencyPoint>>(emptyList())
+    val originalMeasurementR: StateFlow<List<FrequencyPoint>> = _originalMeasurementR.asStateFlow()
+
+    // Which ear band edits and measurement loads target while stereo is on.
+    private val _editChannel = MutableStateFlow(EqChannel.LEFT)
+    val editChannel: StateFlow<EqChannel> = _editChannel.asStateFlow()
+
+    // Names of the per-ear measurement selections for the channel dropdowns.
+    // Session-scoped: the curves themselves are restored across restarts, the
+    // labels aren't (they'd need their own keys for marginal value).
+    private val _measurementLabelL = MutableStateFlow<String?>(null)
+    val measurementLabelL: StateFlow<String?> = _measurementLabelL.asStateFlow()
+    private val _measurementLabelR = MutableStateFlow<String?>(null)
+    val measurementLabelR: StateFlow<String?> = _measurementLabelR.asStateFlow()
+
     private val _currentPreamp = MutableStateFlow(0f)
     val currentPreamp: StateFlow<Float> = _currentPreamp.asStateFlow()
 
@@ -271,6 +295,30 @@ class EqViewModel @Inject constructor(
                     _originalMeasurement.value = points
                 } catch (_: Exception) { }
             }
+
+            // Restore 2-channel state: the switch, right-ear bands, right-ear
+            // measurement. All three survive the switch being off.
+            _stereoMode.value = preferences.eqStereoMode.first()
+            val bandsRJson = preferences.eqBandsRJson.first()
+            if (!bandsRJson.isNullOrBlank()) {
+                try {
+                    val jsonParser = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+                    _currentBandsR.value = jsonParser.decodeFromString(
+                        kotlinx.serialization.builtins.ListSerializer(EqBand.serializer()),
+                        bandsRJson,
+                    )
+                } catch (_: Exception) { }
+            }
+            val measurementRJson = preferences.eqMeasurementRJson.first()
+            if (!measurementRJson.isNullOrBlank()) {
+                try {
+                    val jsonParser = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+                    _originalMeasurementR.value = jsonParser.decodeFromString(
+                        kotlinx.serialization.builtins.ListSerializer(FrequencyPoint.serializer()),
+                        measurementRJson,
+                    )
+                } catch (_: Exception) { }
+            }
         }
 
         viewModelScope.launch {
@@ -290,9 +338,11 @@ class EqViewModel @Inject constructor(
         // their boosts eat the same headroom). Toggling auto on also lands
         // here, since _autoPreamp is a source.
         viewModelScope.launch {
-            combine(_currentBands, _toneControls, _autoPreamp) { bands, tone, auto ->
-                Triple(bands, tone, auto)
-            }.collect { (bands, tone, auto) -> if (auto) applyAutoPreamp(bands, tone) }
+            combine(
+                _currentBands, _currentBandsR, _stereoMode, _toneControls, _autoPreamp,
+            ) { l, r, stereo, tone, auto ->
+                PreampSources(l, r, stereo, tone, auto)
+            }.collect { src -> if (src.auto) applyAutoPreamp(src) }
         }
 
         // Resolve the custom-targets list AND the selected target together so
@@ -384,6 +434,25 @@ class EqViewModel @Inject constructor(
             _currentBands.value = preset.bands
             _currentPreamp.value = preset.preamp
 
+            // A stereo preset restores its right ear and re-enables 2-channel
+            // mode; a mono preset mirrors L into R so, if stereo is on, both
+            // ears follow the preset instead of R keeping a stale curve.
+            val presetR = preset.bandsR
+            if (presetR != null) {
+                _currentBandsR.value = presetR
+                saveBandsRToPreferences(presetR)
+                if (!_stereoMode.value) {
+                    _stereoMode.value = true
+                    preferences.setEqStereoMode(true)
+                }
+            } else if (_stereoMode.value && _currentBandsR.value.isNotEmpty()) {
+                // Only while 2-channel is ON. With the switch off, the stored
+                // right-ear bands are dormant by design — overwriting them here
+                // would destroy the calibration the toggle promised to keep.
+                _currentBandsR.value = preset.bands
+                saveBandsRToPreferences(preset.bands)
+            }
+
             // Update preferences
             preferences.setEqActivePreset(presetId)
             preferences.setEqPreamp(preset.preamp.toDouble())
@@ -404,6 +473,17 @@ class EqViewModel @Inject constructor(
      * Update an individual band
      */
     fun updateBand(bandId: Int, newBand: EqBand) {
+        // In 2-channel mode edits land on whichever ear is selected.
+        if (_stereoMode.value && _editChannel.value == EqChannel.RIGHT) {
+            val updatedR = _currentBandsR.value.toMutableList()
+            val indexR = updatedR.indexOfFirst { it.id == bandId }
+            if (indexR >= 0) {
+                updatedR[indexR] = newBand
+                _currentBandsR.value = updatedR
+                saveBandsRToPreferences(updatedR)
+            }
+            return
+        }
         val updatedBands = _currentBands.value.toMutableList()
         val index = updatedBands.indexOfFirst { it.id == bandId }
         if (index >= 0) {
@@ -444,13 +524,47 @@ class EqViewModel @Inject constructor(
         viewModelScope.launch { preferences.setEqAutoPreamp(enabled) }
     }
 
-    private fun applyAutoPreamp(
-        bands: List<EqBand>,
-        tone: tf.monochrome.android.domain.model.ToneControls,
-    ) {
+    /**
+     * 2-channel (per-ear) switch. Turning it off is non-destructive: the
+     * right-ear bands stay in DataStore and come straight back on re-enable —
+     * only the flag changes what the audio path applies.
+     */
+    fun setStereoMode(enabled: Boolean) {
+        _stereoMode.value = enabled
+        if (enabled && _currentBandsR.value.isEmpty() && _currentBands.value.isNotEmpty()) {
+            // First enable: seed the right ear from the left so the sound is
+            // unchanged until a right-channel measurement is picked.
+            _currentBandsR.value = _currentBands.value
+            saveBandsRToPreferences(_currentBands.value)
+        }
+        if (!enabled) _editChannel.value = EqChannel.LEFT
+        viewModelScope.launch { preferences.setEqStereoMode(enabled) }
+    }
+
+    fun setEditChannel(channel: EqChannel) {
+        _editChannel.value = channel
+    }
+
+    private data class PreampSources(
+        val bandsL: List<EqBand>,
+        val bandsR: List<EqBand>,
+        val stereo: Boolean,
+        val tone: tf.monochrome.android.domain.model.ToneControls,
+        val auto: Boolean,
+    )
+
+    private fun applyAutoPreamp(src: PreampSources) {
         // Fold the tone shelves in as the same EqBands the audio path runs
         // (toBands() is empty when the tone stage is switched off — a bypass).
-        val auto = -combinedPeakBoostDb(bands + tone.toBands(), _sampleRate.value)
+        val toneBands = src.tone.toBands()
+        // ONE shared preamp sized to the hotter ear. Per-channel preamps would
+        // silently re-tilt L/R balance; the curves carry any intended
+        // asymmetry, the preamp only guards headroom.
+        val peakL = combinedPeakBoostDb(src.bandsL + toneBands, _sampleRate.value)
+        val peakR = if (src.stereo && src.bandsR.isNotEmpty()) {
+            combinedPeakBoostDb(src.bandsR + toneBands, _sampleRate.value)
+        } else 0f
+        val auto = -maxOf(peakL, peakR)
         // Epsilon gate: skips the DataStore write when nothing changed (e.g.
         // cut-only band edits) and settles the collector after a preset load
         // briefly sets the stored preamp before the recompute lands.
@@ -515,6 +629,13 @@ class EqViewModel @Inject constructor(
         _currentBands.value = flatBands
         _currentPreamp.value = 0f
         saveBandsToPreferences(flatBands)
+        // Flatten the right ear too — reset means silence the whole correction,
+        // not just the ear currently selected for editing.
+        if (_currentBandsR.value.isNotEmpty()) {
+            val flatR = _currentBandsR.value.map { it.copy(gain = 0f) }
+            _currentBandsR.value = flatR
+            saveBandsRToPreferences(flatR)
+        }
         viewModelScope.launch {
             preferences.setEqPreamp(0.0)
         }
@@ -531,6 +652,9 @@ class EqViewModel @Inject constructor(
                     name = presetName,
                     description = description,
                     bands = _currentBands.value,
+                    // Only a stereo save carries R — a mono preset stays null
+                    // so loading it drives both ears from the left list.
+                    bandsR = if (_stereoMode.value) _currentBandsR.value else null,
                     preamp = _currentPreamp.value,
                     targetId = _selectedTarget.value.id,
                     targetName = _selectedTarget.value.label,
@@ -543,6 +667,79 @@ class EqViewModel @Inject constructor(
                 _error.value = null
             } catch (e: Exception) {
                 _error.value = "Failed to save preset: ${e.message}"
+            }
+        }
+    }
+
+    /**
+     * Import a parsed EqualizerAPO profile: always saved as a custom preset,
+     * optionally applied immediately. [channel] narrows the apply to one ear
+     * (2-channel mode); null applies to both — and mirrors into R whenever an
+     * R list exists, so a stale right-ear curve can't survive a "both" import.
+     */
+    fun importApoProfile(
+        profile: tf.monochrome.android.data.import_.ParsedEqProfile,
+        name: String,
+        channel: EqChannel?,
+        apply: Boolean,
+    ) {
+        viewModelScope.launch {
+            try {
+                // Re-id sequentially: band ids key the UI's selection and the
+                // file's own filter numbers may repeat or skip.
+                val bands = profile.bands.mapIndexed { i, b -> b.copy(id = i) }
+                val preset = EqPreset(
+                    id = "custom_preset_${System.currentTimeMillis()}",
+                    name = name,
+                    description = "Imported EqualizerAPO profile",
+                    bands = bands,
+                    preamp = profile.preamp,
+                    isCustom = true,
+                )
+                eqRepository.savePreset(preset)
+                if (apply) {
+                    when (channel) {
+                        EqChannel.RIGHT -> {
+                            _currentBandsR.value = bands
+                            saveBandsRToPreferences(bands)
+                        }
+                        EqChannel.LEFT -> {
+                            _currentBands.value = bands
+                            saveBandsToPreferences(bands)
+                        }
+                        null -> {
+                            _currentBands.value = bands
+                            saveBandsToPreferences(bands)
+                            if (_currentBandsR.value.isNotEmpty()) {
+                                _currentBandsR.value = bands
+                                saveBandsRToPreferences(bands)
+                            }
+                        }
+                    }
+                    if (channel == EqChannel.RIGHT) {
+                        // Right-only apply: the preset's bands landed on ONE
+                        // ear, so it is not "the active preset". Clearing the
+                        // persisted id makes restart restore from the raw
+                        // per-ear band prefs — exactly the state applied here.
+                        _activePreset.value = null
+                        preferences.setEqActivePreset(null)
+                    } else {
+                        _activePreset.value = preset
+                        preferences.setEqActivePreset(preset.id)
+                    }
+                    // Auto-preamp recomputes from the bands on its own; only a
+                    // manual preamp adopts the file's value.
+                    if (!_autoPreamp.value) {
+                        _currentPreamp.value = profile.preamp
+                        preferences.setEqPreamp(profile.preamp.toDouble())
+                    }
+                    // "Save & apply" means HEAR it — enabling here beats
+                    // silently importing into a bypassed EQ.
+                    if (!_eqEnabled.value) enableEq()
+                }
+                _error.value = null
+            } catch (e: Exception) {
+                _error.value = "Failed to import profile: ${e.message}"
             }
         }
     }
@@ -762,11 +959,12 @@ class EqViewModel @Inject constructor(
     fun selectMeasurement(
         headphone: Headphone,
         measurement: tf.monochrome.android.domain.model.AutoEqMeasurement,
+        channel: EqChannel = EqChannel.LEFT,
     ) {
         _selectedHeadphone.value = headphone
         viewModelScope.launch {
             preferences.setEqSelectedHeadphone(headphone.id, headphone.name)
-            loadHeadphonePresetForMeasurement(measurement)
+            loadHeadphonePresetForMeasurement(measurement, channel)
         }
     }
 
@@ -780,8 +978,19 @@ class EqViewModel @Inject constructor(
         } catch (_: Exception) { }
     }
 
+    private suspend fun persistMeasurementR(points: List<FrequencyPoint>) {
+        try {
+            val json = kotlinx.serialization.json.Json.encodeToString(
+                kotlinx.serialization.builtins.ListSerializer(FrequencyPoint.serializer()),
+                points,
+            )
+            preferences.setEqMeasurementRJson(json)
+        } catch (_: Exception) { }
+    }
+
     private suspend fun loadHeadphonePresetForMeasurement(
         measurement: tf.monochrome.android.domain.model.AutoEqMeasurement,
+        channel: EqChannel = EqChannel.LEFT,
     ) {
         try {
             _isCalculating.value = true
@@ -809,8 +1018,16 @@ class EqViewModel @Inject constructor(
                 return
             }
 
-            _originalMeasurement.value = parsed
-            persistMeasurement(parsed)
+            val label = measurement.fileName + " · " + measurement.source
+            if (channel == EqChannel.RIGHT) {
+                _originalMeasurementR.value = parsed
+                persistMeasurementR(parsed)
+                _measurementLabelR.value = label
+            } else {
+                _originalMeasurement.value = parsed
+                persistMeasurement(parsed)
+                _measurementLabelL.value = label
+            }
 
             val target = _selectedTarget.value.data
             if (target.isEmpty()) {
@@ -826,8 +1043,13 @@ class EqViewModel @Inject constructor(
                 maxFrequency = _maxFrequency.value,
                 sampleRate = _sampleRate.value,
             )
-            _currentBands.value = bands
-            saveBandsToPreferences(bands)
+            if (channel == EqChannel.RIGHT) {
+                _currentBandsR.value = bands
+                saveBandsRToPreferences(bands)
+            } else {
+                _currentBands.value = bands
+                saveBandsToPreferences(bands)
+            }
             _error.value = null
             _isCalculating.value = false
         } catch (e: Exception) {
@@ -932,7 +1154,10 @@ class EqViewModel @Inject constructor(
     }
 
     fun updateBandByDrag(bandId: Int, newFreq: Float, newGain: Float) {
-        val updatedBands = _currentBands.value.toMutableList()
+        // Graph drags edit whichever ear is selected in 2-channel mode.
+        val editRight = _stereoMode.value && _editChannel.value == EqChannel.RIGHT
+        val updatedBands =
+            (if (editRight) _currentBandsR.value else _currentBands.value).toMutableList()
         val index = updatedBands.indexOfFirst { it.id == bandId }
         if (index >= 0) {
             val cap = EqLimits.AUTOEQ_MAX_BAND_DB
@@ -944,15 +1169,27 @@ class EqViewModel @Inject constructor(
                 freq = newFreq.coerceIn(EqLimits.MIN_FREQ_HZ, EqLimits.MAX_FREQ_HZ),
                 gain = clampedGain
             )
-            _currentBands.value = updatedBands
-            saveBandsToPreferences(updatedBands)
+            if (editRight) {
+                _currentBandsR.value = updatedBands
+                saveBandsRToPreferences(updatedBands)
+            } else {
+                _currentBands.value = updatedBands
+                saveBandsToPreferences(updatedBands)
+            }
         }
     }
 
     fun runAutoEq() {
-        val measurement = _originalMeasurement.value
+        // Recompute for the ear currently being edited — same routing idiom as
+        // updateBand. Without this, running AutoEQ with the Right ear selected
+        // read the LEFT measurement and overwrote the LEFT bands.
+        val editRight = _stereoMode.value && _editChannel.value == EqChannel.RIGHT
+        val measurement =
+            if (editRight) _originalMeasurementR.value else _originalMeasurement.value
         if (measurement.isEmpty()) {
-            _error.value = "No headphone measurement loaded"
+            _error.value =
+                if (editRight) "No right-ear measurement loaded"
+                else "No headphone measurement loaded"
             return
         }
         val target = _selectedTarget.value.data
@@ -971,8 +1208,13 @@ class EqViewModel @Inject constructor(
                     maxFrequency = _maxFrequency.value,
                     sampleRate = _sampleRate.value
                 )
-                _currentBands.value = bands
-                saveBandsToPreferences(bands)
+                if (editRight) {
+                    _currentBandsR.value = bands
+                    saveBandsRToPreferences(bands)
+                } else {
+                    _currentBands.value = bands
+                    saveBandsToPreferences(bands)
+                }
             } catch (e: Exception) {
                 _error.value = "AutoEQ calculation failed: ${e.message}"
             } finally {
@@ -986,7 +1228,7 @@ class EqViewModel @Inject constructor(
     /**
      * Import measurement from raw file contents (read by UI via ContentResolver)
      */
-    fun importMeasurementData(rawData: String) {
+    fun importMeasurementData(rawData: String, channel: EqChannel = EqChannel.LEFT) {
         viewModelScope.launch {
             try {
                 _isCalculating.value = true
@@ -999,7 +1241,15 @@ class EqViewModel @Inject constructor(
                     return@launch
                 }
 
-                _originalMeasurement.value = measurement
+                if (channel == EqChannel.RIGHT) {
+                    _originalMeasurementR.value = measurement
+                    persistMeasurementR(measurement)
+                    _measurementLabelR.value = "Imported file"
+                } else {
+                    _originalMeasurement.value = measurement
+                    persistMeasurement(measurement)
+                    _measurementLabelL.value = "Imported file"
+                }
 
                 val target = _selectedTarget.value.data
                 if (target.isEmpty()) {
@@ -1016,8 +1266,13 @@ class EqViewModel @Inject constructor(
                     sampleRate = _sampleRate.value
                 )
 
-                _currentBands.value = bands
-                saveBandsToPreferences(bands)
+                if (channel == EqChannel.RIGHT) {
+                    _currentBandsR.value = bands
+                    saveBandsRToPreferences(bands)
+                } else {
+                    _currentBands.value = bands
+                    saveBandsToPreferences(bands)
+                }
             } catch (e: Exception) {
                 _error.value = "Import failed: ${e.message}"
             } finally {
@@ -1130,4 +1385,24 @@ class EqViewModel @Inject constructor(
             }
         }
     }
+
+    private fun saveBandsRToPreferences(bands: List<EqBand>) {
+        viewModelScope.launch {
+            try {
+                val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+                val bandsJson = json.encodeToString(
+                    kotlinx.serialization.builtins.ListSerializer(
+                        EqBand.serializer()
+                    ),
+                    bands
+                )
+                preferences.setEqBandsR(bandsJson)
+            } catch (e: Exception) {
+                _error.value = "Failed to save right-channel bands: ${e.message}"
+            }
+        }
+    }
 }
+
+/** Which ear a band edit or measurement load targets in 2-channel mode. */
+enum class EqChannel { LEFT, RIGHT }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -99,7 +99,8 @@ class EqViewModel @Inject constructor(
     private val _measurementSampleR = MutableStateFlow<String?>(null)
     val measurementSampleR: StateFlow<String?> = _measurementSampleR.asStateFlow()
 
-    // Measurement smoothing (octave fraction; 0 = off). Session-scoped.
+    // Measurement smoothing, SeapEngine-style percent (0–100; 0 = off).
+    // Session-scoped.
     private val _smoothing = MutableStateFlow(0f)
     val smoothing: StateFlow<Float> = _smoothing.asStateFlow()
 
@@ -562,9 +563,9 @@ class EqViewModel @Inject constructor(
     }
 
     /**
-     * Measurement smoothing in octave fractions (0 = off, up to 1/3 oct).
-     * Applied to the measurement JUST before the optimizer runs — raw curves
-     * stay stored, so stepping the slider re-derives corrections without
+     * Measurement smoothing percent (0–100, SeapEngine's scale). Applied to
+     * the measurement JUST before the optimizer runs — raw curves stay
+     * stored, so moving the slider re-derives corrections without
      * re-fetching anything.
      */
     fun setSmoothing(fraction: Float) {

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -586,17 +586,19 @@ class EqViewModel @Inject constructor(
      * stereo pair, file import, sample stepping, manual re-run) funnels
      * through here so smoothing is applied uniformly.
      */
-    private fun runEngine(
+    private suspend fun runEngine(
         measurement: List<FrequencyPoint>,
         target: List<FrequencyPoint>,
-    ): List<EqBand> = AutoEqEngine.runAutoEqAlgorithm(
-        measurement = AutoEqEngine.smoothCurve(measurement, _smoothing.value),
-        target = target,
-        bandCount = _bandCount.value,
-        maxFrequency = _maxFrequency.value,
-        sampleRate = _sampleRate.value,
-        algorithm = _algorithm.value,
-    )
+    ): List<EqBand> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+        AutoEqEngine.runAutoEqAlgorithm(
+            measurement = AutoEqEngine.smoothCurve(measurement, _smoothing.value),
+            target = target,
+            bandCount = _bandCount.value,
+            maxFrequency = _maxFrequency.value,
+            sampleRate = _sampleRate.value,
+            algorithm = _algorithm.value,
+        )
+    }
 
     /**
      * Step the loaded squig.link measurement to its next/previous published
@@ -1113,7 +1115,7 @@ class EqViewModel @Inject constructor(
             return true
         }
 
-        fun compute(m: List<FrequencyPoint>) = runEngine(m, target)
+        suspend fun compute(m: List<FrequencyPoint>) = runEngine(m, target)
 
         val lSample = if (lParsed.isNotEmpty()) lFetch!!.second else rFetch!!.second
         val rSample = if (rParsed.isNotEmpty()) rFetch!!.second else lFetch!!.second

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -563,35 +563,13 @@ class EqViewModel @Inject constructor(
     }
 
     /**
-     * Measurement smoothing percent (0–100, SeapEngine's scale). Applied to
-     * the measurement JUST before the optimizer runs — raw curves stay
-     * stored, so moving the slider re-derives corrections without
-     * re-fetching anything.
+     * Measurement smoothing percent (0–100, SeapEngine's scale). Preview
+     * only: the graph's curves smooth immediately, but corrections are NOT
+     * re-derived until the AutoEQ button is pressed — SeapEngine's Generate
+     * semantics, and it keeps slider drags from thrashing the audio path.
      */
     fun setSmoothing(fraction: Float) {
-        if (fraction == _smoothing.value) return
         _smoothing.value = fraction
-        viewModelScope.launch {
-            val target = _selectedTarget.value.data
-            if (target.isEmpty()) return@launch
-            try {
-                _isCalculating.value = true
-                val l = _originalMeasurement.value
-                if (l.isNotEmpty()) {
-                    val bands = runEngine(l, target)
-                    _currentBands.value = bands
-                    saveBandsToPreferences(bands)
-                }
-                val r = _originalMeasurementR.value
-                if (r.isNotEmpty()) {
-                    val bands = runEngine(r, target)
-                    _currentBandsR.value = bands
-                    saveBandsRToPreferences(bands)
-                }
-            } finally {
-                _isCalculating.value = false
-            }
-        }
     }
 
     /**
@@ -1376,16 +1354,14 @@ class EqViewModel @Inject constructor(
     }
 
     fun runAutoEq() {
-        // Recompute for the ear currently being edited — same routing idiom as
-        // updateBand. Without this, running AutoEQ with the Right ear selected
-        // read the LEFT measurement and overwrote the LEFT bands.
-        val editRight = _stereoMode.value && _editChannel.value == EqChannel.RIGHT
-        val measurement =
-            if (editRight) _originalMeasurementR.value else _originalMeasurement.value
-        if (measurement.isEmpty()) {
-            _error.value =
-                if (editRight) "No right-ear measurement loaded"
-                else "No headphone measurement loaded"
+        // Reprocess is explicit: the smoothing slider only previews, and this
+        // button re-derives corrections at the current settings — for EVERY
+        // ear that has a measurement, so a smoothing change can't leave the
+        // two ears computed at different settings.
+        val measL = _originalMeasurement.value
+        val measR = if (_stereoMode.value) _originalMeasurementR.value else emptyList<FrequencyPoint>()
+        if (measL.isEmpty() && measR.isEmpty()) {
+            _error.value = "No headphone measurement loaded"
             return
         }
         val target = _selectedTarget.value.data
@@ -1397,16 +1373,18 @@ class EqViewModel @Inject constructor(
             try {
                 _isCalculating.value = true
                 _error.value = null
-                val bands = runEngine(measurement, target)
-                if (editRight) {
-                    _currentBandsR.value = bands
-                    saveBandsRToPreferences(bands)
-                } else {
+                if (measL.isNotEmpty()) {
+                    val bands = runEngine(measL, target)
                     _currentBands.value = bands
                     saveBandsToPreferences(bands)
                 }
+                if (measR.isNotEmpty()) {
+                    val bands = runEngine(measR, target)
+                    _currentBandsR.value = bands
+                    saveBandsRToPreferences(bands)
+                }
             } catch (e: Exception) {
-                _error.value = "AutoEQ calculation failed: ${e.message}"
+                _error.value = "AutoEQ calculation failed: " + e.message
             } finally {
                 _isCalculating.value = false
             }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -104,6 +104,15 @@ class EqViewModel @Inject constructor(
     private val _smoothing = MutableStateFlow(0f)
     val smoothing: StateFlow<Float> = _smoothing.asStateFlow()
 
+    // Fitting algorithm — selectable so shelf-ends and peaking-only stacks
+    // can be A/B'd on the same measurement. Applies on the next AutoEQ press.
+    private val _algorithm = MutableStateFlow(tf.monochrome.android.audio.eq.AutoEqAlgorithm.PEAKING)
+    val algorithm: StateFlow<tf.monochrome.android.audio.eq.AutoEqAlgorithm> = _algorithm.asStateFlow()
+
+    fun setAlgorithm(algorithm: tf.monochrome.android.audio.eq.AutoEqAlgorithm) {
+        _algorithm.value = algorithm
+    }
+
     private val _currentPreamp = MutableStateFlow(0f)
     val currentPreamp: StateFlow<Float> = _currentPreamp.asStateFlow()
 
@@ -586,6 +595,7 @@ class EqViewModel @Inject constructor(
         bandCount = _bandCount.value,
         maxFrequency = _maxFrequency.value,
         sampleRate = _sampleRate.value,
+        algorithm = _algorithm.value,
     )
 
     /**

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -361,6 +361,7 @@ fun EqualizerScreen(
                             if (stereoMode) {
                                 if (editRight) currentBands else currentBandsR
                             } else null,
+                        primaryIsRight = editRight,
                     )
                 }
               }
@@ -430,7 +431,8 @@ fun EqualizerScreen(
               tf.monochrome.android.devedit.DevEditable("eq_autoeq_button", Modifier.fillMaxWidth()) {
                 GradientAutoEqButton(
                     isCalculating = isCalculating,
-                    onClick = { viewModel.runAutoEq() },
+                    // Re-press mid-computation is a race, not a retry.
+                    onClick = { if (!isCalculating) viewModel.runAutoEq() },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 4.dp)

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -1229,7 +1229,9 @@ fun EqualizerScreen(
 fun EqBandSlider(
     band: EqBand,
     onBandChanged: (EqBand) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // Parametric rows are removable; AutoEQ rows (fixed band count) pass null.
+    onDelete: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -1240,8 +1242,19 @@ fun EqBandSlider(
         // --- Filter type ---
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
+            if (onDelete != null) {
+                IconButton(onClick = onDelete, modifier = Modifier.size(24.dp)) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Remove band",
+                        modifier = Modifier.size(15.dp),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
             FilterType.values().forEach { type ->
                 val isSel = band.type == type
                 Box(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -119,7 +119,6 @@ fun EqualizerScreen(
     var showSaveDialog by rememberSaveable { mutableStateOf(false) }
     var showTargetMenu by remember { mutableStateOf(false) }
     var showHeadphoneSelect by remember { mutableStateOf(false) }
-    var showMeasurementUpload by remember { mutableStateOf(false) }
     var showPresetMenu by remember { mutableStateOf(false) }
     var showBandsExpanded by rememberSaveable { mutableStateOf(true) }
     var showProfilesExpanded by rememberSaveable { mutableStateOf(true) }
@@ -308,6 +307,39 @@ fun EqualizerScreen(
               }
             }
 
+            // ─── Preamp (right under the graph it applies to) ───
+            item {
+              tf.monochrome.android.devedit.DevEditable("eq_preamp_slider", Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            "Preamp",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            if (autoPreamp) "Auto · ${currentPreamp.roundToInt()} dB"
+                            else "${currentPreamp.roundToInt()} dB",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    Slider(
+                        value = if (currentPreamp.isNaN()) 0f else currentPreamp.coerceIn(-24f, 24f),
+                        onValueChange = { viewModel.setPreamp(it) },
+                        valueRange = -24f..24f,
+                        steps = 47,
+                        enabled = !autoPreamp,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+              }
+            }
+
             // ─── Bass / treble tone shelves (shares the player's tone setting) ───
             item {
                 tf.monochrome.android.ui.player.ToneControlsPanel(
@@ -472,16 +504,6 @@ fun EqualizerScreen(
                     }
                     // Entry point for the guided measurement-calibration flow,
                     // which was fully built but previously unreachable.
-                    TextButton(onClick = { showMeasurementUpload = true }) {
-                        Icon(
-                            Icons.Default.UploadFile,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text("Upload & calibrate a measurement")
-                    }
                     TextButton(onClick = { showProfileImport = true }) {
                         Icon(
                             Icons.Default.UploadFile,
@@ -919,39 +941,6 @@ fun EqualizerScreen(
             }
 
             if (showBandsExpanded) {
-                // Preamp
-                item {
-                  tf.monochrome.android.devedit.DevEditable("eq_preamp_slider", Modifier.fillMaxWidth()) {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                "Preamp",
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                            Text(
-                                if (autoPreamp) "Auto · ${currentPreamp.roundToInt()} dB"
-                                else "${currentPreamp.roundToInt()} dB",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                        Slider(
-                            value = if (currentPreamp.isNaN()) 0f else currentPreamp.coerceIn(-24f, 24f),
-                            onValueChange = { viewModel.setPreamp(it) },
-                            valueRange = -24f..24f,
-                            steps = 47,
-                            enabled = !autoPreamp,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                  }
-                }
-
                 // Band sliders
                 items(activeBands) { band ->
                     EqBandSlider(
@@ -1113,26 +1102,6 @@ fun EqualizerScreen(
         )
     }
 
-    if (showMeasurementUpload) {
-        AlertDialog(
-            onDismissRequest = { showMeasurementUpload = false },
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Transparent),
-            properties = androidx.compose.ui.window.DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = true,
-                dismissOnClickOutside = false
-            ),
-            content = {
-                MeasurementUploadScreen(
-                    viewModel = viewModel,
-                    onDismiss = { showMeasurementUpload = false },
-                    onCalibrationComplete = { showMeasurementUpload = false }
-                )
-            }
-        )
-    }
 
     presetToDelete?.let { preset ->
         AlertDialog(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -398,6 +398,19 @@ fun EqualizerScreen(
               }
             }
 
+            // ─── AutoEQ (reprocess at current smoothing/target/params) ───
+            item {
+              tf.monochrome.android.devedit.DevEditable("eq_autoeq_button", Modifier.fillMaxWidth()) {
+                GradientAutoEqButton(
+                    isCalculating = isCalculating,
+                    onClick = { viewModel.runAutoEq() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+              }
+            }
+
             // ─── Bass / treble tone shelves (shares the player's tone setting) ───
             item {
                 tf.monochrome.android.ui.player.ToneControlsPanel(
@@ -750,11 +763,7 @@ fun EqualizerScreen(
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
-                    GradientAutoEqButton(
-                        isCalculating = isCalculating,
-                        onClick = { viewModel.runAutoEq() },
-                        modifier = Modifier.weight(1f)
-                    )
+                    Spacer(modifier = Modifier.weight(1f))
                     IconButton(
                         onClick = {
                             val hp = selectedHeadphone?.name

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -106,6 +106,7 @@ fun EqualizerScreen(
     val measurementSampleL by viewModel.measurementSampleL.collectAsState()
     val measurementSampleR by viewModel.measurementSampleR.collectAsState()
     val smoothing by viewModel.smoothing.collectAsState()
+    val algorithm by viewModel.algorithm.collectAsState()
 
     // Which ear the graph, band list and export operate on. Off-stereo this is
     // always the left/mono channel, so everything below reduces to the old UI.
@@ -394,6 +395,32 @@ fun EqualizerScreen(
                         enabled = !autoPreamp,
                         modifier = Modifier.fillMaxWidth()
                     )
+                }
+              }
+            }
+
+            // ─── Algorithm selector — applies on the next AutoEQ press ───
+            item {
+              tf.monochrome.android.devedit.DevEditable("eq_algorithm_row", Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        "ALGORITHM",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    tf.monochrome.android.audio.eq.AutoEqAlgorithm.entries.forEach { algo ->
+                        FilterChip(
+                            selected = algorithm == algo,
+                            onClick = { viewModel.setAlgorithm(algo) },
+                            label = { Text(algo.label) },
+                        )
+                    }
                 }
               }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -1137,10 +1137,10 @@ fun EqualizerScreen(
     if (showProfileImport) {
         ImportEqProfileSheet(
             maxBandGainDb = EqLimits.AUTOEQ_MAX_BAND_DB,
-            channelChoices = stereoMode,
+            perEar = true,
             onDismiss = { showProfileImport = false },
-            onImport = { profile, name, channel, apply ->
-                viewModel.importApoProfile(profile, name, channel, apply)
+            onImport = { left, right, name ->
+                viewModel.importApoProfile(left, right, name)
             },
             onMeasurementDetected = { raw, channel ->
                 viewModel.importMeasurementData(raw, channel ?: EqChannel.LEFT)

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.FilterType
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
 import kotlin.math.roundToInt
@@ -940,10 +941,10 @@ fun EqualizerScreen(
                             )
                         }
                         Slider(
-                            value = if (currentPreamp.isNaN()) 0f else currentPreamp.coerceIn(-12f, 12f),
+                            value = if (currentPreamp.isNaN()) 0f else currentPreamp.coerceIn(-24f, 24f),
                             onValueChange = { viewModel.setPreamp(it) },
-                            valueRange = -12f..12f,
-                            steps = 23,
+                            valueRange = -24f..24f,
+                            steps = 47,
                             enabled = !autoPreamp,
                             modifier = Modifier.fillMaxWidth()
                         )
@@ -1163,13 +1164,48 @@ fun EqBandSlider(
             .liquidGlass(shape = RoundedCornerShape(8.dp))
             .padding(12.dp)
     ) {
+        // --- Filter type ---
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            FilterType.values().forEach { type ->
+                val isSel = band.type == type
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(6.dp))
+                        .liquidGlass(
+                            shape = RoundedCornerShape(6.dp),
+                            tintAlpha = if (isSel) 0.45f else 0.15f,
+                        )
+                        .bounceClick(onClick = { onBandChanged(band.copy(type = type)) })
+                        .padding(vertical = 6.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        when (type) {
+                            FilterType.PEAKING -> "PEAK"
+                            FilterType.LOWSHELF -> "LOW-S"
+                            FilterType.HIGHSHELF -> "HIGH-S"
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = if (isSel) FontWeight.Bold else FontWeight.Normal,
+                        color = if (isSel) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
         // --- Frequency Slider ---
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text("Freq (${band.type})", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("Freq", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text("${band.freq.toInt()} Hz", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold)
         }
         val minLogFreq = kotlin.math.log10(20f)
@@ -1207,10 +1243,11 @@ fun EqBandSlider(
             )
         }
         Slider(
-            value = if (band.gain.isNaN()) 0f else band.gain.coerceIn(-12f, 12f),
+            value = if (band.gain.isNaN()) 0f
+                    else band.gain.coerceIn(-EqLimits.AUTOEQ_MAX_BAND_DB, EqLimits.AUTOEQ_MAX_BAND_DB),
             onValueChange = { onBandChanged(band.copy(gain = it)) },
-            valueRange = -12f..12f,
-            steps = 23,
+            valueRange = -EqLimits.AUTOEQ_MAX_BAND_DB..EqLimits.AUTOEQ_MAX_BAND_DB,
+            steps = 2 * EqLimits.AUTOEQ_MAX_BAND_DB.toInt() - 1,
             modifier = Modifier.fillMaxWidth().height(32.dp)
         )
         

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -127,6 +128,7 @@ fun EqualizerScreen(
     var showTargetNameDialog by rememberSaveable { mutableStateOf(false) }
     var importForRight by rememberSaveable { mutableStateOf(false) }
     var showProfileImport by rememberSaveable { mutableStateOf(false) }
+    var showHelp by rememberSaveable { mutableStateOf(false) }
     var headphoneSelectForRight by rememberSaveable { mutableStateOf(false) }
     var pendingTargetData by rememberSaveable { mutableStateOf("") }
     var targetName by rememberSaveable { mutableStateOf("") }
@@ -254,6 +256,18 @@ fun EqualizerScreen(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
+                        IconButton(
+                            onClick = { showHelp = true },
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
+                                contentDescription = "Help",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
                         Switch(
                             checked = eqEnabled,
                             onCheckedChange = { viewModel.toggleEq() }
@@ -1032,6 +1046,10 @@ fun EqualizerScreen(
                 TextButton(onClick = { showSaveDialog = false }) { Text("Cancel") }
             }
         )
+    }
+
+    if (showHelp) {
+        AutoEqHelpSheet(onDismiss = { showHelp = false })
     }
 
     if (showProfileImport) {

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import tf.monochrome.android.audio.eq.AutoEqEngine
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -100,6 +103,9 @@ fun EqualizerScreen(
     val editChannel by viewModel.editChannel.collectAsState()
     val measurementLabelL by viewModel.measurementLabelL.collectAsState()
     val measurementLabelR by viewModel.measurementLabelR.collectAsState()
+    val measurementSampleL by viewModel.measurementSampleL.collectAsState()
+    val measurementSampleR by viewModel.measurementSampleR.collectAsState()
+    val smoothing by viewModel.smoothing.collectAsState()
 
     // Which ear the graph, band list and export operate on. Off-stereo this is
     // always the left/mono channel, so everything below reduces to the old UI.
@@ -281,6 +287,42 @@ fun EqualizerScreen(
             item {
               tf.monochrome.android.devedit.DevEditable("eq_graph", Modifier.fillMaxWidth()) {
                 Column {
+                    // ── Measurement smoothing ──
+                    // Discrete fractional-octave steps, applied to the
+                    // measurement before the optimizer runs. Displayed curves
+                    // smooth along with it so what you see is what gets EQ'd.
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Text(
+                            "SMOOTHING",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        val smoothSteps = listOf(0f, 1f / 24f, 1f / 12f, 1f / 6f, 1f / 3f)
+                        val smoothLabels = listOf("Off", "1/24", "1/12", "1/6", "1/3")
+                        val smoothIdx = smoothSteps
+                            .indexOfFirst { kotlin.math.abs(it - smoothing) < 0.001f }
+                            .coerceAtLeast(0)
+                        Slider(
+                            value = smoothIdx.toFloat(),
+                            onValueChange = {
+                                viewModel.setSmoothing(smoothSteps[it.roundToInt().coerceIn(0, 4)])
+                            },
+                            valueRange = 0f..4f,
+                            steps = 3,
+                            modifier = Modifier.weight(1f).height(28.dp)
+                        )
+                        Text(
+                            smoothLabels[smoothIdx],
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
                     if (stereoMode) {
                         Row(
                             modifier = Modifier.padding(horizontal = 16.dp),
@@ -298,8 +340,18 @@ fun EqualizerScreen(
                             )
                         }
                     }
+                    // Graph shows the SMOOTHED measurements — the same curves
+                    // the optimizer actually corrects at this slider setting.
+                    val displayMeasurement = remember(activeMeasurement, smoothing) {
+                        AutoEqEngine.smoothCurve(activeMeasurement, smoothing)
+                    }
+                    val otherMeasurement =
+                        if (editRight) originalMeasurement else originalMeasurementR
+                    val displayOther = remember(otherMeasurement, smoothing) {
+                        AutoEqEngine.smoothCurve(otherMeasurement, smoothing)
+                    }
                     FrequencyResponseGraph(
-                        originalCurve = activeMeasurement,
+                        originalCurve = displayMeasurement,
                         targetCurve = selectedTarget.data,
                         eqBands = activeBands,
                         preamp = currentPreamp,
@@ -308,10 +360,7 @@ fun EqualizerScreen(
                             viewModel.updateBandByDrag(bandId, freq, gain)
                         },
                         modifier = Modifier.padding(horizontal = 12.dp),
-                        secondaryMeasurement =
-                            if (stereoMode) {
-                                if (editRight) originalMeasurement else originalMeasurementR
-                            } else emptyList(),
+                        secondaryMeasurement = if (stereoMode) displayOther else emptyList(),
                         secondaryBands =
                             if (stereoMode) {
                                 if (editRight) currentBands else currentBandsR
@@ -441,20 +490,31 @@ fun EqualizerScreen(
                                 showHeadphoneSelect = true
                             },
                             trailingIcon = {
-                                IconButton(
-                                    onClick = {
-                                        importForRight = false
-                                        measurementFilePicker.launch("text/*")
-                                    },
-                                    modifier = Modifier
-                                        .size(44.dp)
-                                        .liquidGlass(shape = RoundedCornerShape(8.dp))
-                                ) {
-                                    Icon(
-                                        Icons.Default.UploadFile,
-                                        contentDescription = "Import left measurement file",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    measurementSampleL?.let { sample ->
+                                        SampleStepper(
+                                            label = sample,
+                                            onStep = { forward ->
+                                                viewModel.cycleMeasurementSample(EqChannel.LEFT, forward)
+                                            },
+                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                    }
+                                    IconButton(
+                                        onClick = {
+                                            importForRight = false
+                                            measurementFilePicker.launch("text/*")
+                                        },
+                                        modifier = Modifier
+                                            .size(44.dp)
+                                            .liquidGlass(shape = RoundedCornerShape(8.dp))
+                                    ) {
+                                        Icon(
+                                            Icons.Default.UploadFile,
+                                            contentDescription = "Import left measurement file",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
                                 }
                             }
                         )
@@ -471,20 +531,31 @@ fun EqualizerScreen(
                                 showHeadphoneSelect = true
                             },
                             trailingIcon = {
-                                IconButton(
-                                    onClick = {
-                                        importForRight = true
-                                        measurementFilePicker.launch("text/*")
-                                    },
-                                    modifier = Modifier
-                                        .size(44.dp)
-                                        .liquidGlass(shape = RoundedCornerShape(8.dp))
-                                ) {
-                                    Icon(
-                                        Icons.Default.UploadFile,
-                                        contentDescription = "Import right measurement file",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    measurementSampleR?.let { sample ->
+                                        SampleStepper(
+                                            label = sample,
+                                            onStep = { forward ->
+                                                viewModel.cycleMeasurementSample(EqChannel.RIGHT, forward)
+                                            },
+                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                    }
+                                    IconButton(
+                                        onClick = {
+                                            importForRight = true
+                                            measurementFilePicker.launch("text/*")
+                                        },
+                                        modifier = Modifier
+                                            .size(44.dp)
+                                            .liquidGlass(shape = RoundedCornerShape(8.dp))
+                                    ) {
+                                        Icon(
+                                            Icons.Default.UploadFile,
+                                            contentDescription = "Import right measurement file",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
                                 }
                             }
                         )
@@ -496,22 +567,33 @@ fun EqualizerScreen(
                                 showHeadphoneSelect = true
                             },
                             trailingIcon = {
-                                IconButton(
-                                    onClick = {
-                                        importForRight = false
-                                        measurementFilePicker.launch("text/*")
-                                    },
-                                    modifier = Modifier
-                                        .size(44.dp)
-                                        .liquidGlass(
-                                            shape = RoundedCornerShape(8.dp)
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    measurementSampleL?.let { sample ->
+                                        SampleStepper(
+                                            label = sample,
+                                            onStep = { forward ->
+                                                viewModel.cycleMeasurementSample(EqChannel.LEFT, forward)
+                                            },
                                         )
-                                ) {
-                                    Icon(
-                                        Icons.Default.UploadFile,
-                                        contentDescription = "Import measurement file",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                    }
+                                    IconButton(
+                                        onClick = {
+                                            importForRight = false
+                                            measurementFilePicker.launch("text/*")
+                                        },
+                                        modifier = Modifier
+                                            .size(44.dp)
+                                            .liquidGlass(
+                                                shape = RoundedCornerShape(8.dp)
+                                            )
+                                    ) {
+                                        Icon(
+                                            Icons.Default.UploadFile,
+                                            contentDescription = "Import measurement file",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
                                 }
                             }
                         )
@@ -1256,6 +1338,50 @@ fun EqBandSlider(
                 modifier = Modifier.fillMaxWidth().height(32.dp)
             )
         }
+    }
+}
+
+/**
+ * squig-style sample switcher: ▲/▼ step through a measurement's published
+ * sweeps (L → L1 → L2 → …, wrapping) with the current sample shown between
+ * the arrows.
+ */
+@Composable
+private fun SampleStepper(
+    label: String,
+    onStep: (forward: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .size(width = 36.dp, height = 44.dp)
+            .liquidGlass(shape = RoundedCornerShape(8.dp)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            Icons.Default.KeyboardArrowUp,
+            contentDescription = "Next sample",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .clickable { onStep(true) }
+        )
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold
+        )
+        Icon(
+            Icons.Default.KeyboardArrowDown,
+            contentDescription = "Previous sample",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .clickable { onStep(false) }
+        )
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -303,22 +303,17 @@ fun EqualizerScreen(
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        val smoothSteps = listOf(0f, 1f / 24f, 1f / 12f, 1f / 6f, 1f / 3f)
-                        val smoothLabels = listOf("Off", "1/24", "1/12", "1/6", "1/3")
-                        val smoothIdx = smoothSteps
-                            .indexOfFirst { kotlin.math.abs(it - smoothing) < 0.001f }
-                            .coerceAtLeast(0)
                         Slider(
-                            value = smoothIdx.toFloat(),
+                            value = smoothing,
                             onValueChange = {
-                                viewModel.setSmoothing(smoothSteps[it.roundToInt().coerceIn(0, 4)])
+                                // 1 % increments, SeapEngine's scale.
+                                viewModel.setSmoothing(it.roundToInt().toFloat().coerceIn(0f, 100f))
                             },
-                            valueRange = 0f..4f,
-                            steps = 3,
+                            valueRange = 0f..100f,
                             modifier = Modifier.weight(1f).height(28.dp)
                         )
                         Text(
-                            smoothLabels[smoothIdx],
+                            "${smoothing.roundToInt()}%",
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary
                         )

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -91,6 +92,20 @@ fun EqualizerScreen(
     val isCalculating by viewModel.isCalculating.collectAsState()
     val originalMeasurement by viewModel.originalMeasurement.collectAsState()
     val selectedHeadphone by viewModel.selectedHeadphone.collectAsState()
+    val stereoMode by viewModel.stereoMode.collectAsState()
+    val currentBandsR by viewModel.currentBandsR.collectAsState()
+    val originalMeasurementR by viewModel.originalMeasurementR.collectAsState()
+    val editChannel by viewModel.editChannel.collectAsState()
+    val measurementLabelL by viewModel.measurementLabelL.collectAsState()
+    val measurementLabelR by viewModel.measurementLabelR.collectAsState()
+
+    // Which ear the graph, band list and export operate on. Off-stereo this is
+    // always the left/mono channel, so everything below reduces to the old UI.
+    val editRight = stereoMode && editChannel == EqChannel.RIGHT
+    val activeBands = if (editRight) currentBandsR else currentBands
+    val activeMeasurement =
+        if (editRight) originalMeasurementR.ifEmpty { originalMeasurement }
+        else originalMeasurement
     val bandCount by viewModel.bandCount.collectAsState()
     val maxFrequency by viewModel.maxFrequency.collectAsState()
     val sampleRate by viewModel.sampleRate.collectAsState()
@@ -110,6 +125,9 @@ fun EqualizerScreen(
     var saveName by rememberSaveable { mutableStateOf("") }
     var saveDescription by rememberSaveable { mutableStateOf("") }
     var showTargetNameDialog by rememberSaveable { mutableStateOf(false) }
+    var importForRight by rememberSaveable { mutableStateOf(false) }
+    var showProfileImport by rememberSaveable { mutableStateOf(false) }
+    var headphoneSelectForRight by rememberSaveable { mutableStateOf(false) }
     var pendingTargetData by rememberSaveable { mutableStateOf("") }
     var targetName by rememberSaveable { mutableStateOf("") }
     var presetToDelete by remember { mutableStateOf<tf.monochrome.android.domain.model.EqPreset?>(null) }
@@ -135,7 +153,10 @@ fun EqualizerScreen(
         try {
             val rawData = context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
             if (!rawData.isNullOrEmpty()) {
-                viewModel.importMeasurementData(rawData)
+                viewModel.importMeasurementData(
+                    rawData,
+                    if (importForRight) EqChannel.RIGHT else EqChannel.LEFT,
+                )
             } else {
                 android.widget.Toast.makeText(context, "Couldn't read the selected file", android.widget.Toast.LENGTH_SHORT).show()
             }
@@ -245,17 +266,44 @@ fun EqualizerScreen(
             // ─── Interactive Frequency Graph ───
             item {
               tf.monochrome.android.devedit.DevEditable("eq_graph", Modifier.fillMaxWidth()) {
-                FrequencyResponseGraph(
-                    originalCurve = originalMeasurement,
-                    targetCurve = selectedTarget.data,
-                    eqBands = currentBands,
-                    preamp = currentPreamp,
-                    sampleRate = sampleRate,
-                    onBandDragged = { bandId, freq, gain ->
-                        viewModel.updateBandByDrag(bandId, freq, gain)
-                    },
-                    modifier = Modifier.padding(horizontal = 12.dp)
-                )
+                Column {
+                    if (stereoMode) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            FilterChip(
+                                selected = !editRight,
+                                onClick = { viewModel.setEditChannel(EqChannel.LEFT) },
+                                label = { Text("Left ear") },
+                            )
+                            FilterChip(
+                                selected = editRight,
+                                onClick = { viewModel.setEditChannel(EqChannel.RIGHT) },
+                                label = { Text("Right ear") },
+                            )
+                        }
+                    }
+                    FrequencyResponseGraph(
+                        originalCurve = activeMeasurement,
+                        targetCurve = selectedTarget.data,
+                        eqBands = activeBands,
+                        preamp = currentPreamp,
+                        sampleRate = sampleRate,
+                        onBandDragged = { bandId, freq, gain ->
+                            viewModel.updateBandByDrag(bandId, freq, gain)
+                        },
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        secondaryMeasurement =
+                            if (stereoMode) {
+                                if (editRight) originalMeasurement else originalMeasurementR
+                            } else emptyList(),
+                        secondaryBands =
+                            if (stereoMode) {
+                                if (editRight) currentBands else currentBandsR
+                            } else null,
+                    )
+                }
               }
             }
 
@@ -304,26 +352,123 @@ fun EqualizerScreen(
               tf.monochrome.android.devedit.DevEditable("eq_headphone_selector", Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
                     SectionLabel("HEADPHONE MODEL")
-                    SelectorRow(
-                        value = selectedHeadphone?.name ?: "Select headphone...",
-                        onClick = { showHeadphoneSelect = true },
-                        trailingIcon = {
-                            IconButton(
-                                onClick = { measurementFilePicker.launch("text/*") },
-                                modifier = Modifier
-                                    .size(44.dp)
-                                    .liquidGlass(
-                                        shape = RoundedCornerShape(8.dp)
-                                    )
-                            ) {
-                                Icon(
-                                    Icons.Default.UploadFile,
-                                    contentDescription = "Import measurement file",
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+
+                    // ── 2-channel (per-ear) switch ──
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                "2-channel calibration",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                "Separate left/right corrections. Non-destructive to " +
+                                    "switch off; system-wide EQ stays mono.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
-                    )
+                        Switch(
+                            checked = stereoMode,
+                            onCheckedChange = { viewModel.setStereoMode(it) }
+                        )
+                    }
+
+                    if (stereoMode) {
+                        Text(
+                            "LEFT EAR",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        SelectorRow(
+                            value = measurementLabelL
+                                ?: selectedHeadphone?.name
+                                ?: "Select left measurement...",
+                            onClick = {
+                                headphoneSelectForRight = false
+                                showHeadphoneSelect = true
+                            },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = {
+                                        importForRight = false
+                                        measurementFilePicker.launch("text/*")
+                                    },
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .liquidGlass(shape = RoundedCornerShape(8.dp))
+                                ) {
+                                    Icon(
+                                        Icons.Default.UploadFile,
+                                        contentDescription = "Import left measurement file",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            "RIGHT EAR",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        SelectorRow(
+                            value = measurementLabelR ?: "Select right measurement...",
+                            onClick = {
+                                headphoneSelectForRight = true
+                                showHeadphoneSelect = true
+                            },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = {
+                                        importForRight = true
+                                        measurementFilePicker.launch("text/*")
+                                    },
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .liquidGlass(shape = RoundedCornerShape(8.dp))
+                                ) {
+                                    Icon(
+                                        Icons.Default.UploadFile,
+                                        contentDescription = "Import right measurement file",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        )
+                    } else {
+                        SelectorRow(
+                            value = selectedHeadphone?.name ?: "Select headphone...",
+                            onClick = {
+                                headphoneSelectForRight = false
+                                showHeadphoneSelect = true
+                            },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = {
+                                        importForRight = false
+                                        measurementFilePicker.launch("text/*")
+                                    },
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .liquidGlass(
+                                            shape = RoundedCornerShape(8.dp)
+                                        )
+                                ) {
+                                    Icon(
+                                        Icons.Default.UploadFile,
+                                        contentDescription = "Import measurement file",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        )
+                    }
                     // Entry point for the guided measurement-calibration flow,
                     // which was fully built but previously unreachable.
                     TextButton(onClick = { showMeasurementUpload = true }) {
@@ -335,6 +480,16 @@ fun EqualizerScreen(
                         )
                         Spacer(modifier = Modifier.width(6.dp))
                         Text("Upload & calibrate a measurement")
+                    }
+                    TextButton(onClick = { showProfileImport = true }) {
+                        Icon(
+                            Icons.Default.UploadFile,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text("Import EQ profile (APO txt / CSV)")
                     }
                 }
               }
@@ -460,11 +615,13 @@ fun EqualizerScreen(
                 ) {
                     IconButton(
                         onClick = {
-                            if (currentBands.isEmpty()) {
+                            if (activeBands.isEmpty()) {
                                 android.widget.Toast.makeText(context, "No EQ bands to export", android.widget.Toast.LENGTH_SHORT).show()
                             } else {
-                                pendingEqExport = buildParametricEqText(currentBands, currentPreamp)
-                                eqExportLauncher.launch("MonochromeEQ.txt")
+                                pendingEqExport = buildParametricEqText(activeBands, currentPreamp)
+                                eqExportLauncher.launch(
+                                    if (editRight) "MonochromeEQ-R.txt" else "MonochromeEQ.txt"
+                                )
                             }
                         },
                         modifier = Modifier
@@ -795,7 +952,7 @@ fun EqualizerScreen(
                 }
 
                 // Band sliders
-                items(currentBands) { band ->
+                items(activeBands) { band ->
                     EqBandSlider(
                         band = band,
                         onBandChanged = { viewModel.updateBand(band.id, it) },
@@ -887,6 +1044,20 @@ fun EqualizerScreen(
         )
     }
 
+    if (showProfileImport) {
+        ImportEqProfileSheet(
+            maxBandGainDb = EqLimits.AUTOEQ_MAX_BAND_DB,
+            channelChoices = stereoMode,
+            onDismiss = { showProfileImport = false },
+            onImport = { profile, name, channel, apply ->
+                viewModel.importApoProfile(profile, name, channel, apply)
+            },
+            onMeasurementDetected = { raw, channel ->
+                viewModel.importMeasurementData(raw, channel ?: EqChannel.LEFT)
+            },
+        )
+    }
+
     if (showHeadphoneSelect) {
         AlertDialog(
             onDismissRequest = { showHeadphoneSelect = false },
@@ -901,6 +1072,7 @@ fun EqualizerScreen(
             content = {
                 HeadphoneSelectScreen(
                     viewModel = viewModel,
+                    channel = if (headphoneSelectForRight) EqChannel.RIGHT else EqChannel.LEFT,
                     onHeadphoneSelected = { showHeadphoneSelect = false },
                     onDismiss = { showHeadphoneSelect = false }
                 )

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -88,6 +88,10 @@ fun FrequencyResponseGraph(
     // no drag dots — edits always go through the primary channel props.
     secondaryMeasurement: List<FrequencyPoint> = emptyList(),
     secondaryBands: List<EqBand>? = null,
+    // True when the PRIMARY (edited) channel is the right ear. Callers pass
+    // the active ear as primary, so without this the legend would label the
+    // right ear's curves "L meas"/"L EQ" whenever the Right chip is selected.
+    primaryIsRight: Boolean = false,
 ) {
     val primary = MaterialTheme.colorScheme.primary
 
@@ -198,6 +202,7 @@ fun FrequencyResponseGraph(
     // curve reappearing after process death is harmless, and a Set isn't
     // Bundle-friendly anyway. Keys: measL / target / eqL / measR / eqR.
     var hiddenCurves by remember { mutableStateOf(setOf<String>()) }
+    val eqDotsHidden by rememberUpdatedState("eqL" in hiddenCurves)
 
     // The pointer gestures below are keyed on Unit so they are NOT torn down and
     // restarted every time a band drag mutates `eqBands` (which froze the drag
@@ -233,6 +238,7 @@ fun FrequencyResponseGraph(
                 .pointerInput(Unit) {
                     if (onBandDragged == null) return@pointerInput
                     detectTapGestures { offset ->
+                        if (eqDotsHidden) return@detectTapGestures
                         val tapped = findNearestBand(
                             offset, latestEqBands, latestCorrected, latestPreamp, latestSampleRate,
                             size.width.toFloat(), size.height.toFloat(),
@@ -245,6 +251,8 @@ fun FrequencyResponseGraph(
                     if (onBandDragged == null) return@pointerInput
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
+                        // Hidden dots must not be silently draggable.
+                        if (eqDotsHidden) return@awaitEachGesture
                         // Grab the band nearest the finger's landing point. If none
                         // is under it, bail without consuming so the enclosing
                         // pager / scroll gets the drag instead of the graph
@@ -477,13 +485,18 @@ fun FrequencyResponseGraph(
         // the other ear's curves get their own entries.
         if (showLegend) {
             val stereo = secondaryBands != null
+            // Slot keys stay fixed (measL = primary slot); LABELS follow the
+            // ear actually occupying the slot, so switching the edit chip
+            // never misattributes one ear's curve to the other.
+            val p1 = if (primaryIsRight) "R" else "L"
+            val p2 = if (primaryIsRight) "L" else "R"
             val entries = buildList {
-                add(Triple("measL", if (stereo) "L meas" else "Original", Color(0xFF4A9EFF)))
+                add(Triple("measL", if (stereo) "$p1 meas" else "Original", Color(0xFF4A9EFF)))
                 add(Triple("target", "Target", primary))
-                add(Triple("eqL", if (stereo) "L EQ" else "Corrected", Color(0xFFFF4444)))
+                add(Triple("eqL", if (stereo) "$p1 EQ" else "Corrected", Color(0xFFFF4444)))
                 if (stereo) {
-                    add(Triple("measR", "R meas", Color(0xFF4A9EFF).copy(alpha = 0.5f)))
-                    add(Triple("eqR", "R EQ", Color(0xFFFFB300)))
+                    add(Triple("measR", "$p2 meas", Color(0xFF4A9EFF).copy(alpha = 0.5f)))
+                    add(Triple("eqR", "$p2 EQ", Color(0xFFFFB300)))
                 }
             }
             Row(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -81,6 +81,11 @@ fun FrequencyResponseGraph(
     // Absolute cap used when mapping a drag's Y-pixel back to a gain value.
     // Defaults to the AutoEQ cap; Parametric EQ callers pass EqLimits.PARAMETRIC_MAX_BAND_DB.
     maxAbsDragGain: Float = EqLimits.AUTOEQ_MAX_BAND_DB,
+    // Read-only overlay of the OTHER ear in 2-channel mode: its measurement
+    // and bands render as stroke-only curves behind the primary channel, with
+    // no drag dots — edits always go through the primary channel props.
+    secondaryMeasurement: List<FrequencyPoint> = emptyList(),
+    secondaryBands: List<EqBand>? = null,
 ) {
     val primary = MaterialTheme.colorScheme.primary
 
@@ -142,6 +147,45 @@ fun FrequencyResponseGraph(
                 }
                 FrequencyPoint(freq, g)
             }.filter { it.gain.isFinite() }
+        }
+    }
+
+    // Secondary (other-ear) corrected curve, mirroring correctedCurve. Falls
+    // back to the primary measurement when the other ear has no curve of its
+    // own yet, so the overlay still shows what that ear's bands would do.
+    val secondaryCorrected = remember(
+        secondaryMeasurement, secondaryBands, originalCurve, preamp, sampleRate, zeroOffset,
+    ) {
+        val bands = secondaryBands
+        if (bands == null) {
+            emptyList()
+        } else {
+            val base = secondaryMeasurement.ifEmpty { originalCurve }
+            if (base.isNotEmpty()) {
+                base.map { point ->
+                    var g = point.gain + preamp
+                    bands.forEach { band ->
+                        if (band.enabled) {
+                            g += AutoEqEngine.calculateBiquadResponse(point.freq, band, sampleRate)
+                        }
+                    }
+                    FrequencyPoint(point.freq, g)
+                }.filter { it.gain.isFinite() }
+            } else if (bands.isNotEmpty()) {
+                val samples = 256
+                val logMin = log10(MIN_FREQ)
+                val logMax = log10(MAX_FREQ)
+                (0 until samples).map { i ->
+                    val freq = 10f.pow(logMin + i.toFloat() / (samples - 1) * (logMax - logMin))
+                    var g = preamp + zeroOffset
+                    bands.forEach { band ->
+                        if (band.enabled) g += AutoEqEngine.calculateBiquadResponse(freq, band, sampleRate)
+                    }
+                    FrequencyPoint(freq, g)
+                }.filter { it.gain.isFinite() }
+            } else {
+                emptyList()
+            }
         }
     }
 
@@ -268,6 +312,16 @@ fun FrequencyResponseGraph(
             // Target curve (bright white dashed) — normalized to measurement
             if (normalizedTarget.size > 1) {
                 drawDashedCurve(normalizedTarget, primary, w, h, minGain, maxGain, 2.5f)
+            }
+
+            // Other ear (2-channel mode): stroke-only so it reads as context
+            // behind the primary channel's filled curve, drawn first so the
+            // primary stays on top.
+            if (secondaryMeasurement.size > 1) {
+                drawCurve(secondaryMeasurement, Color(0xFF4A9EFF).copy(alpha = 0.35f), w, h, minGain, maxGain, 1.5f)
+            }
+            if (secondaryCorrected.size > 1) {
+                drawCurve(secondaryCorrected, Color(0xFFFFB300), w, h, minGain, maxGain, 2f)
             }
 
             // Corrected curve (bright red solid) with fabfilter pro-q 3 style fill

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -291,8 +291,8 @@ fun FrequencyResponseGraph(
             // Grid
             drawGrid(w, h, minGain, maxGain, zeroOffset)
 
-            // dB labels on right
-            drawDbLabels(w, h, minGain, maxGain)
+            // dB labels on right — relative to the centre line
+            drawDbLabels(w, h, minGain, maxGain, zeroOffset)
 
             // Frequency labels at bottom
             drawFreqLabels(w, h)
@@ -311,14 +311,25 @@ fun FrequencyResponseGraph(
                 )
             }
 
-            // Original measurement curve (bright blue for visibility)
-            if (originalCurve.size > 1 && "measL" !in hiddenCurves) {
-                drawCurve(originalCurve, Color(0xFF4A9EFF), w, h, minGain, maxGain, 2.5f)
+            // Correction-gap shading: the region between the measurement and
+            // the target IS the problem the EQ exists to fix. Shading it makes
+            // "why does the correction curve look like that" readable at a
+            // glance — the correction mirrors this shape.
+            if (originalCurve.size > 1 && normalizedTarget.size > 1 &&
+                "measL" !in hiddenCurves && "target" !in hiddenCurves
+            ) {
+                drawCurveGap(originalCurve, normalizedTarget, primary.copy(alpha = 0.08f), w, h, minGain, maxGain)
             }
 
-            // Target curve (bright white dashed) — normalized to measurement
+            // Original measurement curve — an INPUT, drawn thinner and dimmer
+            // than the corrected result so the eye lands on the outcome first.
+            if (originalCurve.size > 1 && "measL" !in hiddenCurves) {
+                drawCurve(originalCurve, Color(0xFF4A9EFF).copy(alpha = 0.8f), w, h, minGain, maxGain, 1.5f)
+            }
+
+            // Target curve (dashed) — the other input, same receded weight.
             if (normalizedTarget.size > 1 && "target" !in hiddenCurves) {
-                drawDashedCurve(normalizedTarget, primary, w, h, minGain, maxGain, 2.5f)
+                drawDashedCurve(normalizedTarget, primary.copy(alpha = 0.85f), w, h, minGain, maxGain, 1.5f)
             }
 
             // Other ear (2-channel mode): stroke-only so it reads as context
@@ -355,7 +366,8 @@ fun FrequencyResponseGraph(
                     drawCurve(contributionPoints, curveNeutral.copy(alpha = 0.2f), w, h, minGain, maxGain, 1.5f)
 
                     // Floating Tooltip
-                    val infoText = "${band.freq.toInt()}Hz  ${"%.1f".format(band.gain)}dB"
+                    val infoText =
+                        "${band.freq.toInt()} Hz  ${"%.1f".format(band.gain)} dB  Q ${"%.2f".format(band.q)}"
                     val paint = android.graphics.Paint().apply {
                         color = android.graphics.Color.WHITE
                         // sp (not raw px) so the label scales with display
@@ -377,15 +389,27 @@ fun FrequencyResponseGraph(
                     drawContext.canvas.nativeCanvas.drawText(infoText, dotX, rectTop, paint)
                 }
 
-                // Dynamic color based on frequency (Rainbow/Spectrum)
-                val hue = ((log10(band.freq) - log10(20f)) / (log10(20000f) - log10(20f)) * 360f)
-                val bandColor = Color.hsl(hue, 0.7f, 0.6f)
+                // Colour encodes what the band DOES — green boosts, red cuts,
+                // grey ≈ flat — instead of the old frequency-rainbow, which was
+                // decorative but said nothing about the band's effect.
+                val bandColor = when {
+                    band.gain > 0.25f -> Color(0xFF4CAF50)
+                    band.gain < -0.25f -> Color(0xFFE53935)
+                    else -> Color(0xFF9E9E9E)
+                }
 
-                // Glow for selected/dragged band
                 if (isSelected) {
+                    // Vertical guide so the band's frequency reads against the
+                    // axis while dragging.
+                    drawLine(
+                        color = curveNeutral.copy(alpha = 0.25f),
+                        start = Offset(dotX, GRAPH_PADDING_TOP),
+                        end = Offset(dotX, h - GRAPH_PADDING_BOTTOM),
+                        strokeWidth = 1.5f,
+                    )
                     drawCircle(
                         color = bandColor.copy(alpha = 0.4f),
-                        radius = 32f,
+                        radius = 34f,
                         center = Offset(dotX, dotY)
                     )
                 }
@@ -393,22 +417,37 @@ fun FrequencyResponseGraph(
                 // Main dot shadow/border
                 drawCircle(
                     color = Color.Black,
-                    radius = if (isSelected) 17f else 15f,
+                    radius = if (isSelected) 19f else 17f,
                     center = Offset(dotX, dotY)
                 )
 
                 // Main dot
                 drawCircle(
                     color = bandColor,
-                    radius = if (isSelected) 15f else 13f,
+                    radius = if (isSelected) 17f else 15f,
                     center = Offset(dotX, dotY)
                 )
                 // White border
                 drawCircle(
                     color = curveNeutral,
-                    radius = if (isSelected) 15f else 13f,
+                    radius = if (isSelected) 17f else 15f,
                     center = Offset(dotX, dotY),
                     style = Stroke(width = if (isSelected) 3f else 2.5f)
+                )
+
+                // Band number, so a dot maps to its row in the list below.
+                val numPaint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.WHITE
+                    textSize = 9.sp.toPx()
+                    textAlign = android.graphics.Paint.Align.CENTER
+                    isFakeBoldText = true
+                    isAntiAlias = true
+                }
+                drawContext.canvas.nativeCanvas.drawText(
+                    "${band.id + 1}",
+                    dotX,
+                    dotY + numPaint.textSize * 0.35f,
+                    numPaint,
                 )
             }
         }
@@ -472,12 +511,12 @@ private fun LegendDot(
     ) {
         Box(
             modifier = Modifier
-                .size(8.dp)
-                .background(color, RoundedCornerShape(4.dp))
+                .size(10.dp)
+                .background(color, RoundedCornerShape(5.dp))
         )
         Text(
             label,
-            fontSize = 9.sp,
+            fontSize = 10.sp,
             color = labelColor
         )
     }
@@ -727,19 +766,32 @@ private fun DrawScope.drawGrid(
         range > 30 -> 5f
         else -> 5f
     }
-    var g = (minGain / step).toInt() * step
-    while (g <= maxGain) {
-        val y = gainToY(g, height, minGain, maxGain)
+    // Step on RELATIVE dB so lines land exactly on the ±labels, with the
+    // centre (0 dB) line emphasized — it is the "no change" reference the
+    // whole graph reads against.
+    var rel = kotlin.math.ceil((minGain - zeroOffset) / step) * step
+    while (rel + zeroOffset <= maxGain) {
+        val y = gainToY(rel + zeroOffset, height, minGain, maxGain)
         if (y in GRAPH_PADDING_TOP..(height - GRAPH_PADDING_BOTTOM)) {
-            // Highlight the zero/center line
-            val lineColor = if (abs(g - zeroOffset) < 0.5f) zeroLineColor else gridColor
-            drawLine(lineColor, Offset(GRAPH_PADDING_LEFT, y), Offset(width - GRAPH_PADDING_RIGHT, y), 1f)
+            val isZero = abs(rel) < 0.5f
+            drawLine(
+                if (isZero) zeroLineColor else gridColor,
+                Offset(GRAPH_PADDING_LEFT, y),
+                Offset(width - GRAPH_PADDING_RIGHT, y),
+                if (isZero) 2f else 1f,
+            )
         }
-        g += step
+        rel += step
     }
 }
 
-private fun DrawScope.drawDbLabels(width: Float, height: Float, minGain: Float, maxGain: Float) {
+private fun DrawScope.drawDbLabels(
+    width: Float,
+    height: Float,
+    minGain: Float,
+    maxGain: Float,
+    zeroOffset: Float,
+) {
     val range = maxGain - minGain
     val step = when {
         range > 60 -> 10f
@@ -752,18 +804,23 @@ private fun DrawScope.drawDbLabels(width: Float, height: Float, minGain: Float, 
         textAlign = android.graphics.Paint.Align.LEFT
         isAntiAlias = true
     }
-    var g = (minGain / step).toInt() * step
-    while (g <= maxGain) {
+    // Labels are RELATIVE to the centre line ("+5", "0", "−5"), not raw SPL.
+    // The axis is normalized to the measurement's midband level, so absolute
+    // numbers like "73" carried no meaning a user could act on — what matters
+    // is how far above or below neutral the curve sits.
+    var rel = kotlin.math.ceil((minGain - zeroOffset) / step) * step
+    while (rel + zeroOffset <= maxGain) {
+        val g = rel + zeroOffset
         val y = gainToY(g, height, minGain, maxGain)
         if (y in GRAPH_PADDING_TOP..(height - GRAPH_PADDING_BOTTOM)) {
             drawContext.canvas.nativeCanvas.drawText(
-                "${g.toInt()}",
+                if (rel > 0f) "+${rel.toInt()}" else "${rel.toInt()}",
                 width - GRAPH_PADDING_RIGHT + 4f,
                 y + 7f,
                 paint
             )
         }
-        g += step
+        rel += step
     }
 }
 
@@ -785,6 +842,44 @@ private fun DrawScope.drawFreqLabels(width: Float, height: Float) {
             label, x, height - 2f, paint
         )
     }
+}
+
+/**
+ * Translucent fill between two curves — used to shade the measurement↔target
+ * gap. Both are resampled onto a shared log-frequency grid over their
+ * overlapping range, so differing point densities can't shear the polygon.
+ */
+private fun DrawScope.drawCurveGap(
+    a: List<FrequencyPoint>,
+    b: List<FrequencyPoint>,
+    color: Color,
+    width: Float,
+    height: Float,
+    minGain: Float,
+    maxGain: Float,
+) {
+    if (a.size < 2 || b.size < 2) return
+    val lo = maxOf(a.first().freq, b.first().freq).coerceAtLeast(MIN_FREQ)
+    val hi = minOf(a.last().freq, b.last().freq).coerceAtMost(MAX_FREQ)
+    if (hi <= lo) return
+    val samples = 128
+    val logLo = log10(lo)
+    val logHi = log10(hi)
+    val path = Path()
+    for (i in 0..samples) {
+        val freq = 10f.pow(logLo + i.toFloat() / samples * (logHi - logLo))
+        val x = freqToX(freq, width)
+        val y = gainToY(interpolateGain(freq, a), height, minGain, maxGain)
+        if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+    }
+    for (i in samples downTo 0) {
+        val freq = 10f.pow(logLo + i.toFloat() / samples * (logHi - logLo))
+        val x = freqToX(freq, width)
+        val y = gainToY(interpolateGain(freq, b), height, minGain, maxGain)
+        path.lineTo(x, y)
+    }
+    path.close()
+    drawPath(path, color)
 }
 
 private fun DrawScope.drawCurve(

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.clickable
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -192,6 +194,11 @@ fun FrequencyResponseGraph(
     var selectedBandId by remember { mutableIntStateOf(-1) }
     var isDragging by remember { mutableStateOf(false) }
 
+    // Curves hidden via legend taps. Plain remember, not saveable: a hidden
+    // curve reappearing after process death is harmless, and a Set isn't
+    // Bundle-friendly anyway. Keys: measL / target / eqL / measR / eqR.
+    var hiddenCurves by remember { mutableStateOf(setOf<String>()) }
+
     // The pointer gestures below are keyed on Unit so they are NOT torn down and
     // restarted every time a band drag mutates `eqBands` (which froze the drag
     // mid-gesture). All the values they need are read through updated-state
@@ -305,32 +312,32 @@ fun FrequencyResponseGraph(
             }
 
             // Original measurement curve (bright blue for visibility)
-            if (originalCurve.size > 1) {
+            if (originalCurve.size > 1 && "measL" !in hiddenCurves) {
                 drawCurve(originalCurve, Color(0xFF4A9EFF), w, h, minGain, maxGain, 2.5f)
             }
 
             // Target curve (bright white dashed) — normalized to measurement
-            if (normalizedTarget.size > 1) {
+            if (normalizedTarget.size > 1 && "target" !in hiddenCurves) {
                 drawDashedCurve(normalizedTarget, primary, w, h, minGain, maxGain, 2.5f)
             }
 
             // Other ear (2-channel mode): stroke-only so it reads as context
             // behind the primary channel's filled curve, drawn first so the
             // primary stays on top.
-            if (secondaryMeasurement.size > 1) {
+            if (secondaryMeasurement.size > 1 && "measR" !in hiddenCurves) {
                 drawCurve(secondaryMeasurement, Color(0xFF4A9EFF).copy(alpha = 0.35f), w, h, minGain, maxGain, 1.5f)
             }
-            if (secondaryCorrected.size > 1) {
+            if (secondaryCorrected.size > 1 && "eqR" !in hiddenCurves) {
                 drawCurve(secondaryCorrected, Color(0xFFFFB300), w, h, minGain, maxGain, 2f)
             }
 
             // Corrected curve (bright red solid) with fabfilter pro-q 3 style fill
-            if (correctedCurve.size > 1) {
+            if (correctedCurve.size > 1 && "eqL" !in hiddenCurves) {
                 drawFilledCurve(correctedCurve, Color(0xFFFF4444), w, h, minGain, maxGain, zeroOffset, 2.5f)
             }
 
-            // EQ band dots
-            eqBands.forEach { band ->
+            // EQ band dots ride the corrected curve, so they hide with it.
+            if ("eqL" !in hiddenCurves) eqBands.forEach { band ->
                 if (!band.enabled) return@forEach
                 // Find normalized positions
                 val dotX = freqToX(band.freq, w)
@@ -406,29 +413,62 @@ fun FrequencyResponseGraph(
             }
         }
 
-        // Legend overlay (hidden in parametric-only mode since there's no measurement/target curve)
+        // Legend overlay (hidden in parametric-only mode since there's no
+        // measurement/target curve). Every entry is a toggle: tapping hides or
+        // shows its curve, and the entry dims while hidden. In 2-channel mode
+        // the other ear's curves get their own entries.
         if (showLegend) {
+            val stereo = secondaryBands != null
+            val entries = buildList {
+                add(Triple("measL", if (stereo) "L meas" else "Original", Color(0xFF4A9EFF)))
+                add(Triple("target", "Target", primary))
+                add(Triple("eqL", if (stereo) "L EQ" else "Corrected", Color(0xFFFF4444)))
+                if (stereo) {
+                    add(Triple("measR", "R meas", Color(0xFF4A9EFF).copy(alpha = 0.5f)))
+                    add(Triple("eqR", "R EQ", Color(0xFFFFB300)))
+                }
+            }
             Row(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .background(legendBackground)
                     .padding(horizontal = 12.dp, vertical = 6.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
+                horizontalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterHorizontally)
             ) {
-                LegendDot("Original", Color(0xFF4A9EFF), legendLabelColor)
-                LegendDot("Target (Primary)", primary, legendLabelColor)
-                LegendDot("Corrected", Color(0xFFFF4444), legendLabelColor)
+                entries.forEach { (key, label, color) ->
+                    LegendDot(
+                        label = label,
+                        color = color,
+                        labelColor = legendLabelColor,
+                        active = key !in hiddenCurves,
+                        onClick = {
+                            hiddenCurves =
+                                if (key in hiddenCurves) hiddenCurves - key
+                                else hiddenCurves + key
+                        },
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-private fun LegendDot(label: String, color: Color, labelColor: Color) {
+private fun LegendDot(
+    label: String,
+    color: Color,
+    labelColor: Color,
+    active: Boolean = true,
+    onClick: (() -> Unit)? = null,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .let { m -> if (onClick != null) m.clip(RoundedCornerShape(4.dp)).clickable(onClick = onClick) else m }
+            .padding(horizontal = 2.dp, vertical = 2.dp)
+            .graphicsLayer { alpha = if (active) 1f else 0.35f }
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -348,6 +348,10 @@ fun FrequencyResponseGraph(
             }
 
             // EQ band dots ride the corrected curve, so they hide with it.
+            // Above ten bands the dots switch to compact handles — numbers and
+            // full-size circles at 31 bands are a wall that buries the very
+            // curve they annotate; the selected band always gets full detail.
+            val compactDots = eqBands.count { it.enabled } > 10
             if ("eqL" !in hiddenCurves) eqBands.forEach { band ->
                 if (!band.enabled) return@forEach
                 // Find normalized positions
@@ -414,41 +418,56 @@ fun FrequencyResponseGraph(
                     )
                 }
 
+                val dotRadius = when {
+                    isSelected -> 17f
+                    compactDots -> 6.5f
+                    else -> 15f
+                }
                 // Main dot shadow/border
                 drawCircle(
                     color = Color.Black,
-                    radius = if (isSelected) 19f else 17f,
+                    radius = dotRadius + 2f,
                     center = Offset(dotX, dotY)
                 )
 
                 // Main dot
                 drawCircle(
                     color = bandColor,
-                    radius = if (isSelected) 17f else 15f,
+                    radius = dotRadius,
                     center = Offset(dotX, dotY)
                 )
                 // White border
                 drawCircle(
                     color = curveNeutral,
-                    radius = if (isSelected) 17f else 15f,
+                    radius = dotRadius,
                     center = Offset(dotX, dotY),
-                    style = Stroke(width = if (isSelected) 3f else 2.5f)
+                    style = Stroke(
+                        width = when {
+                            isSelected -> 3f
+                            compactDots -> 1.5f
+                            else -> 2.5f
+                        }
+                    )
                 )
 
                 // Band number, so a dot maps to its row in the list below.
-                val numPaint = android.graphics.Paint().apply {
-                    color = android.graphics.Color.WHITE
-                    textSize = 9.sp.toPx()
-                    textAlign = android.graphics.Paint.Align.CENTER
-                    isFakeBoldText = true
-                    isAntiAlias = true
+                // Compact handles skip it (unreadable at that size and count);
+                // the selected band always shows its number.
+                if (!compactDots || isSelected) {
+                    val numPaint = android.graphics.Paint().apply {
+                        color = android.graphics.Color.WHITE
+                        textSize = 9.sp.toPx()
+                        textAlign = android.graphics.Paint.Align.CENTER
+                        isFakeBoldText = true
+                        isAntiAlias = true
+                    }
+                    drawContext.canvas.nativeCanvas.drawText(
+                        "${band.id + 1}",
+                        dotX,
+                        dotY + numPaint.textSize * 0.35f,
+                        numPaint,
+                    )
                 }
-                drawContext.canvas.nativeCanvas.drawText(
-                    "${band.id + 1}",
-                    dotX,
-                    dotY + numPaint.textSize * 0.35f,
-                    numPaint,
-                )
             }
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/eq/HeadphoneSelectScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/HeadphoneSelectScreen.kt
@@ -76,6 +76,7 @@ fun HeadphoneSelectScreen(
     viewModel: EqViewModel,
     onHeadphoneSelected: (Headphone) -> Unit,
     onDismiss: () -> Unit,
+    channel: EqChannel = EqChannel.LEFT,
 ) {
     val availableHeadphones by viewModel.availableHeadphones.collectAsState()
     val uploadedHeadphones by viewModel.uploadedHeadphones.collectAsState()
@@ -340,6 +341,7 @@ fun HeadphoneSelectScreen(
                                         viewModel.selectMeasurement(
                                             entry.row.headphone,
                                             entry.row.measurement,
+                                            channel,
                                         )
                                         onHeadphoneSelected(entry.row.headphone)
                                     },

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ImportEqProfileSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ImportEqProfileSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -43,64 +42,37 @@ import tf.monochrome.android.data.import_.ParsedEqProfile
  * Import an EqualizerAPO-style parametric profile (`ParametricEQ.txt` or a
  * band CSV) by paste or file.
  *
- * The centrepiece is the live preview: an EQ profile is invisible until it
- * plays, and a bad import is *audible* — so the parsed curve, the filter
- * count, and every warning the parser produced (skipped filter types, clamped
- * gains, derived preamp) are shown BEFORE anything is saved or applied.
- * Nothing is fixed up silently.
+ * With [perEar] the sheet is two panes — LEFT and RIGHT — each with its own
+ * paste window and Open-file button, and one Upload button at the end:
+ *  - only L filled  → mono import (drives both ears)
+ *  - L and R filled → a stereo preset; each ear gets its own filter stack
+ *  - only R filled  → imported as mono (it's the only curve there is)
  *
- * [channelChoices] — non-null on the AutoEQ surface while 2-channel mode is
- * on: the profile can target both ears or just one. Null hides the selector
- * (Parametric EQ, or mono AutoEQ).
- *
- * [onMeasurementDetected] — AutoEq publishes a frequency-response CSV right
- * next to the PEQ file, and users will inevitably hand us one. The parser
- * recognises it; if this callback is set the sheet offers to import it down
- * the measurement path instead of failing with "no filters found".
+ * The preview shows both stacks at once (right ear as the amber overlay) plus
+ * every warning the parser produced — an EQ profile is invisible until it
+ * plays, so nothing is fixed up or applied silently.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ImportEqProfileSheet(
     maxBandGainDb: Float,
     onDismiss: () -> Unit,
-    onImport: (profile: ParsedEqProfile, name: String, channel: EqChannel?, apply: Boolean) -> Unit,
-    channelChoices: Boolean = false,
+    onImport: (left: ParsedEqProfile?, right: ParsedEqProfile?, name: String) -> Unit,
+    perEar: Boolean = false,
     onMeasurementDetected: ((raw: String, channel: EqChannel?) -> Unit)? = null,
 ) {
-    val context = LocalContext.current
-    var rawText by rememberSaveable { mutableStateOf("") }
+    var rawL by rememberSaveable { mutableStateOf("") }
+    var rawR by rememberSaveable { mutableStateOf("") }
     var name by rememberSaveable { mutableStateOf("") }
-    // null = both ears (or mono); otherwise the single ear to import into.
-    var targetChannel by rememberSaveable { mutableStateOf<String?>(null) }
 
-    val parsed = remember(rawText, maxBandGainDb) {
-        if (rawText.isBlank()) null else ApoProfileParser.parse(rawText, maxBandGainDb)
+    val parsedL = remember(rawL, maxBandGainDb) {
+        if (rawL.isBlank()) null else ApoProfileParser.parse(rawL, maxBandGainDb)
     }
-
-    val filePicker = rememberLauncherForActivityResult(
-        ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        uri ?: return@rememberLauncherForActivityResult
-        try {
-            val text = context.contentResolver.openInputStream(uri)
-                ?.bufferedReader()?.use { it.readText() }
-            if (!text.isNullOrBlank()) {
-                rawText = text
-                if (name.isBlank()) {
-                    // Last path segment, minus extension and SAF's "primary:" /
-                    // "raw:" prefixes — a sensible default the user can retype.
-                    name = uri.lastPathSegment
-                        ?.substringAfterLast('/')
-                        ?.substringAfterLast(':')
-                        ?.removeSuffix(".txt")
-                        ?.removeSuffix(".csv")
-                        ?: ""
-                }
-            }
-        } catch (_: Exception) {
-            // Unreadable file: leave the sheet as-is; the empty state explains.
-        }
+    val parsedR = remember(rawR, maxBandGainDb) {
+        if (rawR.isBlank()) null else ApoProfileParser.parse(rawR, maxBandGainDb)
     }
+    val validL = parsedL?.takeIf { !it.isEmpty && !it.looksLikeMeasurement }
+    val validR = parsedR?.takeIf { !it.isEmpty && !it.looksLikeMeasurement }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
@@ -117,161 +89,198 @@ fun ImportEqProfileSheet(
                 fontWeight = FontWeight.Bold,
             )
             Text(
-                "EqualizerAPO / AutoEq ParametricEQ.txt, or a type,fc,gain,q CSV. " +
-                    "Paste below or open a file.",
+                if (perEar) {
+                    "EqualizerAPO / AutoEq ParametricEQ.txt or a type,fc,gain,q CSV. " +
+                        "Fill LEFT only for a mono profile, or both panes for a " +
+                        "per-ear stereo profile."
+                } else {
+                    "EqualizerAPO / AutoEq ParametricEQ.txt, or a type,fc,gain,q CSV. " +
+                        "Paste below or open a file."
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                TextButton(onClick = { filePicker.launch("*/*") }) {
-                    Icon(
-                        Icons.Default.UploadFile,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(Modifier.width(6.dp))
-                    Text("Open file")
-                }
-            }
-
-            OutlinedTextField(
-                value = rawText,
-                onValueChange = { rawText = it },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 96.dp, max = 160.dp),
-                placeholder = {
-                    Text(
-                        "Preamp: -6.8 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.9 dB Q 0.70",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
+            ProfilePane(
+                title = if (perEar) "LEFT EAR" else null,
+                raw = rawL,
+                onRaw = { rawL = it },
+                parsed = parsedL,
+                onFileName = { if (name.isBlank()) name = it },
+                onMeasurementImport = onMeasurementDetected?.let { cb ->
+                    { text -> cb(text, EqChannel.LEFT); onDismiss() }
                 },
-                textStyle = MaterialTheme.typography.bodySmall,
             )
 
-            when {
-                parsed == null -> Unit
+            if (perEar) {
+                ProfilePane(
+                    title = "RIGHT EAR",
+                    raw = rawR,
+                    onRaw = { rawR = it },
+                    parsed = parsedR,
+                    onFileName = { if (name.isBlank()) name = it },
+                    onMeasurementImport = onMeasurementDetected?.let { cb ->
+                        { text -> cb(text, EqChannel.RIGHT); onDismiss() }
+                    },
+                )
+            }
 
-                parsed.looksLikeMeasurement -> {
+            if (validL != null || validR != null) {
+                // ── Live preview: L primary, R as the amber overlay ──
+                val primaryProfile = validL ?: validR!!
+                FrequencyResponseGraph(
+                    originalCurve = emptyList(),
+                    targetCurve = emptyList(),
+                    eqBands = primaryProfile.bands,
+                    preamp = primaryProfile.preamp,
+                    centerOnZero = true,
+                    showLegend = false,
+                    maxAbsDragGain = maxBandGainDb,
+                    secondaryBands = if (validL != null && validR != null) validR.bands else null,
+                )
+                val summary = buildString {
+                    append(primaryProfile.bands.size)
+                    append(" filters")
+                    if (validL != null && validR != null) {
+                        append(" L / ")
+                        append(validR.bands.size)
+                        append(" filters R")
+                    }
+                    append(" · preamp ")
+                    append("%.1f dB".format(minOf(
+                        validL?.preamp ?: Float.MAX_VALUE,
+                        validR?.preamp ?: Float.MAX_VALUE,
+                    )))
+                }
+                Text(summary, style = MaterialTheme.typography.labelMedium)
+
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Profile name") },
+                    singleLine = true,
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                Spacer(Modifier.width(8.dp))
+                Button(
+                    enabled = validL != null || validR != null,
+                    onClick = {
+                        onImport(validL, validR, name.ifBlank { "Imported profile" })
+                        onDismiss()
+                    },
+                ) { Text("Upload") }
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+/** One channel's paste window + Open-file button + live parse feedback. */
+@Composable
+private fun ProfilePane(
+    title: String?,
+    raw: String,
+    onRaw: (String) -> Unit,
+    parsed: ParsedEqProfile?,
+    onFileName: (String) -> Unit,
+    onMeasurementImport: ((String) -> Unit)?,
+) {
+    val context = LocalContext.current
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri ?: return@rememberLauncherForActivityResult
+        try {
+            val text = context.contentResolver.openInputStream(uri)
+                ?.bufferedReader()?.use { it.readText() }
+            if (!text.isNullOrBlank()) {
+                onRaw(text)
+                uri.lastPathSegment
+                    ?.substringAfterLast('/')
+                    ?.substringAfterLast(':')
+                    ?.removeSuffix(".txt")
+                    ?.removeSuffix(".csv")
+                    ?.let(onFileName)
+            }
+        } catch (_: Exception) {
+            // Unreadable file: leave the pane as-is.
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                title ?: "PROFILE",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Bold,
+            )
+            TextButton(
+                onClick = { filePicker.launch("*/*") },
+                modifier = Modifier.height(28.dp),
+            ) {
+                Icon(
+                    Icons.Default.UploadFile,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text("Open file", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+        OutlinedTextField(
+            value = raw,
+            onValueChange = onRaw,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 72.dp, max = 130.dp),
+            placeholder = {
+                Text(
+                    "Preamp: -6.8 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.9 dB Q 0.70",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            },
+            textStyle = MaterialTheme.typography.bodySmall,
+        )
+        when {
+            parsed == null -> Unit
+            parsed.looksLikeMeasurement -> {
+                Text(
+                    "This looks like a frequency-response measurement, not a filter profile.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
+                if (onMeasurementImport != null) {
+                    TextButton(onClick = { onMeasurementImport(raw) }) {
+                        Text("Import as measurement instead")
+                    }
+                }
+            }
+            parsed.isEmpty -> parsed.warnings.forEach { w ->
+                Text(w, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+            else -> {
+                Text(
+                    "${parsed.bands.size} filters · preamp ${"%.1f".format(parsed.preamp)} dB",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                parsed.warnings.forEach { w ->
                     Text(
-                        "This looks like a frequency-response measurement " +
-                            "(AutoEq CSV), not a filter profile.",
+                        "⚠ $w",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.tertiary,
                     )
-                    if (onMeasurementDetected != null) {
-                        Button(onClick = {
-                            onMeasurementDetected(
-                                rawText,
-                                targetChannel?.let { EqChannel.valueOf(it) },
-                            )
-                            onDismiss()
-                        }) { Text("Import as measurement instead") }
-                    } else {
-                        Text(
-                            "Import it from the AutoEQ screen's measurement picker.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-
-                parsed.isEmpty -> {
-                    parsed.warnings.forEach { w ->
-                        Text(
-                            w,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                }
-
-                else -> {
-                    // ── Live preview ──
-                    FrequencyResponseGraph(
-                        originalCurve = emptyList(),
-                        targetCurve = emptyList(),
-                        eqBands = parsed.bands,
-                        preamp = parsed.preamp,
-                        centerOnZero = true,
-                        showLegend = false,
-                        maxAbsDragGain = maxBandGainDb,
-                    )
-                    Text(
-                        "${parsed.bands.size} filters · preamp " +
-                            "%.1f dB".format(parsed.preamp),
-                        style = MaterialTheme.typography.labelMedium,
-                    )
-                    parsed.warnings.forEach { w ->
-                        Text(
-                            "⚠ $w",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.tertiary,
-                        )
-                    }
-
-                    OutlinedTextField(
-                        value = name,
-                        onValueChange = { name = it },
-                        modifier = Modifier.fillMaxWidth(),
-                        label = { Text("Profile name") },
-                        singleLine = true,
-                    )
-
-                    if (channelChoices) {
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            FilterChip(
-                                selected = targetChannel == null,
-                                onClick = { targetChannel = null },
-                                label = { Text("Both ears") },
-                            )
-                            FilterChip(
-                                selected = targetChannel == EqChannel.LEFT.name,
-                                onClick = { targetChannel = EqChannel.LEFT.name },
-                                label = { Text("Left") },
-                            )
-                            FilterChip(
-                                selected = targetChannel == EqChannel.RIGHT.name,
-                                onClick = { targetChannel = EqChannel.RIGHT.name },
-                                label = { Text("Right") },
-                            )
-                        }
-                    }
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        TextButton(onClick = onDismiss) { Text("Cancel") }
-                        Spacer(Modifier.width(4.dp))
-                        TextButton(
-                            onClick = {
-                                onImport(
-                                    parsed,
-                                    name.ifBlank { "Imported profile" },
-                                    targetChannel?.let { EqChannel.valueOf(it) },
-                                    false,
-                                )
-                                onDismiss()
-                            },
-                        ) { Text("Save") }
-                        Spacer(Modifier.width(4.dp))
-                        Button(
-                            onClick = {
-                                onImport(
-                                    parsed,
-                                    name.ifBlank { "Imported profile" },
-                                    targetChannel?.let { EqChannel.valueOf(it) },
-                                    true,
-                                )
-                                onDismiss()
-                            },
-                        ) { Text("Save & apply") }
-                    }
-                    Spacer(Modifier.height(8.dp))
                 }
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ImportEqProfileSheet.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ImportEqProfileSheet.kt
@@ -1,0 +1,279 @@
+package tf.monochrome.android.ui.eq
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import tf.monochrome.android.data.import_.ApoProfileParser
+import tf.monochrome.android.data.import_.ParsedEqProfile
+
+/**
+ * Import an EqualizerAPO-style parametric profile (`ParametricEQ.txt` or a
+ * band CSV) by paste or file.
+ *
+ * The centrepiece is the live preview: an EQ profile is invisible until it
+ * plays, and a bad import is *audible* — so the parsed curve, the filter
+ * count, and every warning the parser produced (skipped filter types, clamped
+ * gains, derived preamp) are shown BEFORE anything is saved or applied.
+ * Nothing is fixed up silently.
+ *
+ * [channelChoices] — non-null on the AutoEQ surface while 2-channel mode is
+ * on: the profile can target both ears or just one. Null hides the selector
+ * (Parametric EQ, or mono AutoEQ).
+ *
+ * [onMeasurementDetected] — AutoEq publishes a frequency-response CSV right
+ * next to the PEQ file, and users will inevitably hand us one. The parser
+ * recognises it; if this callback is set the sheet offers to import it down
+ * the measurement path instead of failing with "no filters found".
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportEqProfileSheet(
+    maxBandGainDb: Float,
+    onDismiss: () -> Unit,
+    onImport: (profile: ParsedEqProfile, name: String, channel: EqChannel?, apply: Boolean) -> Unit,
+    channelChoices: Boolean = false,
+    onMeasurementDetected: ((raw: String, channel: EqChannel?) -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    var rawText by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf("") }
+    // null = both ears (or mono); otherwise the single ear to import into.
+    var targetChannel by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val parsed = remember(rawText, maxBandGainDb) {
+        if (rawText.isBlank()) null else ApoProfileParser.parse(rawText, maxBandGainDb)
+    }
+
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri ?: return@rememberLauncherForActivityResult
+        try {
+            val text = context.contentResolver.openInputStream(uri)
+                ?.bufferedReader()?.use { it.readText() }
+            if (!text.isNullOrBlank()) {
+                rawText = text
+                if (name.isBlank()) {
+                    // Last path segment, minus extension and SAF's "primary:" /
+                    // "raw:" prefixes — a sensible default the user can retype.
+                    name = uri.lastPathSegment
+                        ?.substringAfterLast('/')
+                        ?.substringAfterLast(':')
+                        ?.removeSuffix(".txt")
+                        ?.removeSuffix(".csv")
+                        ?: ""
+                }
+            }
+        } catch (_: Exception) {
+            // Unreadable file: leave the sheet as-is; the empty state explains.
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                "Import EQ profile",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                "EqualizerAPO / AutoEq ParametricEQ.txt, or a type,fc,gain,q CSV. " +
+                    "Paste below or open a file.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TextButton(onClick = { filePicker.launch("*/*") }) {
+                    Icon(
+                        Icons.Default.UploadFile,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text("Open file")
+                }
+            }
+
+            OutlinedTextField(
+                value = rawText,
+                onValueChange = { rawText = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 96.dp, max = 160.dp),
+                placeholder = {
+                    Text(
+                        "Preamp: -6.8 dB\nFilter 1: ON PK Fc 105 Hz Gain -2.9 dB Q 0.70",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                },
+                textStyle = MaterialTheme.typography.bodySmall,
+            )
+
+            when {
+                parsed == null -> Unit
+
+                parsed.looksLikeMeasurement -> {
+                    Text(
+                        "This looks like a frequency-response measurement " +
+                            "(AutoEq CSV), not a filter profile.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                    if (onMeasurementDetected != null) {
+                        Button(onClick = {
+                            onMeasurementDetected(
+                                rawText,
+                                targetChannel?.let { EqChannel.valueOf(it) },
+                            )
+                            onDismiss()
+                        }) { Text("Import as measurement instead") }
+                    } else {
+                        Text(
+                            "Import it from the AutoEQ screen's measurement picker.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                parsed.isEmpty -> {
+                    parsed.warnings.forEach { w ->
+                        Text(
+                            w,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+
+                else -> {
+                    // ── Live preview ──
+                    FrequencyResponseGraph(
+                        originalCurve = emptyList(),
+                        targetCurve = emptyList(),
+                        eqBands = parsed.bands,
+                        preamp = parsed.preamp,
+                        centerOnZero = true,
+                        showLegend = false,
+                        maxAbsDragGain = maxBandGainDb,
+                    )
+                    Text(
+                        "${parsed.bands.size} filters · preamp " +
+                            "%.1f dB".format(parsed.preamp),
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                    parsed.warnings.forEach { w ->
+                        Text(
+                            "⚠ $w",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.tertiary,
+                        )
+                    }
+
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Profile name") },
+                        singleLine = true,
+                    )
+
+                    if (channelChoices) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            FilterChip(
+                                selected = targetChannel == null,
+                                onClick = { targetChannel = null },
+                                label = { Text("Both ears") },
+                            )
+                            FilterChip(
+                                selected = targetChannel == EqChannel.LEFT.name,
+                                onClick = { targetChannel = EqChannel.LEFT.name },
+                                label = { Text("Left") },
+                            )
+                            FilterChip(
+                                selected = targetChannel == EqChannel.RIGHT.name,
+                                onClick = { targetChannel = EqChannel.RIGHT.name },
+                                label = { Text("Right") },
+                            )
+                        }
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(onClick = onDismiss) { Text("Cancel") }
+                        Spacer(Modifier.width(4.dp))
+                        TextButton(
+                            onClick = {
+                                onImport(
+                                    parsed,
+                                    name.ifBlank { "Imported profile" },
+                                    targetChannel?.let { EqChannel.valueOf(it) },
+                                    false,
+                                )
+                                onDismiss()
+                            },
+                        ) { Text("Save") }
+                        Spacer(Modifier.width(4.dp))
+                        Button(
+                            onClick = {
+                                onImport(
+                                    parsed,
+                                    name.ifBlank { "Imported profile" },
+                                    targetChannel?.let { EqChannel.valueOf(it) },
+                                    true,
+                                )
+                                onDismiss()
+                            },
+                        ) { Text("Save & apply") }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -348,8 +348,8 @@ fun ParametricEqScreen(
         ImportEqProfileSheet(
             maxBandGainDb = EqLimits.PARAMETRIC_MAX_BAND_DB,
             onDismiss = { showImportSheet = false },
-            onImport = { profile, name, _, apply ->
-                viewModel.importApoProfile(profile, name, apply)
+            onImport = { left, right, name ->
+                (left ?: right)?.let { viewModel.importApoProfile(it, name, apply = true) }
             },
         )
     }

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -87,6 +87,7 @@ fun ParametricEqScreen(
     }
 
     var showSaveDialog by remember { mutableStateOf(false) }
+    var showImportSheet by remember { mutableStateOf(false) }
     var saveName by remember { mutableStateOf("") }
     var saveDescription by remember { mutableStateOf("") }
     var presetToDelete by remember { mutableStateOf<EqPreset?>(null) }
@@ -231,6 +232,29 @@ fun ParametricEqScreen(
                             color = MaterialTheme.colorScheme.onSurface
                         )
                     }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .liquidGlass(shape = RoundedCornerShape(12.dp))
+                            .bounceClick(onClick = { showImportSheet = true })
+                            .padding(vertical = 12.dp, horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Save,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Text(
+                            "Import profile (APO txt / CSV)",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
                 }
               }
             }
@@ -318,6 +342,16 @@ fun ParametricEqScreen(
                 }
             }
         }
+    }
+
+    if (showImportSheet) {
+        ImportEqProfileSheet(
+            maxBandGainDb = EqLimits.PARAMETRIC_MAX_BAND_DB,
+            onDismiss = { showImportSheet = false },
+            onImport = { profile, name, _, apply ->
+                viewModel.importApoProfile(profile, name, apply)
+            },
+        )
     }
 
     if (showSaveDialog) {

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material3.Slider
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -156,56 +158,98 @@ fun ParametricEqScreen(
                         maxAbsDragGain = EqLimits.PARAMETRIC_MAX_BAND_DB,
                         spectrumBins = if (spectrumEnabled) spectrumBins else FloatArray(0),
                         spectrumColor = MaterialTheme.colorScheme.primary,
+                        onBandDragged = { bandId, freq, gain ->
+                            viewModel.updateBandByDrag(bandId, freq, gain)
+                        },
                     )
                 }
               }
             }
 
-            // Edit pill button
+            // Preamp — same placement as the AutoEQ page: under the graph.
             item {
-              tf.monochrome.android.devedit.DevEditable("peq_edit_button", Modifier.fillMaxWidth()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                ) {
+              tf.monochrome.android.devedit.DevEditable("peq_preamp_slider", Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(50))
-                            .background(MaterialTheme.colorScheme.primary)
-                            .bounceClick(onClick = { navController.navigate(Screen.ParametricEqEdit.route) })
-                            .padding(vertical = 14.dp),
-                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(
-                            Icons.Default.Tune,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            "Edit",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            letterSpacing = 2.sp
+                            "Preamp",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            "${currentPreamp.toInt()} dB",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary
                         )
                     }
+                    Slider(
+                        value = if (currentPreamp.isNaN()) 0f else currentPreamp.coerceIn(-24f, 24f),
+                        onValueChange = { viewModel.setPreamp(it) },
+                        valueRange = -24f..24f,
+                        steps = 47,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
               }
             }
 
-            // Save-as-preset button
+            // Bands — edited inline with the same rows as the AutoEQ screen
+            // (type selector, freq/gain/Q sliders), replacing the separate
+            // Edit page hop.
             item {
-              tf.monochrome.android.devedit.DevEditable("peq_save_button", Modifier.fillMaxWidth()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 4.dp)
+                Text(
+                    "BANDS",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp,
+                    modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 2.dp)
+                )
+            }
+            items(currentBands, key = { it.id }) { band ->
+                EqBandSlider(
+                    band = band,
+                    onBandChanged = { viewModel.updateBand(it) },
+                    onDelete = { viewModel.removeBand(band.id) },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+
+            // Add band + profile actions. A COLUMN of rows — these were once
+            // stacked in a Box, which drew Save and Import on top of each
+            // other as one garbled row.
+            item {
+              tf.monochrome.android.devedit.DevEditable("peq_actions", Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .liquidGlass(shape = RoundedCornerShape(12.dp))
+                            .bounceClick(onClick = { viewModel.addBand() })
+                            .padding(vertical = 12.dp, horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Text(
+                            "Add band",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -232,7 +276,6 @@ fun ParametricEqScreen(
                             color = MaterialTheme.colorScheme.onSurface
                         )
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -244,7 +287,7 @@ fun ParametricEqScreen(
                         horizontalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         Icon(
-                            Icons.Default.Save,
+                            Icons.Default.UploadFile,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(18.dp)

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -245,8 +245,11 @@ class ParametricEqViewModel @Inject constructor(
                 if (apply) {
                     _currentBands.value = bands
                     saveBands(bands)
-                    _currentPreamp.value = profile.preamp
-                    preferences.setParamEqPreamp(profile.preamp.toDouble())
+                    // A file's preamp is untrusted input — clamp to the range
+                    // the page's own slider allows.
+                    val preamp = profile.preamp.coerceIn(-24f, 24f)
+                    _currentPreamp.value = preamp
+                    preferences.setParamEqPreamp(preamp.toDouble())
                     _activePreset.value = preset
                     preferences.setParamEqActivePreset(preset.id)
                     if (!_enabled.value) setEnabled(true)

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -220,6 +220,44 @@ class ParametricEqViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Import a parsed EqualizerAPO profile: saved as a Parametric profile,
+     * optionally loaded as the live curve. Mono by design — per-ear EQ lives
+     * on the AutoEQ surface.
+     */
+    fun importApoProfile(
+        profile: tf.monochrome.android.data.import_.ParsedEqProfile,
+        name: String,
+        apply: Boolean,
+    ) {
+        viewModelScope.launch {
+            try {
+                val bands = profile.bands.mapIndexed { i, b -> b.copy(id = i) }
+                val preset = EqPreset(
+                    id = "custom_paramEq_${System.currentTimeMillis()}",
+                    name = name,
+                    description = "Imported EqualizerAPO profile",
+                    bands = bands,
+                    preamp = profile.preamp,
+                    isCustom = true,
+                )
+                repository.savePreset(preset)
+                if (apply) {
+                    _currentBands.value = bands
+                    saveBands(bands)
+                    _currentPreamp.value = profile.preamp
+                    preferences.setParamEqPreamp(profile.preamp.toDouble())
+                    _activePreset.value = preset
+                    preferences.setParamEqActivePreset(preset.id)
+                    if (!_enabled.value) setEnabled(true)
+                }
+                _error.value = null
+            } catch (e: Exception) {
+                _error.value = "Failed to import profile: ${e.message}"
+            }
+        }
+    }
+
     fun deletePreset(presetId: String) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -3,7 +3,10 @@ package tf.monochrome.android.ui.library
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -17,16 +20,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ScrollableTabRow
-import androidx.compose.material3.Tab
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -34,10 +39,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import kotlinx.coroutines.launch
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,16 +64,44 @@ import tf.monochrome.android.ui.components.rememberTrackSelectionState
 import tf.monochrome.android.ui.navigation.Screen
 import tf.monochrome.android.ui.navigation.openCatalogArtist
 import tf.monochrome.android.ui.player.PlayerViewModel
-import tf.monochrome.android.ui.settings.SettingsViewModel
+
+/**
+ * The section Library lands on — page 0, and deliberately absent from the
+ * overflow menu, since it's reached by swiping back rather than being picked.
+ */
+internal const val LOCAL_SECTION = "local"
+
+/** Display names for every Library section id. */
+internal val LIBRARY_SECTION_NAMES = mapOf(
+    "overview" to "Overview",
+    "local" to "Local",
+    "playlists" to "Playlists",
+    "favorites" to "Favorites",
+    "downloads" to "Downloads",
+)
+
+/**
+ * Library's pages in order: the local library first, then whatever the user has
+ * left in their configured section order.
+ *
+ * Shared with the nav host, which owns the `PagerState` for these pages so the
+ * top-bar indicator can count and track every one of them — Home plus each
+ * Library section — rather than just Home vs Library.
+ */
+internal fun librarySections(order: List<String>): List<String> =
+    listOf(LOCAL_SECTION) + order.filter { it != LOCAL_SECTION && it in LIBRARY_SECTION_NAMES }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryScreen(
     navController: NavController,
     playerViewModel: PlayerViewModel,
+    // Hoisted to the nav host: it owns these so the top-bar page indicator can
+    // track Library's sections, not just the Home↔Library split.
+    sections: List<String>,
+    sectionPager: PagerState,
     viewModel: LibraryViewModel = hiltViewModel(),
     localLibraryViewModel: LocalLibraryViewModel = hiltViewModel(),
-    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val favoriteTracks by viewModel.favoriteTracks.collectAsState()
     val recentTracks by viewModel.recentTracks.collectAsState()
@@ -77,18 +111,14 @@ fun LibraryScreen(
     val favoriteTrackIds by playerViewModel.favoriteTrackIds.collectAsState()
     val activeDownloads by playerViewModel.activeDownloads.collectAsState()
 
-    val libraryTabOrder by settingsViewModel.libraryTabOrder.collectAsState()
+    val sectionScope = rememberCoroutineScope()
+    val currentSectionId = sections.getOrElse(sectionPager.currentPage) { LOCAL_SECTION }
 
-    val tabDisplayNames = mapOf(
-        "overview" to "Overview",
-        "local" to "Local",
-        "playlists" to "Playlists",
-        "favorites" to "Favorites",
-        "downloads" to "Downloads"
-    )
-    val tabs = libraryTabOrder.mapNotNull { id -> tabDisplayNames[id]?.let { id to it } }
-
-    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
+    // The overflow menu survives as a shortcut past the swipe — Downloads sits
+    // several pages deep — not as the only way in.
+    val menuSections = sections.drop(1).mapNotNull { id ->
+        LIBRARY_SECTION_NAMES[id]?.let { id to it }
+    }
 
     // Saveable so the dialog reopens after a process death triggered by its own
     // SAF CSV picker; the dialog's typed fields + picked uri are saveable too.
@@ -98,9 +128,16 @@ fun LibraryScreen(
     var showAddToPlaylistForSelection by remember { mutableStateOf(false) }
 
     val selection = rememberTrackSelectionState<Long>()
+    // Back out of a menu section returns to the local library rather than
+    // leaving Library entirely. Composed BEFORE the selection handler on
+    // purpose: the dispatcher serves the LAST-composed enabled callback first,
+    // so an active selection still wins the first back press.
+    BackHandler(enabled = sectionPager.currentPage != 0) {
+        sectionScope.launch { sectionPager.animateScrollToPage(0) }
+    }
     BackHandler(enabled = selection.active) { selection.clear() }
-    // Lists (and delete semantics) differ per tab — drop any selection on switch.
-    LaunchedEffect(selectedTabIndex) { selection.clear() }
+    // Lists (and delete semantics) differ per section — drop any selection on switch.
+    LaunchedEffect(currentSectionId) { selection.clear() }
 
     showContextMenuForTrack?.let { track ->
         TrackContextMenu(
@@ -199,15 +236,66 @@ fun LibraryScreen(
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
+        var sectionMenuOpen by remember { mutableStateOf(false) }
+
         tf.monochrome.android.devedit.DevEditable("library_header", Modifier.fillMaxWidth()) {
             TopAppBar(
                 title = {
                     Text(
-                        text = "Library",
+                        // Titled for whatever is actually on screen: "Library"
+                        // is the local library, anything else names itself so
+                        // the menu section you picked is identifiable.
+                        text = if (currentSectionId == LOCAL_SECTION) "Library"
+                               else LIBRARY_SECTION_NAMES[currentSectionId] ?: "Library",
                         style = MaterialTheme.typography.headlineMedium
                     )
                 },
+                navigationIcon = {
+                    // Only while a menu section is showing — the local library
+                    // has no entry in the menu, so this is the way back to it.
+                    if (currentSectionId != LOCAL_SECTION) {
+                        IconButton(onClick = {
+                            sectionScope.launch { sectionPager.animateScrollToPage(0) }
+                        }) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back to local library",
+                                tint = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                    }
+                },
                 actions = {
+                    // Settings lets the user strip sections out of the order,
+                    // so the button goes away rather than opening an empty menu.
+                    if (menuSections.isNotEmpty()) Box {
+                        IconButton(onClick = { sectionMenuOpen = true }) {
+                            Icon(
+                                Icons.Default.MoreVert,
+                                contentDescription = "Other library sections",
+                                tint = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = sectionMenuOpen,
+                            onDismissRequest = { sectionMenuOpen = false }
+                        ) {
+                            menuSections.forEach { (id, title) ->
+                                DropdownMenuItem(
+                                    text = { Text(title) },
+                                    onClick = {
+                                        val page = sections.indexOf(id)
+                                        if (page >= 0) {
+                                            sectionScope.launch {
+                                                sectionPager.animateScrollToPage(page)
+                                            }
+                                        }
+                                        sectionMenuOpen = false
+                                    }
+                                )
+                            }
+                        }
+                    }
                     IconButton(onClick = { navController.navigate(Screen.Settings.createRoute()) }) {
                         Icon(
                             Icons.Default.Settings,
@@ -221,24 +309,6 @@ fun LibraryScreen(
                 )
             )
         }
-
-        tf.monochrome.android.devedit.DevEditable("library_tab_row", Modifier.fillMaxWidth()) {
-            ScrollableTabRow(
-                selectedTabIndex = selectedTabIndex,
-                containerColor = Color.Transparent,
-                edgePadding = 8.dp
-            ) {
-                tabs.forEachIndexed { index, (_, title) ->
-                    Tab(
-                        selected = selectedTabIndex == index,
-                        onClick = { selectedTabIndex = index },
-                        text = { Text(title) }
-                    )
-                }
-            }
-        }
-
-        val currentSectionId = tabs.getOrNull(selectedTabIndex)?.first ?: "overview"
 
         AnimatedVisibility(visible = selection.active) {
             TrackSelectionBar(
@@ -260,11 +330,22 @@ fun LibraryScreen(
         }
 
         val sectionStateHolder = androidx.compose.runtime.saveable.rememberSaveableStateHolder()
-        // Preserve each tab's scroll position (and the Local tab's own sub-tab
-        // state) across tab switches, instead of remounting a fresh list that
-        // snaps back to the top every time the user changes tabs.
-        sectionStateHolder.SaveableStateProvider(currentSectionId) {
-        when (currentSectionId) {
+        // Preserve each section's scroll position (and the local library's own
+        // sub-tab state) across section switches, instead of remounting a fresh
+        // list that snaps back to the top every time.
+        //
+        // Nested inside the nav host's Home↔Library pager, same axis. Compose
+        // resolves that through nested scroll: this inner pager consumes the
+        // drag until it's at page 0 and the user keeps pulling right, at which
+        // point the outer pager takes over and carries them to Home.
+        HorizontalPager(
+            state = sectionPager,
+            modifier = Modifier.fillMaxSize(),
+            beyondViewportPageCount = 0,
+        ) { page ->
+        val sectionId = sections[page]
+        sectionStateHolder.SaveableStateProvider(sectionId) {
+        when (sectionId) {
             "overview" ->
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -500,6 +581,7 @@ fun LibraryScreen(
 
             "downloads" ->
                 DownloadsScreen(navController = navController)
+        }
         }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LocalLibraryTab.kt
@@ -8,6 +8,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -120,8 +124,14 @@ fun LocalLibraryTab(
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
 
-    var selectedSubTab by rememberSaveable { mutableIntStateOf(0) }
     val subTabs = listOf("Albums", "Artists", "Songs", "Genres", "Folders")
+    // Sub-tabs are swipeable pages. The tab row above them is a selector onto
+    // the SAME pager state rather than a second source of truth, so a swipe and
+    // a tap can't disagree — and ScrollableTabRow scrolls the selected tab into
+    // view, which is what un-clips "Folders" when you swipe onto it.
+    val subTabPager = rememberPagerState(pageCount = { subTabs.size })
+    val subTabScope = rememberCoroutineScope()
+    val selectedSubTab = subTabPager.currentPage
     var showSearch by remember { mutableStateOf(false) }
     val searchFocus = remember { androidx.compose.ui.focus.FocusRequester() }
     // Focus the field (and pop the IME) the moment search opens, so it doesn't
@@ -248,25 +258,30 @@ fun LocalLibraryTab(
             return@Column
         }
 
-        // Sub-tabs + action buttons
+        // Sub-tabs get the full width. Sharing one row with the sort menu and
+        // four icon buttons left the five labels about 120dp on a 360dp screen,
+        // so "Albums" and "Folders" were clipped at both ends and the row was
+        // permanently mid-scroll. Actions moved to their own row underneath.
+        ScrollableTabRow(
+            selectedTabIndex = selectedSubTab,
+            modifier = Modifier.fillMaxWidth(),
+            containerColor = MaterialTheme.colorScheme.background,
+            edgePadding = 8.dp
+        ) {
+            subTabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedSubTab == index,
+                    onClick = { subTabScope.launch { subTabPager.animateScrollToPage(index) } },
+                    text = { Text(title, style = MaterialTheme.typography.bodySmall) }
+                )
+            }
+        }
+
         Row(
             modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            ScrollableTabRow(
-                selectedTabIndex = selectedSubTab,
-                modifier = Modifier.weight(1f),
-                containerColor = MaterialTheme.colorScheme.background,
-                edgePadding = 8.dp
-            ) {
-                subTabs.forEachIndexed { index, title ->
-                    Tab(
-                        selected = selectedSubTab == index,
-                        onClick = { selectedSubTab = index },
-                        text = { Text(title, style = MaterialTheme.typography.bodySmall) }
-                    )
-                }
-            }
             if (selectedSubTab in 0..2) {
                 val (keys, current, onChange) = when (selectedSubTab) {
                     0 -> Triple(ALBUM_SORT_KEYS, albumSort, viewModel::setAlbumSort)
@@ -309,18 +324,33 @@ fun LocalLibraryTab(
         val genrePairs = remember(localGenres) {
             localGenres.map { it.name to it.trackCount }
         }
-        when (selectedSubTab) {
-            0 -> AlbumGrid(albums = sortedAlbums, onAlbumClick = onAlbumClick)
-            1 -> ArtistList(artists = sortedArtists, onArtistClick = onArtistClick)
-            2 -> SongList(tracks = sortedTracks, onTrackClick = onTrackClick, navController = navController)
-            3 -> GenreList(
-                genres = genrePairs,
-                onGenreClick = onGenreClick
-            )
-            4 -> FolderList(
-                folders = rootFolders,
-                onFolderClick = onFolderClick
-            )
+        // Nested inside Library's section pager, which is itself nested in the
+        // nav host's Home↔Library pager. Compose chains all three through nested
+        // scroll: this innermost one consumes the drag until it runs out of
+        // sub-tabs, then the section pager takes over, then the outer one — so
+        // it's one continuous swipe from Albums all the way out to Home.
+        //
+        // fillMaxWidth without weight() on purpose: the `when` this replaced
+        // sized itself from its child under the Column's remaining-height
+        // constraint, and weight(1f) would starve the empty state below it.
+        HorizontalPager(
+            state = subTabPager,
+            modifier = Modifier.fillMaxWidth(),
+            beyondViewportPageCount = 0,
+        ) { page ->
+            when (page) {
+                0 -> AlbumGrid(albums = sortedAlbums, onAlbumClick = onAlbumClick)
+                1 -> ArtistList(artists = sortedArtists, onArtistClick = onArtistClick)
+                2 -> SongList(tracks = sortedTracks, onTrackClick = onTrackClick, navController = navController)
+                3 -> GenreList(
+                    genres = genrePairs,
+                    onGenreClick = onGenreClick
+                )
+                4 -> FolderList(
+                    folders = rootFolders,
+                    onFolderClick = onFolderClick
+                )
+            }
         }
 
         // Empty state

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.pager.HorizontalPager
@@ -62,6 +63,9 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import kotlinx.coroutines.launch
 import tf.monochrome.android.ui.components.MiniPlayer
+import tf.monochrome.android.ui.components.SwipeToLibraryHint
+import tf.monochrome.android.ui.components.SwipeHintPillHeight
+import tf.monochrome.android.ui.components.swipeHintPillWidth
 import tf.monochrome.android.ui.theme.DynamicColorScope
 import tf.monochrome.android.ui.detail.AlbumDetailScreen
 import tf.monochrome.android.ui.detail.ArtistDetailScreen
@@ -74,6 +78,8 @@ import tf.monochrome.android.ui.eq.ParametricEqScreen
 import tf.monochrome.android.ui.home.HomeScreen
 import tf.monochrome.android.ui.mixer.MixerScreen
 import tf.monochrome.android.ui.library.LibraryScreen
+import tf.monochrome.android.ui.library.LIBRARY_SECTION_NAMES
+import tf.monochrome.android.ui.library.librarySections
 import tf.monochrome.android.ui.library.DownloadsScreen
 import tf.monochrome.android.ui.library.PlaylistScreen
 import tf.monochrome.android.ui.player.NowPlayingScreen
@@ -188,6 +194,14 @@ fun MonochromeNavHost(initialRoute: String? = null) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
     val scope = rememberCoroutineScope()
 
+    // Library's own section pager lives up here rather than inside LibraryScreen
+    // so the top-bar indicator can count and track every page in the app — Home
+    // plus each Library section — instead of only the Home↔Library split.
+    val settingsViewModel: tf.monochrome.android.ui.settings.SettingsViewModel = hiltViewModel()
+    val libraryTabOrder by settingsViewModel.libraryTabOrder.collectAsState()
+    val librarySectionIds = remember(libraryTabOrder) { librarySections(libraryTabOrder) }
+    val librarySectionPager = rememberPagerState(pageCount = { librarySectionIds.size })
+
     // One-shot landing route handed over by onboarding ("library" lands on
     // the Library pager tab; anything else is a plain navigation target).
     LaunchedEffect(Unit) {
@@ -280,7 +294,12 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                                 HomeScreen(navController = navController, playerViewModel = playerViewModel)
                             }
                             1 -> tf.monochrome.android.devedit.DevEditScreen("library") {
-                                LibraryScreen(navController = navController, playerViewModel = playerViewModel)
+                                LibraryScreen(
+                                    navController = navController,
+                                    playerViewModel = playerViewModel,
+                                    sections = librarySectionIds,
+                                    sectionPager = librarySectionPager,
+                                )
                             }
                         }
                     }
@@ -513,6 +532,69 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                         )
                     }
                 }
+            }
+        }
+
+        // ── Layer 1.5: page indicator ───────────────────────────────
+        // Compact glass pill centred on the TopAppBar's own centre line, in the
+        // free gap between the screens' titles and their action icons. Drawn
+        // OVER the pager, not behind it: Haze can only blur content already
+        // drawn this frame, so a pill under the pager loses its frost entirely.
+        if (isOnMainTab) {
+            CompositionLocalProvider(
+                tf.monochrome.android.ui.player.LocalPlayerGlass provides miniPlayerGlass,
+            ) {
+                SwipeToLibraryHint(
+                    // Home, then one slot per Library section.
+                    pageCount = 1 + librarySectionIds.size,
+                    progressProvider = {
+                        // Flattens the two nested pagers onto one axis: Home is
+                        // 0, the local library 1, each further section 2, 3, …
+                        // Multiplying by the outer position keeps it continuous
+                        // across the Home↔Library crossing instead of jumping
+                        // when Library was left on a later section.
+                        val outer = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                        val inner = librarySectionPager.currentPage +
+                            librarySectionPager.currentPageOffsetFraction
+                        outer * (1f + inner)
+                    },
+                    // Tap walks forward one page and wraps at the end. Both
+                    // pagers animate, so the worm plays the same way it does
+                    // under a finger.
+                    onClick = {
+                        scope.launch {
+                            if (pagerState.currentPage == 0) {
+                                librarySectionPager.scrollToPage(0)
+                                pagerState.animateScrollToPage(1)
+                            } else {
+                                val next = librarySectionPager.currentPage + 1
+                                if (next < librarySectionIds.size) {
+                                    librarySectionPager.animateScrollToPage(next)
+                                } else {
+                                    pagerState.animateScrollToPage(0)
+                                }
+                            }
+                        }
+                    },
+                    onClickLabel = when {
+                        pagerState.currentPage == 0 -> "Open Library"
+                        librarySectionPager.currentPage + 1 < librarySectionIds.size ->
+                            "Open " + (LIBRARY_SECTION_NAMES[
+                                librarySectionIds[librarySectionPager.currentPage + 1]
+                            ] ?: "next section")
+                        else -> "Open Home"
+                    },
+                    hazeState = hazeState,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        // The TopAppBar pads itself for the status bar and is
+                        // 64.dp tall, so this drops the pill onto its centre.
+                        .padding(top = statusBarHeight + (64.dp - SwipeHintPillHeight) / 2)
+                        .size(
+                            width = swipeHintPillWidth(1 + librarySectionIds.size),
+                            height = SwipeHintPillHeight,
+                        ),
+                )
             }
         }
 

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -647,7 +647,13 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                             onSkipPreviousClick = { playerViewModel.skipToPrevious() },
                             onClick = { navController.navigate(Screen.NowPlaying.route) },
                             modifier = Modifier.padding(horizontal = 16.dp),
-                            hazeState = hazeState
+                            // No frost on detail screens (Settings, EQ, …): the
+                            // haze source is the tab pager, so here the frost
+                            // has nothing real to sample and its base colour
+                            // renders as a solid bar behind the mini player.
+                            // Null skips the frost layer — the glass slab
+                            // floats clean over the screen's own content.
+                            hazeState = null
                         )
                     }
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -761,12 +761,25 @@ half4 main(float2 p) {
     float sheetI = exp(-sd * sd) * uLiquid * (0.30 + 0.70 * fres);
     col3 += float3(1.0, 0.985, 0.95) * sheetI * 0.5 * uRimGain;
 
+    // Highlight shoulder: every edge term above stacks additively in the same
+    // 1-2px band (Fresnel rim + glint + sheet, each gained by its own knob), and
+    // the premultiply clamp below used to flatten any overflow into a solid
+    // max-brightness line — the over-sharpened halo look when several edge
+    // settings run hot. Roll intensities above the knee off asymptotically
+    // toward white instead; pixels below the knee are bit-identical, so calm
+    // presets keep their exact look and only blown rim pixels are compressed.
+    float3 overHi = max(col3 - 0.82, float3(0.0));
+    col3 = min(col3, float3(0.82)) + 0.18 * (1.0 - exp(-overHi / 0.18));
+
     // Transparent face, opaque bright rim: alpha is low across the body (backdrop
     // reads through) and climbs to full where Fresnel and the glint peak, so the
     // rim highlight reads as a crisp glass edge rather than being clamped away.
     // The light sheet lifts alpha too — without that, the shine pass would be
     // clamped invisible on see-through faces (premultiplied rgb <= alpha).
-    float rim = clamp(fres * 1.2 + spec + sheetI * 0.6, 0.0, 1.0);
+    // Same shoulder as the colour: the outline saturates to opaque gradually
+    // instead of snapping, so the rim doesn't etch a hard 1px contour.
+    float rimSum = fres * 1.2 + spec + sheetI * 0.6;
+    float rim = min(rimSum, 0.82) + 0.18 * (1.0 - exp(-max(rimSum - 0.82, 0.0) / 0.18));
     float outA = clamp(a * (uBodyOpacity + (1.0 - uBodyOpacity) * rim), 0.0, a);
 
     float3 col = col3 * outA;              // premultiplied

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -3,6 +3,13 @@ package tf.monochrome.android.ui.player
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.abs
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -185,9 +192,20 @@ fun MainPlayerRoute(
     }
     val animatedDominant by androidx.compose.animation.animateColorAsState(
         targetValue = albumColors.dominant,
-        animationSpec = androidx.compose.animation.core.tween(durationMillis = 800),
+        animationSpec = androidx.compose.animation.core.tween(durationMillis = 1800),
         label = "playerBackground",
     )
+    // Vibrant tweens alongside dominant so the whole palette crossfades to the
+    // next track rather than the background easing while every accent that
+    // reads `vibrant` — hero ring, spectrum, glass tint — snaps on track change.
+    // Shorter than the background's 800ms: accents sit on top of the art, and
+    // at 800ms they visibly lag the cover that has already swiped in.
+    val animatedVibrant by androidx.compose.animation.animateColorAsState(
+        targetValue = albumColors.vibrant,
+        animationSpec = androidx.compose.animation.core.tween(durationMillis = 1300),
+        label = "playerAccent",
+    )
+    val blendedColors = AlbumColors(animatedDominant, animatedVibrant)
     val spectrumColor = MaterialTheme.colorScheme.primary
 
     val isFullscreenActive = viewMode == NowPlayingViewMode.VISUALIZER && visualizerFullscreen
@@ -264,7 +282,7 @@ fun MainPlayerRoute(
         sleepTimerLabel = if (sleepMinutes > 0) "$sleepRemainingMinutes min" else "Off",
         sleepTimerActive = sleepMinutes > 0,
         queueLabel = queueLabel,
-        albumColors = AlbumColors(animatedDominant, albumColors.vibrant),
+        albumColors = blendedColors,
         visualizerActive = viewMode == NowPlayingViewMode.VISUALIZER,
         waveformActive = showNpSpectrum,
         compressorEnabled = compressorEnabled,
@@ -321,8 +339,8 @@ fun MainPlayerRoute(
         // tones when the blurred album background is on (Apple-OS style).
         LocalPlayerBackdrop provides PlayerBackdrop(
             blurredArt = blurredBackground,
-            dominant = albumColors.dominant,
-            secondary = albumColors.vibrant,
+            dominant = blendedColors.dominant,
+            secondary = blendedColors.vibrant,
         ),
         // The transport buttons' refractive glass parameters (Studio › Player Glass).
         LocalPlayerGlass provides playerGlass,
@@ -408,7 +426,69 @@ fun MainPlayerRoute(
                 // (expensive) art/visualizer doesn't recompose mid-dissolve.
                 val showAlbumHero by remember { derivedStateOf { lyricsProgress < 0.999f } }
                 val showLyricsHero by remember { derivedStateOf { lyricsProgress > 0.001f } }
-                Box(modifier = heroModifier, contentAlignment = Alignment.Center) {
+
+                // Horizontal swipe across the hero skips tracks, matching the
+                // gesture (and the 50px threshold) the mini player already uses.
+                //
+                // detectHorizontalDragGestures, not detectDragGestures: the
+                // latter consumes vertical drags too, which would swallow the
+                // pull-up that opens the audio-tools sheet and the lyric list's
+                // own scrolling. Suppressed entirely in visualizer mode, where
+                // horizontal drags belong to the touch waveform.
+                val swipeSkipEnabled = viewMode != NowPlayingViewMode.VISUALIZER
+                // Art offset, in px, driven by the finger and then animated out
+                // and back in. An Animatable rather than a plain float so the
+                // release animation and a mid-flight new drag can't fight: a
+                // fresh snapTo cancels whatever animation is running.
+                val heroOffset = remember { androidx.compose.animation.core.Animatable(0f) }
+                val heroScope = rememberCoroutineScope()
+                val trackSwipe = Modifier.pointerInput(swipeSkipEnabled) {
+                    if (!swipeSkipEnabled) return@pointerInput
+                    val width = size.width.toFloat().coerceAtLeast(1f)
+                    // Commit distance. Compose's own touch slop only decides
+                    // when a drag *starts*; this is how far it has to travel
+                    // before it counts as a skip. Scaled off the art's width
+                    // (~22%) rather than a fixed pixel count, so it asks for the
+                    // same proportion of a gesture on any screen density.
+                    val skipThreshold = width * 0.22f
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            heroScope.launch {
+                                val dx = heroOffset.value
+                                // Carry the outgoing art the rest of the way off,
+                                // switch track, then bring the incoming one in
+                                // from the opposite edge — so the direction of
+                                // travel matches the direction of the swipe.
+                                when {
+                                    dx < -skipThreshold -> {
+                                        heroOffset.animateTo(-width, tween(140))
+                                        playerViewModel.skipToNext()
+                                        heroOffset.snapTo(width)
+                                        heroOffset.animateTo(0f, tween(260))
+                                    }
+                                    dx > skipThreshold -> {
+                                        heroOffset.animateTo(width, tween(140))
+                                        playerViewModel.skipToPrevious()
+                                        heroOffset.snapTo(-width)
+                                        heroOffset.animateTo(0f, tween(260))
+                                    }
+                                    // Under the threshold: spring back, no skip.
+                                    else -> heroOffset.animateTo(0f, spring())
+                                }
+                            }
+                        },
+                        onDragCancel = { heroScope.launch { heroOffset.animateTo(0f, spring()) } },
+                        onHorizontalDrag = { change, amount ->
+                            change.consume()
+                            heroScope.launch { heroOffset.snapTo(heroOffset.value + amount) }
+                        },
+                    )
+                }
+
+                Box(
+                    modifier = heroModifier.then(trackSwipe),
+                    contentAlignment = Alignment.Center,
+                ) {
                     if (showAlbumHero) {
                         val effectiveStyle = if (viewMode == NowPlayingViewMode.VISUALIZER) {
                             PlayerHeroStyle.Visualizer
@@ -434,13 +514,25 @@ fun MainPlayerRoute(
                             } else base
                         }
                         PlayerHero(
-                            modifier = artMod.graphicsLayer { alpha = 1f - lyricsProgress },
+                            modifier = artMod.graphicsLayer {
+                                // Follows the finger, then rides the release
+                                // animation out and the next cover in.
+                                translationX = heroOffset.value
+                                // Fade with distance so the swap happens while
+                                // the art is already dim, hiding the instant at
+                                // which the cover actually changes. Read in the
+                                // draw phase, so a drag costs no recomposition.
+                                val travelled =
+                                    (abs(heroOffset.value) / size.width.coerceAtLeast(1f))
+                                        .coerceIn(0f, 1f)
+                                alpha = (1f - lyricsProgress) * (1f - travelled * 0.85f)
+                            },
                             style = effectiveStyle,
                             isFullscreen = isFullscreenActive,
                             track = currentTrack,
                             isPlaying = isPlaying,
                             progress = state.progress,
-                            albumColors = albumColors,
+                            albumColors = blendedColors,
                             visualizerSensitivity = visualizerSensitivity,
                             visualizerBrightness = visualizerBrightness,
                             visualizerEngineStatus = visualizerEngineStatus,
@@ -477,7 +569,7 @@ fun MainPlayerRoute(
                         LyricsHeroBox(
                             lyrics = lyrics,
                             isLoading = isLyricsLoading,
-                            albumColors = albumColors,
+                            albumColors = blendedColors,
                             positionMs = playerViewModel.positionMs,
                             // One element, two states: compact taps expand
                             // (synced lyrics only); expanded line taps seek and

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -82,6 +82,7 @@ fun MainPlayerRoute(
     playerViewModel: PlayerViewModel,
 ) {
     val currentTrack by playerViewModel.currentTrack.collectAsState()
+    val miniGlass by playerViewModel.miniPlayerGlass.collectAsState()
     val currentUnified by playerViewModel.currentUnifiedTrack.collectAsState()
     val queue by playerViewModel.queue.collectAsState()
     val currentIndex by playerViewModel.currentIndex.collectAsState()
@@ -347,6 +348,7 @@ fun MainPlayerRoute(
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
         MainPlayerScreen(
+            miniGlass = miniGlass,
             state = state,
             isFullscreen = isFullscreenActive,
             formatTime = playerViewModel::formatTime,

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -64,6 +64,14 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+import tf.monochrome.android.performance.LocalPerformanceProfile
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -224,7 +232,13 @@ fun MainPlayerScreen(
     // closed, and so we never read `reveal` in composition.
     BackHandler(enabled = scrimVisible) { animateRevealTo(0f, 0f) }
 
+    // Frost source for the audio-tools sheet: the backdrop layers (gradient,
+    // album wash, glow, stain) register as ONE haze source so the sheet can
+    // gaussian-blur what's visually behind it — the same frost the mini
+    // player gets from the nav host's source.
+    val hazeState = rememberHazeState()
     Box(modifier = Modifier.fillMaxSize()) {
+        Box(Modifier.matchParentSize().hazeSource(hazeState)) {
         // Background on its own node so the dither layer wraps just the
         // gradient, not the whole screen's content.
         Box(
@@ -267,6 +281,7 @@ fun MainPlayerScreen(
                 albumColors = state.albumColors,
                 alpha = { stainAlpha },
             )
+        }
         }
 
         // Reactive glow — full-screen, above the stain, behind the
@@ -497,6 +512,7 @@ fun MainPlayerScreen(
             ) {
             StatusOverlayPanel(
                 accent = accent,
+                hazeState = hazeState,
                 outputLabel = state.outputLabel,
                 soundLabel = state.soundLabel,
                 speedLabel = state.speedLabel,
@@ -561,6 +577,7 @@ private fun SwipeUpHandle(onClick: () -> Unit) {
 @Composable
 private fun StatusOverlayPanel(
     accent: Color,
+    hazeState: HazeState?,
     outputLabel: String,
     soundLabel: String,
     speedLabel: String,
@@ -602,6 +619,26 @@ private fun StatusOverlayPanel(
                 else PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
     ) {
         androidx.compose.foundation.layout.Box {
+        // Frosted backdrop UNDER the slab — the mini player's exact recipe.
+        val profile = LocalPerformanceProfile.current
+        if (useGlass && hazeState != null && profile.allowHazeBlur) {
+            val frostBg = MaterialTheme.colorScheme.background
+            val isDark = frostBg.luminance() <= 0.5f
+            val frostTint = if (isDark) Color.Black.copy(alpha = 0.32f)
+                            else Color.White.copy(alpha = 0.45f)
+            androidx.compose.foundation.layout.Box(
+                Modifier
+                    .matchParentSize()
+                    .hazeEffect(
+                        state = hazeState,
+                        style = HazeStyle(
+                            backgroundColor = frostBg,
+                            blurRadius = 40.dp,
+                            tints = listOf(HazeTint(frostTint)),
+                        ),
+                    )
+            )
+        }
         if (useGlass) {
             // The mini player's slab: a tint rectangle relit by the playerGlass
             // shader (bevel, refraction, rim — all from the Studio's mini

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -621,11 +621,12 @@ private fun StatusOverlayPanel(
         androidx.compose.foundation.layout.Box {
         // Frosted backdrop UNDER the slab — the mini player's exact recipe.
         val profile = LocalPerformanceProfile.current
-        if (useGlass && hazeState != null && profile.allowHazeBlur) {
+        if (useGlass && hazeState != null && profile.allowHazeBlur && g.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f)
+            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
+                            else Color.White.copy(alpha = 0.45f))
+                .let { it.copy(alpha = (it.alpha * g.hazeTint).coerceIn(0f, 1f)) }
             androidx.compose.foundation.layout.Box(
                 Modifier
                     .matchParentSize()
@@ -633,7 +634,7 @@ private fun StatusOverlayPanel(
                         state = hazeState,
                         style = HazeStyle(
                             backgroundColor = frostBg,
-                            blurRadius = 40.dp,
+                            blurRadius = g.hazeBlurDp.dp,
                             tints = listOf(HazeTint(frostTint)),
                         ),
                     )

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -125,6 +125,10 @@ data class MainPlayerUiState(
 @Composable
 fun MainPlayerScreen(
     state: MainPlayerUiState,
+    // The audio-tools sheet renders in the MINI player's glass material, not
+    // the full player's — the sheet is chrome overlaying the player, exactly
+    // the mini player's role, so it follows that Studio setting.
+    miniGlass: tf.monochrome.android.domain.model.PlayerGlassSettings,
     isFullscreen: Boolean,
     formatTime: (Long) -> String,
     onToggleLike: () -> Unit,
@@ -488,6 +492,9 @@ fun MainPlayerScreen(
         ) {
             // Granular, stable params (not the whole `state`) so this always-
             // composed sheet is SKIPPED on every position tick during playback.
+            androidx.compose.runtime.CompositionLocalProvider(
+                LocalPlayerGlass provides miniGlass,
+            ) {
             StatusOverlayPanel(
                 accent = accent,
                 outputLabel = state.outputLabel,
@@ -511,6 +518,7 @@ fun MainPlayerScreen(
                 onToneControlsChange = onToneControlsChange,
                 onDismiss = { animateRevealTo(0f, 0f) },
             )
+            }
         }
     }
 }
@@ -575,14 +583,41 @@ private fun StatusOverlayPanel(
     onDismiss: () -> Unit,
 ) {
     val shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+    val g = LocalPlayerGlass.current
+    val useGlass = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU &&
+        g.enabled
+    val glassTint = if (g.tintColor != 0) Color(g.tintColor) else accent
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(elevation = 32.dp, shape = shape, clip = false)
             .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f),
         shape = shape,
-        color = PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
+        // The old 92%-opaque black painted OVER the liquidGlass modifier and
+        // buried it — the sheet read as a flat slab. Glass mode keeps only a
+        // readability wash (the AGSL slab is nearly transparent at low
+        // bodyOpacity, and the tiles sit over bright album art); the opaque
+        // fill remains solely as the pre-Tiramisu / glass-off fallback.
+        color = if (useGlass) PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.45f)
+                else PlayerDesignTokens.BackgroundBlack.copy(alpha = 0.92f),
     ) {
+        androidx.compose.foundation.layout.Box {
+        if (useGlass) {
+            // The mini player's slab: a tint rectangle relit by the playerGlass
+            // shader (bevel, refraction, rim — all from the Studio's mini
+            // player settings). Offscreen so the shader only sees the slab.
+            androidx.compose.foundation.Canvas(
+                modifier = Modifier
+                    .matchParentSize()
+                    .playerGlass(tint = glassTint)
+                    .graphicsLayer {
+                        compositingStrategy =
+                            androidx.compose.ui.graphics.CompositingStrategy.Offscreen
+                    },
+            ) {
+                drawRect(color = glassTint)
+            }
+        }
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -648,6 +683,7 @@ private fun StatusOverlayPanel(
             ToggleRow("Compressor", "Oxford dynamics", compressorEnabled, accent, onCompressorToggle)
             ToggleRow("Inflator", "Oxford loudness", inflatorEnabled, accent, onInflatorToggle)
         }
+            }
     }
 }
 

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1052,6 +1052,18 @@ private fun PlayerGlassTab(
             "Frosted blur", "${(glass.frost * 100).toInt()}%", glass.frost, 0f..1f,
             description = "Frosts the glass, from clear to misted.",
         ) { onUpdate { g -> g.copy(frost = it) } }
+        if (previewMini) {
+            // Haze backdrop frost — only surfaces driven by the MINI glass
+            // (mini player bar, audio-tools sheet, nav pill) render it.
+            FxSlider(
+                "Backdrop blur", "%.0f dp".format(glass.hazeBlurDp), glass.hazeBlurDp, 0f..80f,
+                description = "Gaussian blur of whatever sits behind the bar (0 = off).",
+            ) { onUpdate { g -> g.copy(hazeBlurDp = it) } }
+            FxSlider(
+                "Backdrop tint", "${(glass.hazeTint * 100).toInt()}%", glass.hazeTint, 0f..2f,
+                description = "Strength of the frost layer's darkening/lightening wash.",
+            ) { onUpdate { g -> g.copy(hazeTint = it) } }
+        }
         FxSlider(
             "Surface motion", "${(glass.surfaceMotion * 100).toInt()}%", glass.surfaceMotion, 0f..1f,
             description = "Living-liquid shimmer on the glass surface (0 = still).",

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1030,6 +1030,9 @@ private fun PlayerGlassTab(
             )
         }
         Spacer(Modifier.height(14.dp))
+        // Controls are grouped by what they affect, in paint order: what the
+        // glass IS (body), its 3D form (shape & bevel), how light plays on it
+        // (light & reflections), what it casts (drop shadow), then render cost.
         StudioSection("Player Glass")
         FxToggle(
             "Button liquid glass", glass.enabled,
@@ -1039,22 +1042,22 @@ private fun PlayerGlassTab(
             "Glass progress bar", glass.progressGlass,
             description = "Thin glass tube scrubber that fills up, with a sine-wave bulge at the playhead dot.",
         ) { onUpdate { g -> g.copy(progressGlass = it) } }
+
+        StudioSection("Glass body")
         FxSlider(
             "Glass opacity", "${(glass.bodyOpacity * 100).toInt()}%", glass.bodyOpacity, 0.2f..1f,
             description = "Lower makes the buttons more see-through.",
         ) { onUpdate { g -> g.copy(bodyOpacity = it) } }
         FxSlider(
-            "Refraction", "%.2f".format(glass.refraction), glass.refraction, 0f..0.4f,
-            description = "How hard the beveled edges lens the backdrop behind them.",
-        ) { onUpdate { g -> g.copy(refraction = it) } }
+            "Frosted blur", "${(glass.frost * 100).toInt()}%", glass.frost, 0f..1f,
+            description = "Frosts the glass, from clear to misted.",
+        ) { onUpdate { g -> g.copy(frost = it) } }
         FxSlider(
-            "Edge highlight", "${(glass.rimBrightness * 100).toInt()}%", glass.rimBrightness, 0f..2f,
-            description = "Brightness of the specular glass rim.",
-        ) { onUpdate { g -> g.copy(rimBrightness = it) } }
-        FxSlider(
-            "Chromatic aberration", "${(glass.dispersion * 100).toInt()}%", glass.dispersion, 0f..2f,
-            description = "Colour fringing at the refracting edges.",
-        ) { onUpdate { g -> g.copy(dispersion = it) } }
+            "Surface motion", "${(glass.surfaceMotion * 100).toInt()}%", glass.surfaceMotion, 0f..1f,
+            description = "Living-liquid shimmer on the glass surface (0 = still).",
+        ) { onUpdate { g -> g.copy(surfaceMotion = it) } }
+
+        StudioSection("Shape & bevel")
         FxSlider(
             "Roundness", "%.2f".format(glass.roundness), glass.roundness, 0.5f..2f,
             description = "Rolls the glass edge from a sharp bevel to a round, pillowy shoulder.",
@@ -1064,15 +1067,31 @@ private fun PlayerGlassTab(
             description = "How thick and deep the relief reads — higher pops the buttons more in 3D.",
         ) { onUpdate { g -> g.copy(depth = it) } }
         FxSlider(
-            "Shadow depth", "${(glass.shadowDepth * 100).toInt()}%", glass.shadowDepth, 0f..1f,
-            description = "Drop shadow under the round play button — lifts it off the surface.",
-        ) { onUpdate { g -> g.copy(shadowDepth = it) } }
+            "Refraction", "%.2f".format(glass.refraction), glass.refraction, 0f..0.4f,
+            description = "How hard the beveled edges lens the backdrop behind them.",
+        ) { onUpdate { g -> g.copy(refraction = it) } }
         FxSlider(
-            "Per-pixel samples",
-            "${glass.sampleRings} (${when (glass.sampleRings) { 1 -> 5; 2 -> 9; else -> 13 }} taps)",
-            glass.sampleRings.toFloat(), 1f..3f, steps = 1,
-            description = "Bevel quality vs GPU cost.",
-        ) { onUpdate { g -> g.copy(sampleRings = it.toInt()) } }
+            "Chromatic aberration", "${(glass.dispersion * 100).toInt()}%", glass.dispersion, 0f..2f,
+            description = "Colour fringing at the refracting edges.",
+        ) { onUpdate { g -> g.copy(dispersion = it) } }
+
+        StudioSection("Light & reflections")
+        FxSlider(
+            "Light angle", "${glass.lightAngleDeg.toInt()}°", glass.lightAngleDeg, 0f..360f,
+            description = "Direction the key light comes from — where the highlights sit.",
+        ) { onUpdate { g -> g.copy(lightAngleDeg = it) } }
+        FxSlider(
+            "Tilt reactivity", "${(glass.tiltReactivity * 100).toInt()}%", glass.tiltReactivity, 0f..1.5f,
+            description = "How strongly tilting the phone moves the light and reflection.",
+        ) { onUpdate { g -> g.copy(tiltReactivity = it) } }
+        FxSlider(
+            "Edge highlight", "${(glass.rimBrightness * 100).toInt()}%", glass.rimBrightness, 0f..2f,
+            description = "Brightness of the specular glass rim.",
+        ) { onUpdate { g -> g.copy(rimBrightness = it) } }
+        FxSlider(
+            "Edge width", "${(glass.edgeWidth * 100).toInt()}%", glass.edgeWidth, 0f..1f,
+            description = "Reflective rim: thin crisp edge to a broad glassy shoulder.",
+        ) { onUpdate { g -> g.copy(edgeWidth = it) } }
         FxSlider(
             "Reflection", "${(glass.reflection * 100).toInt()}%", glass.reflection, 0f..2f,
             description = "How much of the room/environment reflection shows on the glass.",
@@ -1081,36 +1100,28 @@ private fun PlayerGlassTab(
             "Gloss", "${(glass.gloss * 100).toInt()}%", glass.gloss, 0f..1f,
             description = "Highlight polish: soft frosted-wide glint to a tight mirror.",
         ) { onUpdate { g -> g.copy(gloss = it) } }
-        FxSlider(
-            "Surface motion", "${(glass.surfaceMotion * 100).toInt()}%", glass.surfaceMotion, 0f..1f,
-            description = "Living-liquid shimmer on the glass surface (0 = still).",
-        ) { onUpdate { g -> g.copy(surfaceMotion = it) } }
-        FxSlider(
-            "Frosted blur", "${(glass.frost * 100).toInt()}%", glass.frost, 0f..1f,
-            description = "Frosts the glass, from clear to misted.",
-        ) { onUpdate { g -> g.copy(frost = it) } }
 
-        StudioSection("Light & shadow")
+        StudioSection("Drop shadow")
         FxSlider(
-            "Tilt reactivity", "${(glass.tiltReactivity * 100).toInt()}%", glass.tiltReactivity, 0f..1.5f,
-            description = "How strongly tilting the phone moves the light and reflection.",
-        ) { onUpdate { g -> g.copy(tiltReactivity = it) } }
-        FxSlider(
-            "Light angle", "${glass.lightAngleDeg.toInt()}°", glass.lightAngleDeg, 0f..360f,
-            description = "Direction the key light comes from — where the highlights sit.",
-        ) { onUpdate { g -> g.copy(lightAngleDeg = it) } }
-        FxSlider(
-            "Edge width", "${(glass.edgeWidth * 100).toInt()}%", glass.edgeWidth, 0f..1f,
-            description = "Reflective rim: thin crisp edge to a broad glassy shoulder.",
-        ) { onUpdate { g -> g.copy(edgeWidth = it) } }
+            "Shadow depth", "${(glass.shadowDepth * 100).toInt()}%", glass.shadowDepth, 0f..1f,
+            description = "Drop shadow under the glass buttons and dock — lifts them off the surface.",
+        ) { onUpdate { g -> g.copy(shadowDepth = it) } }
         FxSlider(
             "Shadow softness", "${(glass.shadowSoftness * 100).toInt()}%", glass.shadowSoftness, 0f..1f,
-            description = "Blur / spread of the drop shadow under the play button.",
+            description = "Blur / spread of the drop shadow.",
         ) { onUpdate { g -> g.copy(shadowSoftness = it) } }
         FxSlider(
             "Shadow tint", "${(glass.shadowTint * 100).toInt()}%", glass.shadowTint, 0f..1f,
             description = "Colour of the drop shadow: neutral black to accent glow.",
         ) { onUpdate { g -> g.copy(shadowTint = it) } }
+
+        StudioSection("Quality")
+        FxSlider(
+            "Per-pixel samples",
+            "${glass.sampleRings} (${when (glass.sampleRings) { 1 -> 5; 2 -> 9; else -> 13 }} taps)",
+            glass.sampleRings.toFloat(), 1f..3f, steps = 1,
+            description = "Bevel quality vs GPU cost.",
+        ) { onUpdate { g -> g.copy(sampleRings = it.toInt()) } }
         Spacer(Modifier.height(20.dp))
         OutlinedButton(
             onClick = { onApplyPreset(PlayerGlassSettings.DEFAULT) },

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -1045,8 +1045,8 @@ private fun PlayerGlassTab(
 
         StudioSection("Glass body")
         FxSlider(
-            "Glass opacity", "${(glass.bodyOpacity * 100).toInt()}%", glass.bodyOpacity, 0.2f..1f,
-            description = "Lower makes the buttons more see-through.",
+            "Glass opacity", "${(glass.bodyOpacity * 100).toInt()}%", glass.bodyOpacity, 0f..1f,
+            description = "Lower makes the buttons more see-through (0 = body fully invisible, edges remain).",
         ) { onUpdate { g -> g.copy(bodyOpacity = it) } }
         FxSlider(
             "Frosted blur", "${(glass.frost * 100).toInt()}%", glass.frost, 0f..1f,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -120,7 +120,7 @@ import tf.monochrome.android.ui.theme.themeDisplayNames
 
 // "Radio" is appended after "About" so existing hardcoded tab indices
 // ("settings?tab=4" for Equalizer, "settings?tab=7" for Instances) stay valid.
-private val settingsTabs = listOf("Appearance", "Interface", "Scrobbling", "Audio", "Equalizer", "Library", "Downloads", "Instances", "System", "About", "Radio")
+private val settingsTabs = listOf("Appearance", "Interface", "Scrobbling", "Audio", "Equalizer", "Library", "Downloads", "Instances", "System", "Radio", "About")
 
 /** One selectable step in the Appearance › Font Size picker. */
 private data class FontScalePreset(val label: String, val scale: Float)
@@ -220,8 +220,8 @@ fun SettingsScreen(
                     6 -> DownloadsTab(viewModel)
                     7 -> InstancesTab(viewModel)
                     8 -> SystemTab(viewModel, navController)
-                    9 -> AboutTab()
-                    10 -> tf.monochrome.android.ui.settings.radio.RadioSettingsTab()
+                    9 -> tf.monochrome.android.ui.settings.radio.RadioSettingsTab()
+                    10 -> AboutTab()
                 }
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -29,7 +29,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -140,9 +145,16 @@ fun SettingsScreen(
     initialTab: Int = 0,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    // rememberSaveable so the selected settings tab survives background process
-    // death instead of snapping back to the first tab.
-    var selectedTab by rememberSaveable { mutableIntStateOf(initialTab) }
+    // Tabs are swipeable pages. The chip row is a selector onto the SAME pager
+    // state rather than a second source of truth, so a swipe and a tap can't
+    // disagree. rememberPagerState saves its own page across process death,
+    // which is what the old rememberSaveable int was doing here.
+    val settingsPager = rememberPagerState(
+        initialPage = initialTab.coerceIn(0, settingsTabs.lastIndex),
+        pageCount = { settingsTabs.size },
+    )
+    val settingsScope = rememberCoroutineScope()
+    val selectedTab = settingsPager.currentPage
 
     // Toast one-shot ViewModel messages (font import, backup import, …) from
     // one always-composed collector, regardless of which tab is showing.
@@ -166,18 +178,21 @@ fun SettingsScreen(
             )
         )
 
-        // Tab row
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = 12.dp, vertical = 4.dp),
+        // Tab row. A LazyRow rather than the old horizontalScroll(Row) so it can
+        // scroll the selected chip into view — swiping out to Radio (11th of 11)
+        // would otherwise leave the highlighted chip off-screen behind you.
+        val chipRow = rememberLazyListState()
+        LaunchedEffect(selectedTab) { chipRow.animateScrollToItem(selectedTab) }
+        LazyRow(
+            state = chipRow,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            settingsTabs.forEachIndexed { index, tab ->
+            itemsIndexed(settingsTabs) { index, tab ->
                 FilterChip(
                     selected = selectedTab == index,
-                    onClick = { selectedTab = index },
+                    onClick = { settingsScope.launch { settingsPager.animateScrollToPage(index) } },
                     label = { Text(tab, style = MaterialTheme.typography.labelMedium) },
                     colors = FilterChipDefaults.filterChipColors(
                         selectedContainerColor = MaterialTheme.colorScheme.primary,
@@ -187,19 +202,27 @@ fun SettingsScreen(
             }
         }
 
-        tf.monochrome.android.devedit.DevEditScreen("settings/${devSlug(settingsTabs[selectedTab])}") {
-            when (selectedTab) {
-                0 -> AppearanceTab(viewModel)
-                1 -> InterfaceTab(viewModel, navController)
-                2 -> ScrobblingTab(viewModel)
-                3 -> AudioTab(viewModel, navController)
-                4 -> EqualizerTab(navController)
-                5 -> LibrarySettingsTab(viewModel)
-                6 -> DownloadsTab(viewModel)
-                7 -> InstancesTab(viewModel)
-                8 -> SystemTab(viewModel, navController)
-                9 -> AboutTab()
-                10 -> tf.monochrome.android.ui.settings.radio.RadioSettingsTab()
+        HorizontalPager(
+            state = settingsPager,
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            // Each tab is a full settings form; keeping neighbours composed
+            // would mean building all 11 of them up front.
+            beyondViewportPageCount = 0,
+        ) { page ->
+            tf.monochrome.android.devedit.DevEditScreen("settings/${devSlug(settingsTabs[page])}") {
+                when (page) {
+                    0 -> AppearanceTab(viewModel)
+                    1 -> InterfaceTab(viewModel, navController)
+                    2 -> ScrobblingTab(viewModel)
+                    3 -> AudioTab(viewModel, navController)
+                    4 -> EqualizerTab(navController)
+                    5 -> LibrarySettingsTab(viewModel)
+                    6 -> DownloadsTab(viewModel)
+                    7 -> InstancesTab(viewModel)
+                    8 -> SystemTab(viewModel, navController)
+                    9 -> AboutTab()
+                    10 -> tf.monochrome.android.ui.settings.radio.RadioSettingsTab()
+                }
             }
         }
     }

--- a/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqAlgorithmTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqAlgorithmTest.kt
@@ -23,6 +23,47 @@ class AutoEqAlgorithmTest {
     private val flatTarget = curve { 0f }
 
     @Test
+    fun `four bands flatten a three-feature curve to under 40 percent RMS`() {
+        // Bass tilt + mid bump + presence dip — three broad features against a
+        // four-band budget. One-shot greedy fitting leaves substantially more
+        // residual here; the refinement pass is what earns this bound.
+        fun bump(f: Float, c: Float, w: Float, a: Float): Float {
+            val x = kotlin.math.ln((f / c).toDouble()) / w
+            return (a * kotlin.math.exp(-x * x)).toFloat()
+        }
+        val shape = { f: Float -> bump(f, 60f, 0.9f, -5f) + bump(f, 1000f, 0.5f, 6f) + bump(f, 4000f, 0.45f, -4f) }
+        val meas = curve(shape)
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 4,
+            algorithm = AutoEqAlgorithm.PEAKING,
+        )
+        assertTrue(bands.size <= 4)
+        assertTrue(bands.all { kotlin.math.abs(it.gain) >= 0.2f })
+
+        // Weighted RMS of the error before vs after applying the fitted stack.
+        fun norm(c: List<FrequencyPoint>): Float {
+            val mid = c.filter { it.freq in 250f..2500f }
+            return mid.map { it.gain }.sum() / mid.size
+        }
+        val offset = norm(flatTarget) - norm(meas)
+        fun weight(f: Float) = when {
+            f < 300f -> 1.5; f < 4000f -> 1.0; f < 8000f -> 0.5; else -> 0.25
+        }
+        var beforeSq = 0.0; var afterSq = 0.0
+        for (p in meas) {
+            val e = (p.gain + offset) - 75f  // target is flat 75
+            var corr = e.toDouble()
+            for (b in bands) corr += AutoEqEngine.calculateBiquadResponse(p.freq, b)
+            val w = weight(p.freq)
+            beforeSq += w * e * e
+            afterSq += w * corr * corr
+        }
+        val ratio = kotlin.math.sqrt(afterSq / beforeSq)
+        assertTrue("residual RMS ratio $ratio should be < 0.35", ratio < 0.35)
+    }
+
+    @Test
     fun `bass roll-off produces a boosting low shelf under SHELF_ENDS`() {
         // 6 dB quiet below 100 Hz — a broad tilt, the shelf's home turf.
         val meas = curve { f -> if (f < 100f) -6f else 0f }
@@ -49,6 +90,31 @@ class AutoEqAlgorithmTest {
 
         val shelf = bands.first { it.type == FilterType.HIGHSHELF }
         assertTrue("expected cut, got ${shelf.gain}", shelf.gain < -1f)
+    }
+
+    @Test
+    fun `a 31-band fit on a dense curve completes in interactive time`() {
+        // squig/SeapEngine schedule their fit behind a 600 ms timeout; ours
+        // must land comfortably inside interactive latency even at the max
+        // band count on a dense (500-point) measurement. JVM here is slower
+        // than ART+JIT on device for this arithmetic, so 600 ms is a
+        // conservative ceiling.
+        val meas = (0..500).map { i ->
+            val f = 20f * (1000f).pow(i / 500f)
+            FrequencyPoint(f, 75f + (kotlin.math.sin(i / 7.0) * 4).toFloat())
+        }
+        val target = (0..500).map { i ->
+            val f = 20f * (1000f).pow(i / 500f)
+            FrequencyPoint(f, 75f)
+        }
+        val t0 = System.nanoTime()
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = target, bandCount = 31,
+            algorithm = AutoEqAlgorithm.SHELF_ENDS,
+        )
+        val ms = (System.nanoTime() - t0) / 1_000_000
+        assertTrue(bands.isNotEmpty())
+        assertTrue("fit took ${ms}ms", ms < 600)
     }
 
     @Test

--- a/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqAlgorithmTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqAlgorithmTest.kt
@@ -1,0 +1,90 @@
+package tf.monochrome.android.audio.eq
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tf.monochrome.android.domain.model.FilterType
+import tf.monochrome.android.domain.model.FrequencyPoint
+import kotlin.math.pow
+
+/**
+ * Behavioural contract of the two fitting algorithms on synthetic
+ * measurements with known deviations.
+ */
+class AutoEqAlgorithmTest {
+
+    /** Log-spaced 20 Hz–20 kHz curve built from a shape function. */
+    private fun curve(shape: (Float) -> Float): List<FrequencyPoint> =
+        (0..200).map { i ->
+            val f = 20f * (1000f).pow(i / 200f)  // 20 -> 20k
+            FrequencyPoint(f, 75f + shape(f))
+        }
+
+    private val flatTarget = curve { 0f }
+
+    @Test
+    fun `bass roll-off produces a boosting low shelf under SHELF_ENDS`() {
+        // 6 dB quiet below 100 Hz — a broad tilt, the shelf's home turf.
+        val meas = curve { f -> if (f < 100f) -6f else 0f }
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 10,
+            algorithm = AutoEqAlgorithm.SHELF_ENDS,
+        )
+
+        val shelf = bands.first { it.type == FilterType.LOWSHELF }
+        assertEquals(105f, shelf.freq, 0.01f)
+        assertTrue("expected boost, got ${shelf.gain}", shelf.gain > 2f)
+        assertEquals(0.707f, shelf.q, 0.001f)
+    }
+
+    @Test
+    fun `treble tilt produces a cutting high shelf under SHELF_ENDS`() {
+        val meas = curve { f -> if (f > 9000f) 5f else 0f }
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 10,
+            algorithm = AutoEqAlgorithm.SHELF_ENDS,
+        )
+
+        val shelf = bands.first { it.type == FilterType.HIGHSHELF }
+        assertTrue("expected cut, got ${shelf.gain}", shelf.gain < -1f)
+    }
+
+    @Test
+    fun `PEAKING never emits shelves`() {
+        val meas = curve { f -> if (f < 100f) -6f else if (f > 9000f) 5f else 0f }
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 10,
+            algorithm = AutoEqAlgorithm.PEAKING,
+        )
+
+        assertTrue(bands.all { it.type == FilterType.PEAKING })
+    }
+
+    @Test
+    fun `shelves count against the band budget`() {
+        val meas = curve { f -> if (f < 100f) -6f else if (f > 9000f) 5f else 0f }
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 5,
+            algorithm = AutoEqAlgorithm.SHELF_ENDS,
+        )
+
+        assertTrue("got ${bands.size} bands", bands.size <= 5)
+    }
+
+    @Test
+    fun `flat ends spend no shelves`() {
+        // Deviation only in the mids — inaudible-shelf gate must skip both ends.
+        val meas = curve { f -> if (f in 900f..1100f) 6f else 0f }
+
+        val bands = AutoEqEngine.runAutoEqAlgorithm(
+            measurement = meas, target = flatTarget, bandCount = 10,
+            algorithm = AutoEqAlgorithm.SHELF_ENDS,
+        )
+
+        assertTrue(bands.none { it.type != FilterType.PEAKING })
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqSmoothingTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqSmoothingTest.kt
@@ -1,0 +1,50 @@
+package tf.monochrome.android.audio.eq
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tf.monochrome.android.domain.model.FrequencyPoint
+
+/**
+ * Pins the SeapEngine `a7` port: radius = floor(percent / 2.5) points,
+ * triangular weights 1 − |offset|/(radius+1), edges renormalized.
+ */
+class AutoEqSmoothingTest {
+
+    private fun pts(vararg gains: Float) =
+        gains.mapIndexed { i, g -> FrequencyPoint(20f + i * 10f, g) }
+
+    @Test
+    fun `zero percent and tiny curves are untouched`() {
+        val p = pts(1f, 2f, 3f)
+        assertEquals(p, AutoEqEngine.smoothCurve(p, 0f))
+        assertEquals(pts(1f, 5f), AutoEqEngine.smoothCurve(pts(1f, 5f), 50f))
+    }
+
+    @Test
+    fun `radius-1 triangular window matches hand-computed values`() {
+        // pct 2.5 -> r=1, weights [0.5, 1, 0.5]
+        val out = AutoEqEngine.smoothCurve(pts(0f, 0f, 10f, 0f, 0f), 2.5f)
+        assertEquals(0f, out[0].gain, 1e-4f)     // edge: (0*1 + 0*0.5)/1.5
+        assertEquals(2.5f, out[1].gain, 1e-4f)   // (0*0.5 + 0*1 + 10*0.5)/2
+        assertEquals(5f, out[2].gain, 1e-4f)     // (0*0.5 + 10*1 + 0*0.5)/2
+        assertEquals(2.5f, out[3].gain, 1e-4f)
+        assertEquals(0f, out[4].gain, 1e-4f)
+    }
+
+    @Test
+    fun `frequencies are preserved, only gains change`() {
+        val input = pts(0f, 8f, -3f, 4f, 1f)
+        val out = AutoEqEngine.smoothCurve(input, 60f)
+        assertEquals(input.map { it.freq }, out.map { it.freq })
+    }
+
+    @Test
+    fun `higher percent flattens harder`() {
+        val jagged = pts(0f, 10f, -10f, 10f, -10f, 10f, 0f)
+        fun ripple(c: List<FrequencyPoint>) =
+            c.maxOf { it.gain } - c.minOf { it.gain }
+        val lo = ripple(AutoEqEngine.smoothCurve(jagged, 5f))
+        val hi = ripple(AutoEqEngine.smoothCurve(jagged, 100f))
+        assert(hi < lo) { "expected 100% ($hi) flatter than 5% ($lo)" }
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/data/import_/ApoProfileParserTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/import_/ApoProfileParserTest.kt
@@ -1,0 +1,204 @@
+package tf.monochrome.android.data.import_
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tf.monochrome.android.domain.model.FilterType
+
+/**
+ * Dialect coverage for [ApoProfileParser].
+ *
+ * These profiles reach users from AutoEq, oratory1990, Squiglink, Wavelet and
+ * Poweramp, and each writes the format slightly differently. The parser is pure
+ * Kotlin precisely so those variations can be pinned here instead of only being
+ * discovered on a device with a file that won't load.
+ */
+class ApoProfileParserTest {
+
+    private val parametricCap = 24f
+    private val autoEqCap = 12f
+
+    @Test
+    fun `parses the format the app itself exports`() {
+        val text = """
+            Preamp: -6.8 dB
+            Filter 1: ON PK Fc 105 Hz Gain -2.9 dB Q 0.70
+            Filter 2: ON PK Fc 1000 Hz Gain 3.2 dB Q 1.40
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(2, r.bands.size)
+        assertEquals(-6.8f, r.preamp, 0.001f)
+        assertEquals(105f, r.bands[0].freq, 0.001f)
+        assertEquals(-2.9f, r.bands[0].gain, 0.001f)
+        assertEquals(0.70f, r.bands[0].q, 0.001f)
+        assertEquals(FilterType.PEAKING, r.bands[0].type)
+        assertTrue(r.warnings.isEmpty())
+    }
+
+    @Test
+    fun `maps shelf aliases and slope-qualified shelves`() {
+        val text = """
+            Preamp: -5.0 dB
+            Filter 1: ON LSC 12 dB Fc 105 Hz Gain 5.5 dB Q 0.70
+            Filter 2: ON HS Fc 10000 Hz Gain -2.0 dB Q 0.70
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(2, r.bands.size)
+        assertEquals(FilterType.LOWSHELF, r.bands[0].type)
+        // The bare "12" of the slope qualifier must not be read as Fc or Gain.
+        assertEquals(105f, r.bands[0].freq, 0.001f)
+        assertEquals(5.5f, r.bands[0].gain, 0.001f)
+        assertEquals(FilterType.HIGHSHELF, r.bands[1].type)
+    }
+
+    @Test
+    fun `OFF filters are kept as disabled bands, not dropped`() {
+        val text = """
+            Filter 1: ON PK Fc 100 Hz Gain 1.0 dB Q 1.0
+            Filter 2: OFF PK Fc 200 Hz Gain 2.0 dB Q 1.0
+            Filter 3: ON PK Fc 300 Hz Gain 3.0 dB Q 1.0
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(3, r.bands.size)
+        assertTrue(r.bands[0].enabled)
+        assertFalse(r.bands[1].enabled)
+        assertTrue(r.bands[2].enabled)
+    }
+
+    @Test
+    fun `None placeholders are skipped without warning`() {
+        val text = """
+            Filter 1: ON PK Fc 100 Hz Gain 1.0 dB Q 1.0
+            Filter 2: ON None
+            Filter 3: ON None
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(1, r.bands.size)
+        assertTrue(r.warnings.none { it.contains("unsupported", ignoreCase = true) })
+    }
+
+    @Test
+    fun `unsupported filter types are skipped and reported`() {
+        val text = """
+            Filter 1: ON PK Fc 100 Hz Gain 1.0 dB Q 1.0
+            Filter 2: ON HP Fc 30 Hz Q 0.70
+            Filter 3: ON LP Fc 18000 Hz Q 0.70
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(1, r.bands.size)
+        val warning = r.warnings.single { it.contains("unsupported", ignoreCase = true) }
+        assertTrue(warning.contains("HP"))
+        assertTrue(warning.contains("LP"))
+    }
+
+    @Test
+    fun `accepts EU decimal commas`() {
+        val text = """
+            Preamp: -6,8 dB
+            Filter 1: ON PK Fc 105 Hz Gain -2,9 dB Q 0,70
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(-6.8f, r.preamp, 0.001f)
+        assertEquals(-2.9f, r.bands[0].gain, 0.001f)
+        assertEquals(0.70f, r.bands[0].q, 0.001f)
+    }
+
+    @Test
+    fun `clamps gain to the destination ceiling and says so`() {
+        val text = "Filter 1: ON PK Fc 100 Hz Gain 18.0 dB Q 1.0"
+
+        val intoAutoEq = ApoProfileParser.parse(text, autoEqCap)
+        assertEquals(12f, intoAutoEq.bands[0].gain, 0.001f)
+        assertTrue(intoAutoEq.warnings.any { it.contains("12 dB") })
+
+        // The same file is untouched by the Parametric surface's wider ceiling.
+        val intoParametric = ApoProfileParser.parse(text, parametricCap)
+        assertEquals(18f, intoParametric.bands[0].gain, 0.001f)
+    }
+
+    @Test
+    fun `no filter count limit`() {
+        val text = buildString {
+            appendLine("Preamp: -3.0 dB")
+            repeat(40) { i ->
+                appendLine("Filter ${i + 1}: ON PK Fc ${100 + i * 100} Hz Gain 1.0 dB Q 1.0")
+            }
+        }
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(40, r.bands.size)
+        // Ids stay sequential and unique — they key the UI's band selection.
+        assertEquals(r.bands.map { it.id }, r.bands.indices.toList())
+    }
+
+    @Test
+    fun `an AutoEq measurement CSV is recognised rather than failing to parse`() {
+        val text = """
+            frequency,raw,smoothed,error,equalization,target
+            20.0,3.5,3.4,-1.2,1.2,4.7
+            21.0,3.4,3.3,-1.1,1.1,4.5
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertTrue(r.looksLikeMeasurement)
+        assertTrue(r.isEmpty)
+    }
+
+    @Test
+    fun `band CSV rows parse`() {
+        val text = """
+            type,fc,gain,q
+            PK,105,-2.9,0.7
+            LSC,200,3.0,0.7
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(2, r.bands.size)
+        assertEquals(FilterType.PEAKING, r.bands[0].type)
+        assertEquals(FilterType.LOWSHELF, r.bands[1].type)
+    }
+
+    @Test
+    fun `a file with no filters explains the expected format`() {
+        val r = ApoProfileParser.parse("hello world\nnot an eq profile", parametricCap)
+
+        assertTrue(r.isEmpty)
+        assertTrue(r.warnings.single().contains("Filter 1: ON PK"))
+    }
+
+    @Test
+    fun `missing preamp is derived from the peak boost`() {
+        val text = """
+            Filter 1: ON PK Fc 100 Hz Gain 4.0 dB Q 1.0
+            Filter 2: ON PK Fc 200 Hz Gain 6.5 dB Q 1.0
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(-6.5f, r.preamp, 0.001f)
+        assertTrue(r.warnings.any { it.contains("preamp", ignoreCase = true) })
+    }
+
+    @Test
+    fun `shelves without an explicit Q get the Butterworth default`() {
+        val r = ApoProfileParser.parse("Filter 1: ON LS Fc 105 Hz Gain 5.0 dB", parametricCap)
+
+        assertEquals(0.707f, r.bands[0].q, 0.001f)
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/data/import_/ApoProfileParserTest.kt
+++ b/app/src/test/java/tf/monochrome/android/data/import_/ApoProfileParserTest.kt
@@ -160,6 +160,109 @@ class ApoProfileParserTest {
     }
 
     @Test
+    fun `CSV rows are clamped and counted like filter lines`() {
+        val text = """
+            type,fc,gain,q
+            PK,100,40.0,1.0
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, autoEqCap)
+
+        assertEquals(12f, r.bands[0].gain, 0.001f)
+        assertTrue(r.warnings.any { it.contains("12 dB") })
+    }
+
+    @Test
+    fun `newline-stripped SeapEngine paste is rebuilt and parses fully`() {
+        // Verbatim from a chat paste: comment header and all ten filters glued
+        // into ONE line — no newlines survived the copy.
+        val text = "# Headphone correction: Moondrop Blessing 2# Rig: IEC-711 Clone" +
+            "# Target Curve: HARMAN# Configured Bass Boost: 3 dB" +
+            "# Exported from SeapEngine Professional Audio Workstation" +
+            "Filter 1: ON PK Fc 20 Hz Gain 6.7 dB Q 1.4" +
+            "Filter 2: ON PK Fc 50 Hz Gain 5.8 dB Q 1.2" +
+            "Filter 3: ON PK Fc 100 Hz Gain 3.9 dB Q 1.0" +
+            "Filter 4: ON PK Fc 200 Hz Gain 1 dB Q 1.4" +
+            "Filter 5: ON PK Fc 500 Hz Gain 0.1 dB Q 1.4" +
+            "Filter 6: ON PK Fc 1000 Hz Gain -0.3 dB Q 1.4" +
+            "Filter 7: ON PK Fc 2000 Hz Gain 0.4 dB Q 1.8" +
+            "Filter 8: ON PK Fc 4000 Hz Gain 1.7 dB Q 2.0" +
+            "Filter 9: ON PK Fc 8000 Hz Gain 0.5 dB Q 2.5" +
+            "Filter 10: ON PK Fc 16000 Hz Gain 4 dB Q 2.5"
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(10, r.bands.size)
+        assertEquals(20f, r.bands[0].freq, 0.001f)
+        assertEquals(6.7f, r.bands[0].gain, 0.001f)
+        assertEquals(1.4f, r.bands[0].q, 0.001f)
+        // Integer gain ("Gain 1 dB") and the final line both survive.
+        assertEquals(1f, r.bands[3].gain, 0.001f)
+        assertEquals(16000f, r.bands[9].freq, 0.001f)
+        assertEquals(2.5f, r.bands[9].q, 0.001f)
+        // No preamp in the file -> derived from the +6.7 peak.
+        assertEquals(-6.7f, r.preamp, 0.001f)
+    }
+
+    @Test
+    fun `the same SeapEngine profile with real newlines parses identically`() {
+        val text = """
+            # Headphone correction: Moondrop Blessing 2
+            # Exported from SeapEngine Professional Audio Workstation
+            Filter 1: ON PK Fc 20 Hz Gain 6.7 dB Q 1.4
+            Filter 2: ON PK Fc 50 Hz Gain 5.8 dB Q 1.2
+        """.trimIndent()
+
+        val r = ApoProfileParser.parse(text, parametricCap)
+
+        assertEquals(2, r.bands.size)
+        assertEquals(50f, r.bands[1].freq, 0.001f)
+    }
+
+    @Test
+    fun `20-filter AutoEq export with shelves and 3-decimal Qs parses fully`() {
+        val text = """
+            Preamp: -9.1 dB
+            Filter 1: ON PK Fc 20 Hz Gain 2.92 dB Q 0.406
+            Filter 2: ON PK Fc 55 Hz Gain 1.32 dB Q 0.811
+            Filter 3: ON PK Fc 79 Hz Gain 0.27 dB Q 1.404
+            Filter 4: ON PK Fc 277 Hz Gain -0.91 dB Q 1.167
+            Filter 5: ON PK Fc 389 Hz Gain -5.82 dB Q 1.192
+            Filter 6: ON LSC Fc 784 Hz Gain -1.33 dB Q 0.707
+            Filter 7: ON PK Fc 817 Hz Gain 0.95 dB Q 3.595
+            Filter 8: ON PK Fc 874 Hz Gain 4.13 dB Q 2.507
+            Filter 9: ON PK Fc 1185 Hz Gain -2.27 dB Q 2.107
+            Filter 10: ON PK Fc 2312 Hz Gain 4.65 dB Q 1.891
+            Filter 11: ON PK Fc 2874 Hz Gain -6.26 dB Q 1.413
+            Filter 12: ON PK Fc 3820 Hz Gain 5.39 dB Q 3.996
+            Filter 13: ON PK Fc 5659 Hz Gain -8.09 dB Q 4.000
+            Filter 14: ON PK Fc 6179 Hz Gain 6.52 dB Q 1.992
+            Filter 15: ON HSC Fc 6977 Hz Gain -5.53 dB Q 0.707
+            Filter 16: ON PK Fc 8119 Hz Gain -3.58 dB Q 3.950
+            Filter 17: ON PK Fc 9126 Hz Gain 4.89 dB Q 3.825
+            Filter 18: ON PK Fc 10561 Hz Gain 3.83 dB Q 3.383
+            Filter 19: ON PK Fc 13000 Hz Gain -9.34 dB Q 2.131
+            Filter 20: ON PK Fc 16000 Hz Gain 16.00 dB Q 0.411
+        """.trimIndent()
+
+        // Parametric surface (±24 dB): everything passes through untouched.
+        val r = ApoProfileParser.parse(text, parametricCap)
+        assertEquals(20, r.bands.size)
+        assertEquals(-9.1f, r.preamp, 0.001f)
+        assertEquals(FilterType.LOWSHELF, r.bands[5].type)
+        assertEquals(784f, r.bands[5].freq, 0.001f)
+        assertEquals(FilterType.HIGHSHELF, r.bands[14].type)
+        assertEquals(0.406f, r.bands[0].q, 0.001f)
+        assertEquals(16f, r.bands[19].gain, 0.001f)
+        assertTrue(r.warnings.isEmpty())
+
+        // AutoEQ surface (±12 dB): only Filter 20's +16 dB is clamped, loudly.
+        val auto = ApoProfileParser.parse(text, autoEqCap)
+        assertEquals(12f, auto.bands[19].gain, 0.001f)
+        assertTrue(auto.warnings.any { it.contains("12 dB") })
+    }
+
+    @Test
     fun `band CSV rows parse`() {
         val text = """
             type,fc,gain,q

--- a/app/src/test/java/tf/monochrome/android/domain/model/EqPresetStereoTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/EqPresetStereoTest.kt
@@ -1,0 +1,49 @@
+package tf.monochrome.android.domain.model
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The 2-channel preset contract: bandsR is nullable, null MEANS mono, and both
+ * shapes survive JSON round-trips — including decoding pre-v11 JSON that has
+ * no bandsR field at all (every existing saved preset).
+ */
+class EqPresetStereoTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun band(id: Int, freq: Float, gain: Float) =
+        EqBand(id = id, freq = freq, gain = gain, q = 1f)
+
+    @Test
+    fun `stereo preset round-trips with distinct per-ear bands`() {
+        val preset = EqPreset(
+            id = "p1",
+            name = "LR",
+            bands = listOf(band(0, 100f, 2f), band(1, 1000f, -3f)),
+            bandsR = listOf(band(0, 120f, 1.5f)),
+            preamp = -3f,
+        )
+        val decoded = json.decodeFromString<EqPreset>(json.encodeToString(EqPreset.serializer(), preset))
+        assertEquals(2, decoded.bands.size)
+        assertEquals(1, decoded.bandsR?.size)
+        assertEquals(120f, decoded.bandsR!![0].freq, 0f)
+    }
+
+    @Test
+    fun `mono preset keeps bandsR null through a round-trip`() {
+        val preset = EqPreset(id = "p2", name = "mono", bands = listOf(band(0, 100f, 2f)))
+        val decoded = json.decodeFromString<EqPreset>(json.encodeToString(EqPreset.serializer(), preset))
+        assertNull(decoded.bandsR)
+    }
+
+    @Test
+    fun `pre-v11 JSON with no bandsR field decodes as a mono preset`() {
+        val legacy = """{"id":"p3","name":"old","bands":[{"id":0,"freq":100.0,"gain":2.0}]}"""
+        val decoded = json.decodeFromString<EqPreset>(legacy)
+        assertNull(decoded.bandsR)
+        assertEquals(1, decoded.bands.size)
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
@@ -47,6 +47,8 @@ class PlayerGlassSettingsTest {
         assertEquals(2f, c.dispersion, 0f)
         assertEquals(3, c.sampleRings)
         assertEquals(360f, c.lightAngleDeg, 0f)
+        assertEquals(80f, PlayerGlassSettings(hazeBlurDp = 500f).clamped().hazeBlurDp, 0f)
+        assertEquals(0f, PlayerGlassSettings(hazeTint = -3f).clamped().hazeTint, 0f)
     }
 
     @Test

--- a/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
@@ -12,19 +12,21 @@ class PlayerGlassSettingsTest {
 
     @Test
     fun `defaults reproduce the shipped glass`() {
-        // The shipped default is the "55" material: ghost body, maxed
-        // refraction/dispersion/relief, mirror gloss over a light mist,
-        // locked back-left key light.
+        // The shipped default: ghost body at full refraction, mirror-strong
+        // room reflection under a tight glint, dim rim on a hairline edge,
+        // perfectly clear glass, locked key light at 215°.
         val d = PlayerGlassSettings.DEFAULT
         assertTrue(d.enabled)
         assertEquals(0.2f, d.bodyOpacity, 0f)
         assertEquals(0.4f, d.refraction, 0f)
-        assertEquals(2f, d.rimBrightness, 0f)
+        assertEquals(0.2633547f, d.rimBrightness, 0f)
         assertEquals(3, d.sampleRings)
         assertEquals(1f, d.gloss, 0f)
-        assertEquals(0.17f, d.frost, 0f)
+        assertEquals(2f, d.reflection, 0f)
+        assertEquals(0f, d.frost, 0f)
+        assertEquals(0f, d.edgeWidth, 0f)
         assertEquals(0f, d.tiltReactivity, 0f)
-        assertEquals(280f, d.lightAngleDeg, 0f)
+        assertEquals(215.1965f, d.lightAngleDeg, 0f)
         assertTrue(d.progressGlass)
         // Colour fields default to "use the current album colour".
         assertEquals(0, d.tintColor)


### PR DESCRIPTION
## Per-ear (L/R) AutoEQ
- Independent left/right filter chains in `AutoEqProcessor` (different lengths are normal); tone shelves apply to both ears; one shared preamp sized to the hotter ear
- 2-channel calibration toggle — non-destructive to switch off; per-ear measurement rows with file import each
- squig.link: true L/R pair loading in one tap, exact-channel fetching (the right picker used to silently receive left-ear data), numbered-sample rigs (Listener/GRAS `L1.txt`) supported, ▲▼ sample stepper (`L → L1 → L2 …`) with HEAD-probe discovery
- Room v10→v11: nullable `bandsRJson` on presets — every pre-v11 row stays a valid mono preset; stereo presets carry both ears

## EqualizerAPO profile import (both EQ surfaces)
- Dialect-tolerant parser: APO txt + band CSV, EU decimals, OFF filters kept, `None` slots skipped, unsupported types reported, per-surface gain clamps, measurement-CSV detection, newline reconstruction for chat/web-mangled pastes
- Dual L/R paste panes with per-pane Open file and one Upload; live preview with warnings before anything applies; L-only = mono, both panes = stereo preset + auto-enables 2-channel

## Fitting engine
- Cyclic coordinate-descent refinement after greedy seeding: ±half-octave × 0.5–2×Q candidate grids, closed-form least-squares gain, exact-RBJ scoring, absorbed-band pruning — 4 bands must flatten a three-feature curve below 35% weighted residual RMS (pinned)
- Biquad coefficients hoisted out of the per-point path + precomputed phase tables: 31-band fit on a 500-point curve in interactive time (pinned <600 ms on JVM)
- `SHELF_ENDS` algorithm: low shelf at 105 Hz (±12) and high shelf at 10 kHz (boost ≤4 dB) fitted first, bells on the residual; sub-1 dB shelves skipped (tilt JND). `ALGORITHM Peaking | Shelf ends` selector for A/B
- SeapEngine-exact smoothing (0–100%, triangular window, radius = pct/2.5 points), preview-only; the AutoEq button is the explicit reprocess point and refits every ear

## UI
- Readable graph: relative ±dB axis, boost/cut-coloured numbered dots (compact handles above ten bands), correction-gap shading, tappable per-curve legend, selected-band guide + Hz/dB/Q readout
- AutoEQ band cap lifted to ±24 dB; shelf type selector on every band row
- Parametric EQ page rebuilt to the same standard (inline band editing, draggable dots, preamp under the graph; fixes overlapping Save/Import rows)
- "?" tutorial sheet; preamp/AutoEq layout reflow; version 1.8.2 (182); Settings About tab moved last

## Verification
- 189 JVM tests: parser dialects (incl. real SeapEngine/AutoEq exports), stereo preset round-trips + pre-v11 JSON compatibility, algorithm contracts, smoothing port pinned to hand-computed values, speed/precision bounds
- Adversarial multi-agent review of the stereo core found and fixed 3 real bugs before merge (dormant right-ear calibration overwritten by mono preset loads; runAutoEq reading the wrong ear; import leaving a stale active-preset id)