### PR TITLE
What's New: cover the whole 1.8.3 to 1.8.4 release

### DIFF
--- a/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/library/LibraryScreen.kt
@@ -95,6 +95,32 @@ internal val LIBRARY_SECTION_NAMES = mapOf(
 internal fun librarySections(order: List<String>): List<String> =
     listOf(LOCAL_SECTION) + order.filter { it != LOCAL_SECTION && it in LIBRARY_SECTION_NAMES }
 
+/**
+ * Lazy list keys for Library's two mixed pages.
+ *
+ * A key has to be unique across the whole `LazyColumn`, not just within the
+ * `items()` call it came from, and Compose throws rather than recovering when
+ * two collide. Both of these pages stack several `items()` blocks into one
+ * list, and a bare `it.id` is unique in neither of them:
+ *
+ * - Favorites lists tracks, then albums, then artists. All three ids are
+ *   `Long` from separate catalogue namespaces, so a liked track and a liked
+ *   album sharing a number is coincidence, not corruption — and it crashed
+ *   the page for anyone who happened to hold both.
+ * - Overview shows recently played above liked songs, and a song you like and
+ *   have just played is in both lists by construction.
+ *
+ * Tagging by the row's kind makes the key unique by shape rather than by
+ * luck. They're `String`, which a lazy list can save and restore.
+ */
+internal object LibraryKeys {
+    fun track(id: Long) = "track:$id"
+    fun album(id: Long) = "album:$id"
+    fun artist(id: Long) = "artist:$id"
+    fun recent(id: Long) = "recent:$id"
+    fun liked(id: Long) = "liked:$id"
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryScreen(
@@ -366,7 +392,7 @@ fun LibraryScreen(
                 ) {
                     if (recentTracks.isNotEmpty()) {
                         item { SectionHeader(title = "Recently Played") }
-                        items(recentTracks.take(5), key = { it.id }) { track ->
+                        items(recentTracks.take(5), key = { LibraryKeys.recent(it.id) }) { track ->
                             TrackItem(
                                 track = track,
                                 isLiked = favoriteTrackIds.contains(track.id),
@@ -391,7 +417,7 @@ fun LibraryScreen(
 
                     if (favoriteTracks.isNotEmpty()) {
                         item { SectionHeader(title = "Liked Songs") }
-                        items(favoriteTracks.take(5), key = { it.id }) { track ->
+                        items(favoriteTracks.take(5), key = { LibraryKeys.liked(it.id) }) { track ->
                             TrackItem(
                                 track = track,
                                 isLiked = true,
@@ -548,7 +574,7 @@ fun LibraryScreen(
                                 onSortChange = { likedSort = it },
                             )
                         }
-                        items(visibleFavorites, key = { it.id }) { track ->
+                        items(visibleFavorites, key = { LibraryKeys.track(it.id) }) { track ->
                             TrackItem(
                                 track = track,
                                 isLiked = true,
@@ -574,7 +600,7 @@ fun LibraryScreen(
                     if (favoriteAlbums.isNotEmpty()) {
                         item { Spacer(modifier = Modifier.height(8.dp)) }
                         item { SectionHeader(title = "Liked Albums") }
-                        items(favoriteAlbums, key = { it.id }) { album ->
+                        items(favoriteAlbums, key = { LibraryKeys.album(it.id) }) { album ->
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -589,7 +615,7 @@ fun LibraryScreen(
                     if (favoriteArtists.isNotEmpty()) {
                         item { Spacer(modifier = Modifier.height(8.dp)) }
                         item { SectionHeader(title = "Liked Artists") }
-                        items(favoriteArtists, key = { it.id }) { artist ->
+                        items(favoriteArtists, key = { LibraryKeys.artist(it.id) }) { artist ->
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/app/src/main/java/tf/monochrome/android/ui/settings/WhatsNew.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/WhatsNew.kt
@@ -41,6 +41,12 @@ object WhatsNew {
                         "to re-stream from every screen but Downloads.",
                 ),
                 WhatsNewEntry(
+                    title = "Gapless playback actually works",
+                    body = "The toggle had never been connected to anything: it saved your " +
+                        "choice and nothing read it. The next track is now made ready while the " +
+                        "current one plays, so on-device files and Qobuz run straight on.",
+                ),
+                WhatsNewEntry(
                     title = "Blend between tracks",
                     body = "One slider in Settings decides what happens between songs. At zero " +
                         "they run straight into each other with no gap; add time and they " +
@@ -64,29 +70,10 @@ object WhatsNew {
                         "play, most often the first time you heard it. It now starts on its own.",
                 ),
                 WhatsNewEntry(
-                    title = "Auto-download liked songs",
-                    body = "Turn it on in Settings and every song you like from then on is saved " +
-                        "for offline. Songs you liked earlier are left alone, so switching it on " +
-                        "never kicks off a huge download.",
-                ),
-                WhatsNewEntry(
-                    title = "Inflator oversampling",
-                    body = "The Inflator can now run at 2x or 4x to keep its harmonics from " +
-                        "folding back into the audible band as grit. Measured about 30 dB " +
-                        "cleaner on bright material.",
-                ),
-                WhatsNewEntry(
-                    title = "The player changes colour at the speed the music does",
-                    body = "The background, the accents, the blurred backdrop and the album art " +
-                        "itself now cross into the next track across your blend time, so nothing " +
-                        "repaints while the previous song is still playing. Skip by hand and it " +
-                        "still changes at once.",
-                ),
-                WhatsNewEntry(
-                    title = "Download as many as you like",
-                    body = "Downloads are a proper queue now — send it fifty tracks and three " +
-                        "transfer at a time under one notification. Queueing more than one at " +
-                        "once used to be able to take the app down.",
+                    title = "A song tapped straight after opening the app plays",
+                    body = "Tap one before playback had finished connecting and nothing " +
+                        "happened at all — no sound, no error, nothing to retry. The tap now " +
+                        "waits the moment it needs instead of being dropped.",
                 ),
                 WhatsNewEntry(
                     title = "A slow track is no longer skipped past",
@@ -96,9 +83,90 @@ object WhatsNew {
                         "previous song out into silence.",
                 ),
                 WhatsNewEntry(
+                    title = "Download as many as you like",
+                    body = "Downloads are a proper queue now — send it fifty tracks and three " +
+                        "transfer at a time under one notification. Queueing more than one at " +
+                        "once used to be able to take the app down.",
+                ),
+                WhatsNewEntry(
+                    title = "You can see what's already downloaded",
+                    body = "Song rows show a ring with a down arrow when the track is on your " +
+                        "device, in Library, playlists, albums, artists, Home and search. " +
+                        "Unlike the progress spinner, it is still there after a restart.",
+                ),
+                WhatsNewEntry(
+                    title = "Auto-download liked songs",
+                    body = "Turn it on in Settings › Downloads and every song you like from " +
+                        "then on is saved for offline. Songs you liked earlier are left alone, " +
+                        "so switching it on never kicks off a huge download.",
+                ),
+                WhatsNewEntry(
+                    title = "Crossfeed for headphones",
+                    body = "A new toggle in the audio tools sheet sends a little of each " +
+                        "channel to the far ear, the way speakers do, softening hard-panned " +
+                        "old mixes. Long-press the row to set the speaker angle or pick a " +
+                        "classic network.",
+                ),
+                WhatsNewEntry(
+                    title = "Cleaner effects, and a louder ladder filter",
+                    body = "The Inflator and Compressor gain an Off / 2x / 4x anti-alias " +
+                        "control. The ladder filter is 25 dB cleaner and 6 dB louder — it had " +
+                        "been throwing away half its level — so old ladder presets may want " +
+                        "pulling down.",
+                ),
+                WhatsNewEntry(
+                    title = "ReplayGain is gone",
+                    body = "It never did anything: the mode had no control anywhere in the app, " +
+                        "so volume matching sat switched off on every track. It is removed " +
+                        "rather than left there looking functional. Nothing sounds different.",
+                ),
+                WhatsNewEntry(
+                    title = "Apple Music is off the menu",
+                    body = "Its settings, its onboarding card and its search results are gone, " +
+                        "and search now covers TIDAL and Qobuz. Apple tracks you have already " +
+                        "downloaded still play.",
+                ),
+                WhatsNewEntry(
+                    title = "Search and sort any list of tracks",
+                    body = "Playlists, album and artist pages, Liked Songs and every local " +
+                        "library screen share one toolbar. Play, shuffle, select and Download " +
+                        "All all follow what is on screen rather than what the filter hides.",
+                ),
+                WhatsNewEntry(
+                    title = "A track menu wherever there are tracks",
+                    body = "Local album, artist, genre, folder, Songs and Downloads rows gain " +
+                        "the menu they never had: play next, add to playlist, go to album or " +
+                        "artist, share the file.",
+                ),
+                WhatsNewEntry(
+                    title = "Ten fonts, built in",
+                    body = "The font library used to be empty until you found a .ttf yourself. " +
+                        "Ten typefaces now ship with the app, from Space Grotesk and Manrope to " +
+                        "JetBrains Mono, and the list folds away when you are not picking one.",
+                ),
+                WhatsNewEntry(
+                    title = "Settings you can find things in",
+                    body = "Instances, Scrobbling and Account merge into Connections, Appearance " +
+                        "and Interface become one tab, and Playback, Equalizer, Library and " +
+                        "Downloads each hold what belongs to them. Every tab looks the same now.",
+                ),
+                WhatsNewEntry(
+                    title = "The player changes colour at the speed the music does",
+                    body = "The background, the accents, the blurred backdrop and the album art " +
+                        "itself now cross into the next track across your blend time, so nothing " +
+                        "repaints while the previous song is still playing. Skip by hand and it " +
+                        "still changes at once.",
+                ),
+                WhatsNewEntry(
                     title = "Tap the artwork to play",
                     body = "Album art in a song row plays the song instead of opening the album, " +
                         "and the artist and album links are harder to hit by accident.",
+                ),
+                WhatsNewEntry(
+                    title = "Lighter to move around",
+                    body = "The player rebuilt itself four times a second for the clock alone, " +
+                        "long lists redrew from any change downwards, and screens kept working " +
+                        "in the background. Scrolling and navigation are smoother for it.",
                 ),
             ),
         ),

--- a/app/src/test/java/tf/monochrome/android/ui/library/LibraryKeysTest.kt
+++ b/app/src/test/java/tf/monochrome/android/ui/library/LibraryKeysTest.kt
@@ -1,0 +1,63 @@
+package tf.monochrome.android.ui.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Library's Favorites and Overview pages each stack several `items()` blocks
+ * into one `LazyColumn`, and Compose throws `IllegalArgumentException` the
+ * moment two rows in one lazy list claim the same key — it does not fall back
+ * to position.
+ *
+ * Both collisions this guards against are ordinary states, not corruption: a
+ * liked track and a liked album carrying the same number (separate catalogue
+ * namespaces, both `Long`), and a song that is both liked and recently played.
+ * So the test is the number-sharing case, not a spread of unrelated ids.
+ */
+class LibraryKeysTest {
+
+    @Test
+    fun `the favorites page keys three kinds of row apart at one id`() {
+        val id = 150973193L
+        val keys = listOf(
+            LibraryKeys.track(id),
+            LibraryKeys.album(id),
+            LibraryKeys.artist(id),
+        )
+        assertEquals("keys collide at id $id: $keys", keys.size, keys.toSet().size)
+    }
+
+    @Test
+    fun `the overview page keys a recently played song apart from a liked one`() {
+        val id = 42L
+        assertEquals(
+            "a song that is both liked and recently played is one row twice",
+            2,
+            setOf(LibraryKeys.recent(id), LibraryKeys.liked(id)).size,
+        )
+    }
+
+    @Test
+    fun `no key of one kind is ever the key of another`() {
+        val kinds = listOf(
+            LibraryKeys::track,
+            LibraryKeys::album,
+            LibraryKeys::artist,
+            LibraryKeys::recent,
+            LibraryKeys::liked,
+        )
+        // Adjacent ids as well as equal ones: a scheme that appended the id
+        // without a separator would let "track:1" + 2 meet "track:12".
+        val ids = listOf(0L, 1L, 2L, 12L, 150973193L, Long.MAX_VALUE)
+        val all = kinds.flatMap { kind -> ids.map { kind(it) } }
+        assertEquals("two rows would share a key: $all", all.size, all.toSet().size)
+    }
+
+    @Test
+    fun `a key is stable for the same row`() {
+        // Lazy lists use the key to keep scroll position and state across a
+        // recomposition, so it has to be the same string every time.
+        assertEquals(LibraryKeys.track(7L), LibraryKeys.track(7L))
+        assertEquals(LibraryKeys.album(7L), LibraryKeys.album(7L))
+    }
+}


### PR DESCRIPTION
The notes were written mid-cycle and stopped at the commit that added
them, so half of 1.8.4 was missing from the only place a user would look
for it: gapless finally being connected to something, crossfeed, the
downloaded badge, ReplayGain and Apple Music leaving, the search and
sort toolbar, the local track menus, the ten bundled fonts, the settings
reshuffle and the recomposition work.

Two existing entries were out of date rather than absent. Oversampling
had grown past the Inflator to the Compressor and the ladder filter,
which also came out 6 dB louder, and that is worth saying because it
changes how old ladder presets sound. Auto-download liked songs moved
off Library onto Downloads.

Every body stays inside the 260-character limit the test pins.