### PR TITLE
Add crossfeed toggle + config page; long-press effect rows to configure

### DIFF
--- a/app/src/main/java/tf/monochrome/android/audio/dsp/MixBusProcessor.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/dsp/MixBusProcessor.kt
@@ -8,6 +8,7 @@ import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect
 import tf.monochrome.android.audio.dsp.oxford.CompressorEffect
 import tf.monochrome.android.audio.dsp.oxford.InflatorEffect
 import java.nio.ByteBuffer
@@ -20,6 +21,7 @@ import javax.inject.Singleton
 class MixBusProcessor @Inject constructor(
     private val inflator: InflatorEffect,
     private val compressor: CompressorEffect,
+    private val crossfeed: CrossfeedEffect,
 ) : AudioProcessor {
 
     private var enginePtr: Long = 0L
@@ -299,6 +301,7 @@ class MixBusProcessor @Inject constructor(
                 nativeProcess(enginePtr, chunkScratchInL, chunkScratchInR, chunkScratchOutL, chunkScratchOutR, n)
                 inflator.processArrays(chunkScratchOutL, chunkScratchOutR, n)
                 compressor.processArrays(chunkScratchOutL, chunkScratchOutR, n)
+                crossfeed.processArrays(chunkScratchOutL, chunkScratchOutR, n)
                 System.arraycopy(chunkScratchOutL, 0, scratchOutL, processed, n)
                 System.arraycopy(chunkScratchOutR, 0, scratchOutR, processed, n)
             } else {
@@ -306,6 +309,7 @@ class MixBusProcessor @Inject constructor(
                 nativeProcess(enginePtr, scratchInL, scratchInR, scratchOutL, scratchOutR, n)
                 inflator.processArrays(scratchOutL, scratchOutR, n)
                 compressor.processArrays(scratchOutL, scratchOutR, n)
+                crossfeed.processArrays(scratchOutL, scratchOutR, n)
             }
             processed += n
         }
@@ -387,6 +391,7 @@ class MixBusProcessor @Inject constructor(
             // its own sample-rate prep call on every format change.
             inflator.prepare(inputFormat.sampleRate.toDouble(), 2)
             compressor.prepare(inputFormat.sampleRate.toDouble(), 2)
+            crossfeed.prepare(inputFormat.sampleRate.toDouble())
 
             // Signal ready (false→true transition ensures StateFlow emits)
             _engineReady.value = false

--- a/app/src/main/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffect.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffect.kt
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Headphone crossfeed — simulates a stereo speaker pair in front of the
+// listener by feeding each channel into the opposite ear, delayed (interaural
+// time difference) and low-pass filtered (head shadow).
+//
+// Integration points:
+//   - MixBusProcessor calls prepare() on format change and
+//     processArrays(L, R, frames) after the Oxford post-chain.
+//   - UI observes `state`; updates go through the public setters. Parameters
+//     are recomputed on set and read as @Volatile primitives on the audio
+//     thread, with per-sample smoothing so live slider moves never click.
+
+package tf.monochrome.android.audio.dsp.crossfeed
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.exp
+import kotlin.math.sin
+
+data class CrossfeedState(
+    val enabled: Boolean = false,
+    /**
+     * Total angle between the two virtual speakers as seen from the listener,
+     * in degrees. 30° = narrow frontal pair (strongest crossfeed), 180° =
+     * speakers at the ears, i.e. plain headphones (no crossfeed at all).
+     */
+    val speakerAngleDeg: Float = DEFAULT_ANGLE_DEG,
+) {
+    companion object {
+        const val MIN_ANGLE_DEG = 30f
+        const val MAX_ANGLE_DEG = 180f
+        const val DEFAULT_ANGLE_DEG = 60f
+    }
+}
+
+@Singleton
+class CrossfeedEffect @Inject constructor() {
+
+    private val _state = MutableStateFlow(CrossfeedState())
+    val state: StateFlow<CrossfeedState> = _state.asStateFlow()
+
+    // ---- Audio-thread parameters (recomputed on every state/format change) --
+
+    @Volatile private var targetCrossGain = 0f       // contralateral feed level
+    @Volatile private var targetDelaySamples = 0f    // ITD as fractional samples
+    @Volatile private var lowpassCoeff = 0f          // one-pole head-shadow LPF
+    @Volatile private var smoothCoeff = 0f           // per-sample param smoothing
+
+    private var sampleRate = 48000.0
+
+    // Smoothed working copies — audio thread only.
+    private var crossGain = 0f
+    private var delaySamples = 0f
+
+    // Ring buffers holding recent input for the delayed contralateral tap.
+    // Max ITD is (r/c)·(π/2 + 1) ≈ 0.66 ms → 127 samples at 192 kHz; 256 is
+    // comfortably above that for any sample rate we'll see.
+    private val ringL = FloatArray(RING_SIZE)
+    private val ringR = FloatArray(RING_SIZE)
+    private var ringPos = 0
+
+    // One-pole low-pass state for each cross path.
+    private var lpL = 0f
+    private var lpR = 0f
+
+    init { recompute() }
+
+    fun prepare(sampleRate: Double) {
+        this.sampleRate = sampleRate
+        recompute()
+        // Fresh format — stale ring/filter contents belong to the old stream.
+        java.util.Arrays.fill(ringL, 0f)
+        java.util.Arrays.fill(ringR, 0f)
+        lpL = 0f; lpR = 0f
+        crossGain = targetCrossGain
+        delaySamples = targetDelaySamples
+    }
+
+    fun update(transform: (CrossfeedState) -> CrossfeedState) {
+        _state.value = transform(_state.value)
+        recompute()
+    }
+
+    fun setEnabled(on: Boolean) = update { it.copy(enabled = on) }
+
+    fun setSpeakerAngleDeg(deg: Float) = update {
+        it.copy(speakerAngleDeg = deg.coerceIn(CrossfeedState.MIN_ANGLE_DEG, CrossfeedState.MAX_ANGLE_DEG))
+    }
+
+    fun processArrays(l: FloatArray, r: FloatArray, frames: Int) {
+        val gT = targetCrossGain
+        // Fast path: bypassed and fully faded out — skip the whole loop (same
+        // rationale as the Oxford effects' JNI skip). Reset the delay/filter
+        // state so re-enabling doesn't replay a stale tail.
+        if (gT <= 0f && crossGain < 1e-4f) {
+            if (crossGain != 0f) {
+                crossGain = 0f
+                java.util.Arrays.fill(ringL, 0f)
+                java.util.Arrays.fill(ringR, 0f)
+                lpL = 0f; lpR = 0f
+            }
+            return
+        }
+
+        val dT = targetDelaySamples
+        val lpC = lowpassCoeff
+        val smC = smoothCoeff
+        var g = crossGain
+        var d = delaySamples
+        var pos = ringPos
+        var fL = lpL
+        var fR = lpR
+
+        for (i in 0 until frames) {
+            // Glide gain and delay toward their targets (~5 ms time constant).
+            g += (gT - g) * smC
+            d += (dT - d) * smC
+
+            val inL = l[i]
+            val inR = r[i]
+            ringL[pos] = inL
+            ringR[pos] = inR
+
+            // Fractional delay tap with linear interpolation.
+            val di = d.toInt()
+            val frac = d - di
+            val i0 = (pos - di) and RING_MASK
+            val i1 = (i0 - 1) and RING_MASK
+            val tapL = ringL[i0] + (ringL[i1] - ringL[i0]) * frac
+            val tapR = ringR[i0] + (ringR[i1] - ringR[i0]) * frac
+
+            // Head-shadow low-pass on the cross path only.
+            fL += (tapL - fL) * lpC
+            fR += (tapR - fR) * lpC
+
+            // Feed each ear the opposite channel; renormalise so the summed
+            // level stays roughly constant as the angle (and thus g) moves.
+            val norm = 1f / (1f + g)
+            l[i] = (inL + fR * g) * norm
+            r[i] = (inR + fL * g) * norm
+
+            pos = (pos + 1) and RING_MASK
+        }
+
+        crossGain = g
+        delaySamples = d
+        ringPos = pos
+        lpL = fL
+        lpR = fR
+    }
+
+    /** Map the speaker angle onto gain/delay/filter coefficients. */
+    private fun recompute() {
+        val s = _state.value
+        val halfAngleRad = Math.toRadians(s.speakerAngleDeg / 2.0)
+
+        // Woodworth ITD for a source at the speaker's azimuth: r/c · (θ + sin θ).
+        val itdSec = HEAD_RADIUS_M / SPEED_OF_SOUND_MS * (halfAngleRad + sin(halfAngleRad))
+        targetDelaySamples = (itdSec * sampleRate).toFloat().coerceIn(0f, RING_SIZE - 2f)
+
+        // Contralateral level: cos(halfAngle) → full crossfeed as the pair
+        // narrows toward the front, zero when the speakers sit at the ears
+        // (180°), which is exactly "plain headphones". MAX_CROSS ≈ -4 dB at
+        // 30°, in bs2b/Meier territory.
+        targetCrossGain = if (!s.enabled) 0f
+            else MAX_CROSS_GAIN * cos(halfAngleRad).toFloat().coerceAtLeast(0f)
+
+        lowpassCoeff = onePoleCoeff(HEAD_SHADOW_CUTOFF_HZ)
+        smoothCoeff = onePoleCoeff(1.0 / (2.0 * PI * SMOOTH_TIME_SEC))
+    }
+
+    private fun onePoleCoeff(cutoffHz: Double): Float =
+        (1.0 - exp(-2.0 * PI * cutoffHz / sampleRate)).toFloat()
+
+    private companion object {
+        const val RING_SIZE = 256
+        const val RING_MASK = RING_SIZE - 1
+        const val HEAD_RADIUS_M = 0.0875
+        const val SPEED_OF_SOUND_MS = 343.0
+        const val HEAD_SHADOW_CUTOFF_HZ = 700.0
+        const val MAX_CROSS_GAIN = 0.65f
+        const val SMOOTH_TIME_SEC = 0.005
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffect.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffect.kt
@@ -20,14 +20,51 @@ import javax.inject.Singleton
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.exp
+import kotlin.math.pow
 import kotlin.math.sin
+
+/**
+ * Selectable crossfeed tunings. SPEAKER derives its feed level and delay from
+ * the user's speaker angle; the rest are fixed classic networks whose feed
+ * level / cutoff / delay triplets follow the published bs2b tunings.
+ */
+enum class CrossfeedAlgorithm(
+    val label: String,
+    val blurb: String,
+    val feedDb: Float,
+    val cutoffHz: Double,
+    val delayUs: Double,
+) {
+    SPEAKER(
+        "Speaker angle",
+        "Physical model. Set the virtual speaker angle with the slider below.",
+        feedDb = 0f, cutoffHz = 700.0, delayUs = 0.0, // derived from the angle
+    ),
+    BS2B(
+        "BS2B",
+        "Bauer stereophonic-to-binaural. 700 Hz cut, -4.5 dB feed, 260 µs delay.",
+        feedDb = -4.5f, cutoffHz = 700.0, delayUs = 260.0,
+    ),
+    CMOY(
+        "Chu Moy",
+        "Chu Moy crossfeeder. 700 Hz cut, -6 dB feed, 260 µs delay.",
+        feedDb = -6.0f, cutoffHz = 700.0, delayUs = 260.0,
+    ),
+    JMEIER(
+        "Jan Meier",
+        "Jan Meier CORDA network. 650 Hz cut, -9.5 dB feed, 280 µs delay.",
+        feedDb = -9.5f, cutoffHz = 650.0, delayUs = 280.0,
+    );
+}
 
 data class CrossfeedState(
     val enabled: Boolean = false,
+    val algorithm: CrossfeedAlgorithm = CrossfeedAlgorithm.SPEAKER,
     /**
      * Total angle between the two virtual speakers as seen from the listener,
      * in degrees. 30° = narrow frontal pair (strongest crossfeed), 180° =
      * speakers at the ears, i.e. plain headphones (no crossfeed at all).
+     * Only meaningful for [CrossfeedAlgorithm.SPEAKER].
      */
     val speakerAngleDeg: Float = DEFAULT_ANGLE_DEG,
 ) {
@@ -87,6 +124,8 @@ class CrossfeedEffect @Inject constructor() {
     }
 
     fun setEnabled(on: Boolean) = update { it.copy(enabled = on) }
+
+    fun setAlgorithm(algorithm: CrossfeedAlgorithm) = update { it.copy(algorithm = algorithm) }
 
     fun setSpeakerAngleDeg(deg: Float) = update {
         it.copy(speakerAngleDeg = deg.coerceIn(CrossfeedState.MIN_ANGLE_DEG, CrossfeedState.MAX_ANGLE_DEG))
@@ -154,23 +193,31 @@ class CrossfeedEffect @Inject constructor() {
         lpR = fR
     }
 
-    /** Map the speaker angle onto gain/delay/filter coefficients. */
+    /** Map the selected algorithm (and, for SPEAKER, the angle) onto coefficients. */
     private fun recompute() {
         val s = _state.value
-        val halfAngleRad = Math.toRadians(s.speakerAngleDeg / 2.0)
+        if (s.algorithm == CrossfeedAlgorithm.SPEAKER) {
+            val halfAngleRad = Math.toRadians(s.speakerAngleDeg / 2.0)
 
-        // Woodworth ITD for a source at the speaker's azimuth: r/c · (θ + sin θ).
-        val itdSec = HEAD_RADIUS_M / SPEED_OF_SOUND_MS * (halfAngleRad + sin(halfAngleRad))
-        targetDelaySamples = (itdSec * sampleRate).toFloat().coerceIn(0f, RING_SIZE - 2f)
+            // Woodworth ITD for a source at the speaker's azimuth: r/c · (θ + sin θ).
+            val itdSec = HEAD_RADIUS_M / SPEED_OF_SOUND_MS * (halfAngleRad + sin(halfAngleRad))
+            targetDelaySamples = (itdSec * sampleRate).toFloat().coerceIn(0f, RING_SIZE - 2f)
 
-        // Contralateral level: cos(halfAngle) → full crossfeed as the pair
-        // narrows toward the front, zero when the speakers sit at the ears
-        // (180°), which is exactly "plain headphones". MAX_CROSS ≈ -4 dB at
-        // 30°, in bs2b/Meier territory.
-        targetCrossGain = if (!s.enabled) 0f
-            else MAX_CROSS_GAIN * cos(halfAngleRad).toFloat().coerceAtLeast(0f)
+            // Contralateral level: cos(halfAngle) → full crossfeed as the pair
+            // narrows toward the front, zero when the speakers sit at the ears
+            // (180°), which is exactly "plain headphones". MAX_CROSS ≈ -4 dB at
+            // 30°, in bs2b/Meier territory.
+            targetCrossGain = if (!s.enabled) 0f
+                else MAX_CROSS_GAIN * cos(halfAngleRad).toFloat().coerceAtLeast(0f)
 
-        lowpassCoeff = onePoleCoeff(HEAD_SHADOW_CUTOFF_HZ)
+            lowpassCoeff = onePoleCoeff(HEAD_SHADOW_CUTOFF_HZ)
+        } else {
+            targetDelaySamples = (s.algorithm.delayUs * 1e-6 * sampleRate)
+                .toFloat().coerceIn(0f, RING_SIZE - 2f)
+            targetCrossGain = if (!s.enabled) 0f
+                else 10f.pow(s.algorithm.feedDb / 20f)
+            lowpassCoeff = onePoleCoeff(s.algorithm.cutoffHz)
+        }
         smoothCoeff = onePoleCoeff(1.0 / (2.0 * PI * SMOOTH_TIME_SEC))
     }
 

--- a/app/src/main/java/tf/monochrome/android/di/DspModule.kt
+++ b/app/src/main/java/tf/monochrome/android/di/DspModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import tf.monochrome.android.audio.dsp.DspEngineManager
 import tf.monochrome.android.audio.dsp.MixBusProcessor
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect
 import tf.monochrome.android.audio.dsp.oxford.CompressorEffect
 import tf.monochrome.android.audio.dsp.oxford.InflatorEffect
 import tf.monochrome.android.data.preferences.PreferencesManager
@@ -20,7 +21,8 @@ object DspModule {
     fun provideMixBusProcessor(
         inflator: InflatorEffect,
         compressor: CompressorEffect,
-    ): MixBusProcessor = MixBusProcessor(inflator, compressor)
+        crossfeed: CrossfeedEffect,
+    ): MixBusProcessor = MixBusProcessor(inflator, compressor, crossfeed)
 
     @Provides
     @Singleton

--- a/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedScreen.kt
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Crossfeed configuration page — enable switch, speaker-angle slider, and a
+// live top-down visual of the virtual speaker pair around the listener.
+
+package tf.monochrome.android.ui.crossfeed
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedState
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+@Composable
+fun CrossfeedScreen(
+    effect: CrossfeedEffect,
+    modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
+) {
+    val state by effect.state.collectAsState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        if (onBack != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+                Text(
+                    text = "Crossfeed",
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+        ) {
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(20.dp),
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                ),
+                elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Speaker simulation",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                text = "Blends a touch of each channel into the " +
+                                    "opposite ear — delayed and darkened the way a " +
+                                    "real room would — so headphones image like a " +
+                                    "speaker pair in front of you.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        Switch(
+                            checked = state.enabled,
+                            onCheckedChange = effect::setEnabled,
+                        )
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
+                    SpeakerStage(
+                        angleDeg = state.speakerAngleDeg,
+                        enabled = state.enabled,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1.45f)
+                            .alpha(if (state.enabled) 1f else 0.45f),
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Speaker angle",
+                            style = MaterialTheme.typography.labelLarge,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            text = "${state.speakerAngleDeg.roundToInt()}°",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    Slider(
+                        value = state.speakerAngleDeg,
+                        onValueChange = effect::setSpeakerAngleDeg,
+                        valueRange = CrossfeedState.MIN_ANGLE_DEG..CrossfeedState.MAX_ANGLE_DEG,
+                        enabled = state.enabled,
+                    )
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = "30° · narrow",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            text = "180° · headphones",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = "Narrow angles pull the stereo image together in " +
+                            "front of you (strongest crossfeed). At 180° the " +
+                            "speakers sit at your ears — plain headphones, no " +
+                            "crossfeed at all.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Top-down view of the listening setup: the listener's head at the sweet spot
+ * with the two virtual speakers on an arc, ±angle/2 either side of straight
+ * ahead. Redraws live as the slider moves.
+ */
+@Composable
+private fun SpeakerStage(
+    angleDeg: Float,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val accent = MaterialTheme.colorScheme.primary
+    val outline = MaterialTheme.colorScheme.onSurfaceVariant
+    val speakerBody = MaterialTheme.colorScheme.onSurface
+    val surface = MaterialTheme.colorScheme.surfaceContainerHighest
+
+    Canvas(modifier = modifier) {
+        val cx = size.width / 2f
+        val cy = size.height * 0.62f
+        val radius = minOf(size.width * 0.36f, size.height * 0.52f)
+        val half = Math.toRadians(angleDeg / 2.0)
+
+        // Guide arc the speakers travel on (front semicircle, dashed).
+        drawArc(
+            color = outline.copy(alpha = 0.30f),
+            startAngle = 180f,
+            sweepAngle = 180f,
+            useCenter = false,
+            topLeft = Offset(cx - radius, cy - radius),
+            size = Size(radius * 2f, radius * 2f),
+            style = Stroke(
+                width = 1.dp.toPx(),
+                pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 8f)),
+            ),
+        )
+
+        // Speaker azimuths measured from straight ahead (up on the canvas).
+        val azimuths = floatArrayOf(-half.toFloat(), half.toFloat())
+        val positions = azimuths.map { az ->
+            Offset(cx + radius * sin(az), cy - radius * cos(az))
+        }
+
+        // Sound paths from each speaker to the sweet spot.
+        for (p in positions) {
+            drawLine(
+                color = accent.copy(alpha = if (enabled) 0.45f else 0.25f),
+                start = p,
+                end = Offset(cx, cy),
+                strokeWidth = 1.5.dp.toPx(),
+                pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 6f)),
+            )
+        }
+
+        // Angle wedge at the head with the current spread.
+        val wedgeR = radius * 0.38f
+        drawArc(
+            color = accent.copy(alpha = 0.9f),
+            startAngle = -90f - angleDeg / 2f,
+            sweepAngle = angleDeg,
+            useCenter = false,
+            topLeft = Offset(cx - wedgeR, cy - wedgeR),
+            size = Size(wedgeR * 2f, wedgeR * 2f),
+            style = Stroke(width = 2.dp.toPx()),
+        )
+
+        // Listener head: circle + ears + nose, facing up.
+        val headR = radius * 0.16f
+        drawCircle(color = surface, radius = headR, center = Offset(cx, cy))
+        drawCircle(
+            color = outline,
+            radius = headR,
+            center = Offset(cx, cy),
+            style = Stroke(width = 1.5.dp.toPx()),
+        )
+        // Ears
+        for (side in intArrayOf(-1, 1)) {
+            drawCircle(
+                color = outline,
+                radius = headR * 0.28f,
+                center = Offset(cx + side * headR, cy),
+                style = Stroke(width = 1.5.dp.toPx()),
+            )
+        }
+        // Nose — small triangle on the front of the head.
+        val nose = Path().apply {
+            moveTo(cx - headR * 0.28f, cy - headR * 0.92f)
+            lineTo(cx + headR * 0.28f, cy - headR * 0.92f)
+            lineTo(cx, cy - headR * 1.38f)
+            close()
+        }
+        drawPath(nose, color = outline)
+
+        // Speakers — rounded cabinet + driver, each rotated to face the head.
+        positions.forEachIndexed { i, p ->
+            drawSpeaker(
+                at = p,
+                facingDeg = Math.toDegrees(azimuths[i].toDouble()).toFloat(),
+                scale = radius,
+                body = speakerBody,
+                cone = if (enabled) accent else outline,
+            )
+        }
+    }
+}
+
+/**
+ * One speaker cabinet at [at]. [facingDeg] is the speaker's azimuth from the
+ * listener's front axis; the cabinet is drawn pointing down (toward the
+ * listener when at 0°) and rotated by the azimuth so it always aims at the
+ * sweet spot.
+ */
+private fun DrawScope.drawSpeaker(
+    at: Offset,
+    facingDeg: Float,
+    scale: Float,
+    body: Color,
+    cone: Color,
+) {
+    val w = scale * 0.22f
+    val h = scale * 0.30f
+    withTransform({
+        rotate(degrees = facingDeg, pivot = at)
+    }) {
+        drawRoundRect(
+            color = body,
+            topLeft = Offset(at.x - w / 2f, at.y - h),
+            size = Size(w, h),
+            cornerRadius = CornerRadius(w * 0.2f, w * 0.2f),
+        )
+        // Driver cone near the front (listener-facing) edge.
+        drawCircle(
+            color = cone,
+            radius = w * 0.26f,
+            center = Offset(at.x, at.y - h * 0.30f),
+        )
+        drawCircle(
+            color = body.copy(alpha = 0.35f),
+            radius = w * 0.12f,
+            center = Offset(at.x, at.y - h * 0.75f),
+        )
+    }
+}

--- a/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -45,6 +47,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedAlgorithm
 import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect
 import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedState
 import kotlin.math.cos
@@ -106,10 +109,10 @@ fun CrossfeedScreen(
                                 fontWeight = FontWeight.SemiBold,
                             )
                             Text(
-                                text = "Blends a touch of each channel into the " +
-                                    "opposite ear — delayed and darkened the way a " +
-                                    "real room would — so headphones image like a " +
-                                    "speaker pair in front of you.",
+                                text = "Feeds a small amount of each channel into " +
+                                    "the opposite ear, slightly delayed and " +
+                                    "low-pass filtered, so headphones sound more " +
+                                    "like a pair of speakers.",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -123,62 +126,98 @@ fun CrossfeedScreen(
 
                     Spacer(Modifier.height(16.dp))
 
-                    SpeakerStage(
-                        angleDeg = state.speakerAngleDeg,
-                        enabled = state.enabled,
+                    // Algorithm picker — the physical speaker model plus the
+                    // classic fixed networks (BS2B / Chu Moy / Jan Meier).
+                    Text(
+                        text = "Algorithm",
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .aspectRatio(1.45f)
-                            .alpha(if (state.enabled) 1f else 0.45f),
-                    )
-
-                    Spacer(Modifier.height(8.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
-                        Text(
-                            text = "Speaker angle",
-                            style = MaterialTheme.typography.labelLarge,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            text = "${state.speakerAngleDeg.roundToInt()}°",
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
+                        CrossfeedAlgorithm.entries.forEach { algo ->
+                            FilterChip(
+                                selected = state.algorithm == algo,
+                                onClick = { effect.setAlgorithm(algo) },
+                                label = {
+                                    Text(
+                                        text = algo.label,
+                                        style = MaterialTheme.typography.labelSmall,
+                                    )
+                                },
+                            )
+                        }
                     }
-                    Slider(
-                        value = state.speakerAngleDeg,
-                        onValueChange = effect::setSpeakerAngleDeg,
-                        valueRange = CrossfeedState.MIN_ANGLE_DEG..CrossfeedState.MAX_ANGLE_DEG,
-                        enabled = state.enabled,
-                    )
-                    Row(modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            text = "30° · narrow",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            text = "180° · headphones",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-
-                    Spacer(Modifier.height(8.dp))
+                    Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "Narrow angles pull the stereo image together in " +
-                            "front of you (strongest crossfeed). At 180° the " +
-                            "speakers sit at your ears — plain headphones, no " +
-                            "crossfeed at all.",
+                        text = state.algorithm.blurb,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+
+                    if (state.algorithm == CrossfeedAlgorithm.SPEAKER) {
+                        Spacer(Modifier.height(16.dp))
+
+                        SpeakerStage(
+                            angleDeg = state.speakerAngleDeg,
+                            enabled = state.enabled,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1.45f)
+                                .alpha(if (state.enabled) 1f else 0.45f),
+                        )
+
+                        Spacer(Modifier.height(8.dp))
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Speaker angle",
+                                style = MaterialTheme.typography.labelLarge,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                text = "${state.speakerAngleDeg.roundToInt()}°",
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        Slider(
+                            value = state.speakerAngleDeg,
+                            onValueChange = effect::setSpeakerAngleDeg,
+                            valueRange = CrossfeedState.MIN_ANGLE_DEG..CrossfeedState.MAX_ANGLE_DEG,
+                            enabled = state.enabled,
+                        )
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = "30° narrow",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                text = "180° headphones",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "Narrow angles give the strongest crossfeed. " +
+                                "At 180° the speakers sit at your ears and no " +
+                                "crossfeed is applied.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/crossfeed/CrossfeedViewModel.kt
@@ -1,0 +1,11 @@
+package tf.monochrome.android.ui.crossfeed
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect
+import javax.inject.Inject
+
+@HiltViewModel
+class CrossfeedViewModel @Inject constructor(
+    val crossfeed: CrossfeedEffect,
+) : ViewModel()

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -92,6 +92,8 @@ import tf.monochrome.android.ui.search.SearchScreen
 import tf.monochrome.android.ui.settings.SettingsScreen
 import tf.monochrome.android.ui.carmode.CarModeScreen
 import tf.monochrome.android.ui.debug.DebugLogScreen
+import tf.monochrome.android.ui.crossfeed.CrossfeedScreen
+import tf.monochrome.android.ui.crossfeed.CrossfeedViewModel
 import tf.monochrome.android.ui.oxford.OxfordEffectsTabs
 import tf.monochrome.android.ui.oxford.OxfordViewModel
 
@@ -141,6 +143,7 @@ sealed class Screen(val route: String) {
         /** tab: 0 = Compressor, 1 = Inflator. */
         fun createRoute(tab: Int = 0) = "oxford?tab=$tab"
     }
+    data object Crossfeed : Screen("crossfeed")
     data object DebugLog : Screen("debug_log")
     data object LyricsFxStudio : Screen("lyrics_fx_studio")
     data object AtmosRenderer : Screen("atmos_renderer")
@@ -417,6 +420,16 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                             inflator = vm.inflator,
                             compressor = vm.compressor,
                             initialTab = tab,
+                            onBack = { navController.popBackStack() },
+                            modifier = Modifier.fillMaxSize().padding(top = statusBarHeight),
+                        )
+                    }
+                }
+                composable(Screen.Crossfeed.route) {
+                    val vm: CrossfeedViewModel = hiltViewModel()
+                    tf.monochrome.android.devedit.DevEditScreen("crossfeed") {
+                        CrossfeedScreen(
+                            effect = vm.crossfeed,
                             onBack = { navController.popBackStack() },
                             modifier = Modifier.fillMaxSize().padding(top = statusBarHeight),
                         )

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -107,6 +107,7 @@ fun MainPlayerRoute(
     val preservePitch by playerViewModel.preservePitch.collectAsState()
     val compressorEnabled by playerViewModel.compressorEnabled.collectAsState()
     val inflatorEnabled by playerViewModel.inflatorEnabled.collectAsState()
+    val crossfeedEnabled by playerViewModel.crossfeedEnabled.collectAsState()
     val systemWideAutoEqEnabled by playerViewModel.systemWideAutoEqEnabled.collectAsState()
     val toneControls by playerViewModel.toneControls.collectAsState()
 
@@ -288,6 +289,7 @@ fun MainPlayerRoute(
         waveformActive = showNpSpectrum,
         compressorEnabled = compressorEnabled,
         inflatorEnabled = inflatorEnabled,
+        crossfeedEnabled = crossfeedEnabled,
         systemWideAutoEqEnabled = systemWideAutoEqEnabled,
         toneControls = toneControls,
     )
@@ -382,6 +384,10 @@ fun MainPlayerRoute(
             onWaveform = { playerViewModel.setSpectrumShowOnNowPlaying(!spectrumShowOnNowPlaying) },
             onCompressorToggle = playerViewModel::setCompressorEnabled,
             onInflatorToggle = playerViewModel::setInflatorEnabled,
+            onCrossfeedToggle = playerViewModel::setCrossfeedEnabled,
+            onCompressorOpen = { navController.navigate(Screen.Oxford.createRoute(tab = 0)) },
+            onInflatorOpen = { navController.navigate(Screen.Oxford.createRoute(tab = 1)) },
+            onCrossfeedOpen = { navController.navigate(Screen.Crossfeed.route) },
             onSystemWideAutoEqToggle = playerViewModel::setSystemWideAutoEq,
             onToneControlsChange = playerViewModel::setToneControls,
             topBar = {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -108,6 +108,7 @@ fun MainPlayerRoute(
     val compressorEnabled by playerViewModel.compressorEnabled.collectAsState()
     val inflatorEnabled by playerViewModel.inflatorEnabled.collectAsState()
     val crossfeedEnabled by playerViewModel.crossfeedEnabled.collectAsState()
+    val autoEqEnabled by playerViewModel.autoEqEnabled.collectAsState()
     val systemWideAutoEqEnabled by playerViewModel.systemWideAutoEqEnabled.collectAsState()
     val toneControls by playerViewModel.toneControls.collectAsState()
 
@@ -290,6 +291,7 @@ fun MainPlayerRoute(
         compressorEnabled = compressorEnabled,
         inflatorEnabled = inflatorEnabled,
         crossfeedEnabled = crossfeedEnabled,
+        autoEqEnabled = autoEqEnabled,
         systemWideAutoEqEnabled = systemWideAutoEqEnabled,
         toneControls = toneControls,
     )
@@ -388,6 +390,7 @@ fun MainPlayerRoute(
             onCompressorOpen = { navController.navigate(Screen.Oxford.createRoute(tab = 0)) },
             onInflatorOpen = { navController.navigate(Screen.Oxford.createRoute(tab = 1)) },
             onCrossfeedOpen = { navController.navigate(Screen.Crossfeed.route) },
+            onAutoEqToggle = playerViewModel::setAutoEqEnabled,
             onSystemWideAutoEqToggle = playerViewModel::setSystemWideAutoEq,
             onToneControlsChange = playerViewModel::setToneControls,
             topBar = {

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -121,6 +121,7 @@ data class MainPlayerUiState(
     val compressorEnabled: Boolean,
     val inflatorEnabled: Boolean,
     val crossfeedEnabled: Boolean = false,
+    val autoEqEnabled: Boolean = false,
     val systemWideAutoEqEnabled: Boolean = false,
     val toneControls: tf.monochrome.android.domain.model.ToneControls =
         tf.monochrome.android.domain.model.ToneControls.DEFAULT,
@@ -164,6 +165,7 @@ fun MainPlayerScreen(
     onCompressorOpen: () -> Unit,
     onInflatorOpen: () -> Unit,
     onCrossfeedOpen: () -> Unit,
+    onAutoEqToggle: (Boolean) -> Unit,
     onSystemWideAutoEqToggle: (Boolean) -> Unit,
     onToneControlsChange: (tf.monochrome.android.domain.model.ToneControls) -> Unit,
     topBar: @Composable () -> Unit,
@@ -529,6 +531,7 @@ fun MainPlayerScreen(
                 compressorEnabled = state.compressorEnabled,
                 inflatorEnabled = state.inflatorEnabled,
                 crossfeedEnabled = state.crossfeedEnabled,
+                autoEqEnabled = state.autoEqEnabled,
                 systemWideAutoEqEnabled = state.systemWideAutoEqEnabled,
                 toneControls = state.toneControls,
                 onOutput = onOutput,
@@ -543,6 +546,7 @@ fun MainPlayerScreen(
                 onCompressorOpen = onCompressorOpen,
                 onInflatorOpen = onInflatorOpen,
                 onCrossfeedOpen = onCrossfeedOpen,
+                onAutoEqToggle = onAutoEqToggle,
                 onSystemWideAutoEqToggle = onSystemWideAutoEqToggle,
                 onToneControlsChange = onToneControlsChange,
                 onDismiss = { animateRevealTo(0f, 0f) },
@@ -599,6 +603,7 @@ private fun StatusOverlayPanel(
     compressorEnabled: Boolean,
     inflatorEnabled: Boolean,
     crossfeedEnabled: Boolean,
+    autoEqEnabled: Boolean,
     systemWideAutoEqEnabled: Boolean,
     toneControls: tf.monochrome.android.domain.model.ToneControls,
     onOutput: () -> Unit,
@@ -613,6 +618,7 @@ private fun StatusOverlayPanel(
     onCompressorOpen: () -> Unit,
     onInflatorOpen: () -> Unit,
     onCrossfeedOpen: () -> Unit,
+    onAutoEqToggle: (Boolean) -> Unit,
     onSystemWideAutoEqToggle: (Boolean) -> Unit,
     onToneControlsChange: (tf.monochrome.android.domain.model.ToneControls) -> Unit,
     onDismiss: () -> Unit,
@@ -699,15 +705,34 @@ private fun StatusOverlayPanel(
                         .background(Color.White.copy(alpha = 0.35f), RoundedCornerShape(999.dp)),
                 )
             }
-            // Top of the audio options: apply the AutoEQ headphone correction to
-            // ALL device audio (Wavelet-style global effect), not just this app.
-            ToggleRow(
-                "System-wide AutoEQ",
-                "Apply your headphone EQ to all device audio",
-                systemWideAutoEqEnabled,
-                accent,
-                onSystemWideAutoEqToggle,
-            )
+            // Top of the audio options: the AutoEQ headphone correction. The
+            // Wavelet-style system-wide variant is a sub-toggle that only
+            // appears while AutoEQ itself is on (and turning AutoEQ off also
+            // clears it, so the global effect never runs hidden).
+            Column(modifier = Modifier.fillMaxWidth()) {
+                ToggleRow(
+                    "AutoEQ",
+                    "Headphone EQ correction",
+                    autoEqEnabled,
+                    accent,
+                    onAutoEqToggle,
+                )
+                AnimatedVisibility(visible = autoEqEnabled) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp, top = 12.dp),
+                    ) {
+                        ToggleRow(
+                            "System-wide",
+                            "Apply to all device audio",
+                            systemWideAutoEqEnabled,
+                            accent,
+                            onSystemWideAutoEqToggle,
+                        )
+                    }
+                }
+            }
             // Bass/treble tone shelves (independent of the system-wide toggle —
             // applied in-app, or via the global effect when system-wide is on).
             ToneControlsPanel(

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -762,11 +762,11 @@ private fun StatusOverlayPanel(
             }
 
             // Effects toggles — long-press a row to open that tool's page.
-            ToggleRow("Compressor", "Oxford dynamics · hold to configure", compressorEnabled, accent,
+            ToggleRow("Compressor", "Oxford dynamics. Hold to configure", compressorEnabled, accent,
                 onCompressorToggle, onLongPress = onCompressorOpen)
-            ToggleRow("Inflator", "Oxford loudness · hold to configure", inflatorEnabled, accent,
+            ToggleRow("Inflator", "Oxford loudness. Hold to configure", inflatorEnabled, accent,
                 onInflatorToggle, onLongPress = onInflatorOpen)
-            ToggleRow("Crossfeed", "Speaker simulation · hold to configure", crossfeedEnabled, accent,
+            ToggleRow("Crossfeed", "Speaker simulation. Hold to configure", crossfeedEnabled, accent,
                 onCrossfeedToggle, onLongPress = onCrossfeedOpen)
         }
             }

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -118,6 +120,7 @@ data class MainPlayerUiState(
     val waveformActive: Boolean,
     val compressorEnabled: Boolean,
     val inflatorEnabled: Boolean,
+    val crossfeedEnabled: Boolean = false,
     val systemWideAutoEqEnabled: Boolean = false,
     val toneControls: tf.monochrome.android.domain.model.ToneControls =
         tf.monochrome.android.domain.model.ToneControls.DEFAULT,
@@ -156,6 +159,11 @@ fun MainPlayerScreen(
     onWaveform: () -> Unit,
     onCompressorToggle: (Boolean) -> Unit,
     onInflatorToggle: (Boolean) -> Unit,
+    onCrossfeedToggle: (Boolean) -> Unit,
+    // Long-pressing an effect row opens that tool's configuration page.
+    onCompressorOpen: () -> Unit,
+    onInflatorOpen: () -> Unit,
+    onCrossfeedOpen: () -> Unit,
     onSystemWideAutoEqToggle: (Boolean) -> Unit,
     onToneControlsChange: (tf.monochrome.android.domain.model.ToneControls) -> Unit,
     topBar: @Composable () -> Unit,
@@ -520,6 +528,7 @@ fun MainPlayerScreen(
                 waveformActive = state.waveformActive,
                 compressorEnabled = state.compressorEnabled,
                 inflatorEnabled = state.inflatorEnabled,
+                crossfeedEnabled = state.crossfeedEnabled,
                 systemWideAutoEqEnabled = state.systemWideAutoEqEnabled,
                 toneControls = state.toneControls,
                 onOutput = onOutput,
@@ -530,6 +539,10 @@ fun MainPlayerScreen(
                 onWaveform = onWaveform,
                 onCompressorToggle = onCompressorToggle,
                 onInflatorToggle = onInflatorToggle,
+                onCrossfeedToggle = onCrossfeedToggle,
+                onCompressorOpen = onCompressorOpen,
+                onInflatorOpen = onInflatorOpen,
+                onCrossfeedOpen = onCrossfeedOpen,
                 onSystemWideAutoEqToggle = onSystemWideAutoEqToggle,
                 onToneControlsChange = onToneControlsChange,
                 onDismiss = { animateRevealTo(0f, 0f) },
@@ -585,6 +598,7 @@ private fun StatusOverlayPanel(
     waveformActive: Boolean,
     compressorEnabled: Boolean,
     inflatorEnabled: Boolean,
+    crossfeedEnabled: Boolean,
     systemWideAutoEqEnabled: Boolean,
     toneControls: tf.monochrome.android.domain.model.ToneControls,
     onOutput: () -> Unit,
@@ -595,6 +609,10 @@ private fun StatusOverlayPanel(
     onWaveform: () -> Unit,
     onCompressorToggle: (Boolean) -> Unit,
     onInflatorToggle: (Boolean) -> Unit,
+    onCrossfeedToggle: (Boolean) -> Unit,
+    onCompressorOpen: () -> Unit,
+    onInflatorOpen: () -> Unit,
+    onCrossfeedOpen: () -> Unit,
     onSystemWideAutoEqToggle: (Boolean) -> Unit,
     onToneControlsChange: (tf.monochrome.android.domain.model.ToneControls) -> Unit,
     onDismiss: () -> Unit,
@@ -718,9 +736,13 @@ private fun StatusOverlayPanel(
                 OverlayAction(Icons.Default.GraphicEq, "Waveform", accent, waveformActive, onWaveform)
             }
 
-            // Effects toggles
-            ToggleRow("Compressor", "Oxford dynamics", compressorEnabled, accent, onCompressorToggle)
-            ToggleRow("Inflator", "Oxford loudness", inflatorEnabled, accent, onInflatorToggle)
+            // Effects toggles — long-press a row to open that tool's page.
+            ToggleRow("Compressor", "Oxford dynamics · hold to configure", compressorEnabled, accent,
+                onCompressorToggle, onLongPress = onCompressorOpen)
+            ToggleRow("Inflator", "Oxford loudness · hold to configure", inflatorEnabled, accent,
+                onInflatorToggle, onLongPress = onInflatorOpen)
+            ToggleRow("Crossfeed", "Speaker simulation · hold to configure", crossfeedEnabled, accent,
+                onCrossfeedToggle, onLongPress = onCrossfeedOpen)
         }
             }
     }
@@ -766,15 +788,28 @@ private fun RowScope.OverlayAction(
 }
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 private fun ToggleRow(
     label: String,
     subtitle: String,
     checked: Boolean,
     accent: Color,
     onCheckedChange: (Boolean) -> Unit,
+    onLongPress: (() -> Unit)? = null,
 ) {
+    val rowModifier = if (onLongPress != null) {
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .combinedClickable(
+                onClick = { onCheckedChange(!checked) },
+                onLongClick = onLongPress,
+            )
+    } else {
+        Modifier.fillMaxWidth()
+    }
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = rowModifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -67,6 +67,7 @@ class PlayerViewModel @Inject constructor(
     private val bypassVolumeController: tf.monochrome.android.audio.usb.BypassVolumeController,
     private val inflatorEffect: tf.monochrome.android.audio.dsp.oxford.InflatorEffect,
     private val compressorEffect: tf.monochrome.android.audio.dsp.oxford.CompressorEffect,
+    private val crossfeedEffect: tf.monochrome.android.audio.dsp.crossfeed.CrossfeedEffect,
     private val nowPlayingLyrics: tf.monochrome.android.player.NowPlayingLyricsHolder,
 ) : ViewModel() {
 
@@ -252,6 +253,13 @@ class PlayerViewModel @Inject constructor(
     fun setCompressorEnabled(on: Boolean) = compressorEffect.setBypass(!on)
 
     fun setInflatorEnabled(on: Boolean) = inflatorEffect.setEffectIn(on)
+
+    // --- Crossfeed (headphone speaker simulation) ---
+    val crossfeedEnabled: StateFlow<Boolean> = crossfeedEffect.state
+        .map { it.enabled }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setCrossfeedEnabled(on: Boolean) = crossfeedEffect.setEnabled(on)
 
     // --- System-wide AutoEQ (global output-mix effect) ---
     // The SystemAudioEqController (app singleton) observes this preference and

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerViewModel.kt
@@ -261,6 +261,20 @@ class PlayerViewModel @Inject constructor(
 
     fun setCrossfeedEnabled(on: Boolean) = crossfeedEffect.setEnabled(on)
 
+    // --- AutoEQ (headphone correction) ---
+    // The in-app correction flag; the same one the Equalizer screen toggles.
+    val autoEqEnabled: StateFlow<Boolean> = preferences.eqEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setAutoEqEnabled(on: Boolean) {
+        viewModelScope.launch {
+            preferences.setEqEnabled(on)
+            // The system-wide sub-toggle only shows while AutoEQ is on; clear it
+            // on the way out so the global effect can't keep running invisibly.
+            if (!on) preferences.setSystemWideAutoEqEnabled(false)
+        }
+    }
+
     // --- System-wide AutoEQ (global output-mix effect) ---
     // The SystemAudioEqController (app singleton) observes this preference and
     // attaches/detaches the global effect; the ViewModel only flips the flag.

--- a/app/src/test/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffectTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffectTest.kt
@@ -1,0 +1,87 @@
+package tf.monochrome.android.audio.dsp.crossfeed
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * Pure-JVM tests for the headphone crossfeed stage. The effect is plain
+ * Kotlin (no JNI), so these lock its bypass transparency, the angle → mix
+ * mapping, and the contralateral feed behaviour.
+ */
+class CrossfeedEffectTest {
+
+    private fun impulseLeft(n: Int) = FloatArray(n) { if (it == 0) 1f else 0f }
+
+    private fun freshEffect(): CrossfeedEffect =
+        CrossfeedEffect().also { it.prepare(48000.0) }
+
+    @Test
+    fun `disabled is bit-transparent`() {
+        val fx = freshEffect()
+        val l = FloatArray(512) { kotlin.math.sin(it * 0.1f) }
+        val r = FloatArray(512) { kotlin.math.cos(it * 0.07f) }
+        val refL = l.copyOf()
+        val refR = r.copyOf()
+        fx.processArrays(l, r, 512)
+        assertTrue(l.contentEquals(refL))
+        assertTrue(r.contentEquals(refR))
+    }
+
+    @Test
+    fun `180 degrees is (near) transparent even when enabled`() {
+        val fx = freshEffect()
+        fx.setEnabled(true)
+        fx.setSpeakerAngleDeg(180f)
+        val l = impulseLeft(2048)
+        val r = FloatArray(2048)
+        fx.processArrays(l, r, 2048)
+        // cos(90°) → crossfeed gain ~0: right stays silent, left stays ~unity.
+        assertEquals(1f, l[0], 1e-3f)
+        assertTrue(r.all { abs(it) < 1e-3f })
+    }
+
+    @Test
+    fun `narrow angle feeds left signal into right ear, delayed`() {
+        val fx = freshEffect()
+        fx.setEnabled(true)
+        fx.setSpeakerAngleDeg(30f)
+        // Long enough for the 5 ms parameter glide to land at full strength.
+        val frames = 4096
+        val l = FloatArray(frames) { kotlin.math.sin(it * 0.05f) }
+        val r = FloatArray(frames)
+        fx.processArrays(l, r, frames)
+        val tailEnergy = (frames / 2 until frames).sumOf { abs(r[it]).toDouble() }
+        assertTrue("contralateral feed should be audible", tailEnergy > 1.0)
+        // Direct channel is renormalised, never boosted above unity.
+        assertTrue(l.all { abs(it) <= 1f + 1e-4f })
+    }
+
+    @Test
+    fun `angle is clamped to the supported range`() {
+        val fx = freshEffect()
+        fx.setSpeakerAngleDeg(500f)
+        assertEquals(CrossfeedState.MAX_ANGLE_DEG, fx.state.value.speakerAngleDeg, 0f)
+        fx.setSpeakerAngleDeg(1f)
+        assertEquals(CrossfeedState.MIN_ANGLE_DEG, fx.state.value.speakerAngleDeg, 0f)
+    }
+
+    @Test
+    fun `re-enabling after fade-out does not replay a stale tail`() {
+        val fx = freshEffect()
+        fx.setEnabled(true)
+        fx.setSpeakerAngleDeg(30f)
+        val frames = 4096
+        fx.processArrays(FloatArray(frames) { 0.5f }, FloatArray(frames) { 0.5f }, frames)
+        fx.setEnabled(false)
+        // Silence long enough for the gain glide to hit the fast-path reset.
+        repeat(8) { fx.processArrays(FloatArray(frames), FloatArray(frames), frames) }
+        fx.setEnabled(true)
+        val l = FloatArray(64)
+        val r = FloatArray(64)
+        fx.processArrays(l, r, 64)
+        assertTrue(l.all { abs(it) < 1e-4f })
+        assertTrue(r.all { abs(it) < 1e-4f })
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffectTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/dsp/crossfeed/CrossfeedEffectTest.kt
@@ -59,6 +59,48 @@ class CrossfeedEffectTest {
     }
 
     @Test
+    fun `speaker model is the default algorithm`() {
+        assertEquals(CrossfeedAlgorithm.SPEAKER, freshEffect().state.value.algorithm)
+    }
+
+    @Test
+    fun `fixed algorithms feed the opposite ear at their published levels`() {
+        // Same signal through each network; a hotter feed level must leave more
+        // contralateral energy: BS2B (−4.5 dB) > Chu Moy (−6) > Meier (−9.5).
+        fun tailEnergyFor(algo: CrossfeedAlgorithm): Double {
+            val fx = freshEffect()
+            fx.setEnabled(true)
+            fx.setAlgorithm(algo)
+            val frames = 4096
+            val l = FloatArray(frames) { kotlin.math.sin(it * 0.05f) }
+            val r = FloatArray(frames)
+            fx.processArrays(l, r, frames)
+            return (frames / 2 until frames).sumOf { abs(r[it]).toDouble() }
+        }
+        val bs2b = tailEnergyFor(CrossfeedAlgorithm.BS2B)
+        val cmoy = tailEnergyFor(CrossfeedAlgorithm.CMOY)
+        val meier = tailEnergyFor(CrossfeedAlgorithm.JMEIER)
+        assertTrue("all algorithms should crossfeed", meier > 1.0)
+        assertTrue("BS2B should feed harder than Chu Moy", bs2b > cmoy)
+        assertTrue("Chu Moy should feed harder than Meier", cmoy > meier)
+    }
+
+    @Test
+    fun `switching algorithm mid-stream stays bounded`() {
+        val fx = freshEffect()
+        fx.setEnabled(true)
+        val frames = 1024
+        for (algo in CrossfeedAlgorithm.entries) {
+            fx.setAlgorithm(algo)
+            val l = FloatArray(frames) { kotlin.math.sin(it * 0.05f) }
+            val r = FloatArray(frames) { kotlin.math.cos(it * 0.03f) }
+            fx.processArrays(l, r, frames)
+            assertTrue(l.all { it.isFinite() && abs(it) <= 1.5f })
+            assertTrue(r.all { it.isFinite() && abs(it) <= 1.5f })
+        }
+    }
+
+    @Test
     fun `angle is clamped to the supported range`() {
         val fx = freshEffect()
         fx.setSpeakerAngleDeg(500f)


### PR DESCRIPTION
The Audio tools sheet gains a Crossfeed toggle below Compressor and
Inflator, backed by a new pure-Kotlin CrossfeedEffect on the mix bus
(after the Oxford post-chain): each ear receives the opposite channel
delayed by the Woodworth ITD and darkened by a 700 Hz head-shadow
low-pass, with per-sample smoothing so live changes never click.

Long-pressing any of the three effect rows opens that tool's page:
Compressor and Inflator jump to their Oxford tabs, Crossfeed opens a
new config screen with a top-down visual of the virtual speaker pair
around the listener and a slider sweeping the speaker angle from 180
degrees (plain headphones, no crossfeed) down to 30 degrees (narrow
frontal pair, strongest crossfeed).