### PR TITLE
Open the EQ screens from the Equalizer settings tab

### DIFF
--- a/app/src/main/java/tf/monochrome/android/domain/model/DiscoveryShelf.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/DiscoveryShelf.kt
@@ -43,4 +43,17 @@ data class DiscoveryShelf(
     val items: List<DiscoveryItem> = emptyList(),
     /** Whether the header offers a "See All" into the full grid. */
     val seeAll: Boolean = true,
+    /**
+     * The genre this shelf was built from, when it was built from one.
+     *
+     * Carried so a See All grid can ask for more of the same genre without
+     * having to parse it back out of [id]. Null for shelves with no genre
+     * behind them — "New from X", "Because you play X", a mood's flat search.
+     */
+    val genreId: String? = null,
+    /**
+     * How deep into [genreId] this shelf already reaches. The next page is
+     * [depth] + 1; see DiscoveryFeedUseCase.moreForGenre.
+     */
+    val depth: Int = 0,
 )

--- a/app/src/main/java/tf/monochrome/android/domain/usecase/DiscoveryFeedUseCase.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/usecase/DiscoveryFeedUseCase.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withTimeoutOrNull
@@ -215,24 +216,22 @@ class DiscoveryFeedUseCase @Inject constructor(
     /**
      * One genre's shelf. [mood] is null when the genre is the subject rather
      * than a means to a mood — the reason line changes, nothing else does.
+     *
+     * [page] is depth *within this genre*, not a different genre: page one is
+     * the next stretch of the same ranking. Paging used to mean only "walk
+     * further across the graph", so the genre you actually asked for was one
+     * shelf deep and there was no way to reach its thirteenth track.
      */
     private suspend fun genreShelfFor(
         related: RelatedGenre,
         mood: MoodProfile?,
         limit: Int,
         variation: Int = 0,
-    ): DiscoveryShelf? = withTimeoutOrNull(QOBUZ_BUDGET_MS) {
+        page: Int = 0,
+    ): DiscoveryShelf? {
         val node = related.node
-        // The node's own name first — it is what the catalogue is most likely
-        // to have tagged — with an alias as the fallback for genres a store
-        // spells differently. [variation] walks the aliases instead, which is
-        // what stops a genre asked for twice from returning the same search.
-        val queries = node.queries()
-        if (queries.isEmpty()) return@withTimeoutOrNull null
-        val query = queries[Math.floorMod(variation, queries.size)]
-        val result = music.searchQobuz(query).getOrNull() ?: return@withTimeoutOrNull null
-        registerArtists(result.tracks.flatMap { it.artists }.map { it.id })
-
+        val prefix = mood?.let { "mood_" + it.id } ?: "genre"
+        val id = shelfId(prefix, node.id, page)
         val reason = buildString {
             append(
                 when {
@@ -245,12 +244,79 @@ class DiscoveryFeedUseCase @Inject constructor(
             if (node.hasTempo) append(" · ${node.bpmLow}–${node.bpmHigh} BPM")
         }
 
-        // The search ranked these by how well a *title or album* matched the
-        // genre's name, which is the query machine-generated filler is built to
-        // win: asking for hardstyle returns "Hardstyle Fish", "I'm so lucky! -
-        // Hardstyle" and compilations whose artwork happens to say Hardstyle.
-        // Keep only the ones whose artist the genre actually owns.
+        // What the genre actually is, before what merely says so. The chart is
+        // ranked by what people played and each row is admitted only when it
+        // agrees with the catalogue on both artist and title, so nothing gets
+        // in on the strength of its name alone.
         //
+        // The timeout is the budget; a cancellation is the feed being replaced
+        // out from under us and has to keep travelling. runCatching around the
+        // whole thing would swallow the second as if it were the first and go
+        // on to run the fallback search for a shelf nobody is waiting for.
+        val charted = try {
+            withTimeoutOrNull(CHART_BUDGET_MS) {
+                genreCharts.playablePool(node.id, depth = limit, skip = page * limit)
+            }.orEmpty()
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            emptyList()
+        }
+
+        if (charted.size >= MIN_CHART_TRACKS) {
+            return charted.map { DiscoveryItem.TrackItem(it.chartedAs(node)) }
+                .toShelf(
+                    id = id,
+                    title = node.name,
+                    reason = "$reason · ranked by plays",
+                    genreId = node.id,
+                    depth = page,
+                )
+        }
+
+        return withTimeoutOrNull(QOBUZ_BUDGET_MS) {
+            searchShelf(node, id, reason, limit, variation, page)
+        }
+    }
+
+    /**
+     * The fallback shelf: a catalogue search on the genre's name, cleaned up.
+     *
+     * Reached only when no chart source has heard of the genre. The search
+     * ranks by how well a *title or album* matches the words, which is the
+     * query machine-generated filler is built to win — asking for hardstyle
+     * returns "Hardstyle Fish", "I'm so lucky! - Hardstyle" and compilations
+     * whose artwork happens to say Hardstyle.
+     *
+     * Two defences, because either alone lets the filler through. Artists the
+     * genre demonstrably owns are kept whatever their tracks are called, and
+     * floated to the front. Everyone else has to not be echoing the genre's own
+     * name back at us. What survives is presented as a search result and says so
+     * — the previous code fell back to the raw, unfiltered hits and titled them
+     * as though they were the genre, which is the part that read as broken.
+     */
+    private suspend fun searchShelf(
+        node: GenreNode,
+        id: String,
+        reason: String,
+        limit: Int,
+        variation: Int,
+        page: Int,
+    ): DiscoveryShelf? {
+        // The node's own name first — it is what the catalogue is most likely
+        // to have tagged — with an alias as the fallback for genres a store
+        // spells differently. [variation] walks the aliases instead, which is
+        // what stops a genre asked for twice from returning the same search.
+        val queries = node.queries()
+        if (queries.isEmpty()) return null
+        val query = queries[Math.floorMod(variation, queries.size)]
+        // Deeper pages ask the catalogue for a later slice rather than
+        // re-reading the first one. The parameter has been plumbed through
+        // MusicRepository and HiFiApiClient all along and was never passed.
+        val offset = page * limit * SHELF_OVERFETCH
+        val result = music.searchQobuz(query, offset).getOrNull() ?: return null
+        registerArtists(result.tracks.flatMap { it.artists }.map { it.id })
+
         // Verification is by artist rather than per track because it is cached
         // per artist for a month and shared across every shelf and chart — a
         // warm cache makes this free, and a cold one costs at most one request
@@ -263,23 +329,61 @@ class DiscoveryFeedUseCase @Inject constructor(
             )
         }.getOrDefault(emptySet())
 
-        val kept = if (confirmed.isEmpty()) {
-            // Nothing to verify against — an obscure genre no source knows.
-            // Filtering on no evidence would empty the shelf, which is worse
-            // than showing the unfiltered search.
-            candidates
-        } else {
-            candidates.filter { track ->
-                normalizeForMatch(track.artists.firstOrNull()?.name.orEmpty()) in confirmed
-            }.ifEmpty { candidates }
-        }
+        val (owned, rest) = candidates
+            .filter { track ->
+                val artist = normalizeForMatch(track.artists.firstOrNull()?.name.orEmpty())
+                artist in confirmed || !echoesGenreName(track.title, track.album?.title, queries)
+            }
+            .partition { normalizeForMatch(it.artists.firstOrNull()?.name.orEmpty()) in confirmed }
 
-        val tracks = kept.take(limit)
+        val tracks = (owned + rest).take(limit)
             .map { DiscoveryItem.TrackItem(it.toQobuzUnifiedTrack().taggedWith(node)) }
-        val items = tracks.ifEmpty { result.albums.take(limit).map { DiscoveryItem.AlbumItem(it) } }
-        val prefix = mood?.let { "mood_" + it.id } ?: "genre"
-        items.toShelf(id = prefix + "_" + node.id, title = node.name, reason = reason)
+        // Albums only when no track survived, and held to the same standard:
+        // the shelf that has just dropped every track called "Techno" would
+        // otherwise fill itself back up with compilations called "Techno 2024".
+        val items = tracks.ifEmpty {
+            result.albums
+                .filterNot { echoesGenreName(it.title, null, queries) }
+                .take(limit)
+                .map { DiscoveryItem.AlbumItem(it) }
+        }
+        val honest = if (confirmed.isEmpty()) "$reason · matched by name" else reason
+        return items.toShelf(
+            id = id,
+            title = node.name,
+            reason = honest,
+            genreId = node.id,
+            depth = page,
+        )
     }
+
+    /**
+     * The next page of one genre, as items to append to a shelf already on
+     * screen.
+     *
+     * This is what "See All" scrolls into. It deliberately returns items rather
+     * than a shelf: the grid is already showing this genre under its own title
+     * and reason, and swapping the shelf underneath it would reset the scroll
+     * position and any running selection.
+     */
+    suspend fun moreForGenre(
+        genreId: String,
+        page: Int,
+        limit: Int = 20,
+    ): List<DiscoveryItem> {
+        val node = genreGraph.graph[genreId] ?: return emptyList()
+        return genreShelfFor(
+            related = RelatedGenre(node, 1f, 0),
+            mood = null,
+            limit = limit,
+            variation = page,
+            page = page,
+        )?.items.orEmpty()
+    }
+
+    /** Shelf ids carry their depth, or a genre's second page collides with its first. */
+    private fun shelfId(prefix: String, nodeId: String, page: Int): String =
+        if (page == 0) prefix + "_" + nodeId else prefix + "_" + nodeId + "_p" + page
 
     /**
      * A feed built around one genre — what the map hands back when you tap a node.
@@ -303,22 +407,27 @@ class DiscoveryFeedUseCase @Inject constructor(
         val floor = DiscoveryAdventure.neighbourFloor(adventure)
         val neighbours = graph.neighbours(genreId, maxHops = hopsFor(adventure, page), floor = floor)
 
-        // The genre itself leads its own first page and nothing else's — page
-        // two is neighbours, not the same shelf again with a different name.
-        val picks = if (page == 0) {
-            listOf(RelatedGenre(root, 1f, 0)) + neighbours.take(maxShelves - 1)
-        } else {
-            neighbours.drop(page * maxShelves - 1).take(maxShelves)
+        // The genre itself leads every page, one stretch deeper each time,
+        // followed by neighbours we haven't shown yet. It used to lead page one
+        // and then vanish, so scrolling a genre walked away from it — twelve
+        // tracks of what you asked for and then an hour of things adjacent to
+        // it. Each pick carries its own depth: the root goes deeper, while a
+        // neighbour appearing for the first time starts at its own beginning.
+        val picks = buildList {
+            add(RelatedGenre(root, 1f, 0) to page)
+            neighbours.drop(page * (maxShelves - 1))
+                .take(maxShelves - 1)
+                .forEach { add(it to 0) }
         }
-        if (picks.isEmpty()) return@coroutineScope emptyList()
 
-        picks.map { related ->
+        picks.map { (related, depth) ->
             async {
                 genreShelfFor(
                     related,
                     mood = null,
                     limit = itemsPerShelf,
                     variation = variation + page,
+                    page = depth,
                 )
             }
         }.mapNotNull { it.await() }
@@ -422,9 +531,20 @@ class DiscoveryFeedUseCase @Inject constructor(
         id: String,
         title: String,
         reason: String?,
+        genreId: String? = null,
+        depth: Int = 0,
     ): DiscoveryShelf? = distinctBy { it.key }
         .takeIf { it.isNotEmpty() }
-        ?.let { DiscoveryShelf(id = id, title = title, reason = reason, items = it) }
+        ?.let {
+            DiscoveryShelf(
+                id = id,
+                title = title,
+                reason = reason,
+                items = it,
+                genreId = genreId,
+                depth = depth,
+            )
+        }
 
     /**
      * Tag every credited artist id as Qobuz, so ArtistDetailViewModel routes it
@@ -483,6 +603,22 @@ class DiscoveryFeedUseCase @Inject constructor(
             genreConfidence = GenreConfidence.INFERRED,
         )
 
+    /**
+     * Attach a genre the track earned by charting in it.
+     *
+     * A rung above [taggedWith]: this track is not here because a search for
+     * the genre's name returned it, but because the genre's chart ranked it and
+     * the catalogue agreed on both artist and title. That is inherited from the
+     * scene rather than stated by the file, which is what DERIVED means.
+     */
+    private fun UnifiedTrack.chartedAs(node: GenreNode): UnifiedTrack =
+        if (genre != null) copy(genreId = genreId ?: node.id)
+        else copy(
+            genre = node.name,
+            genreId = node.id,
+            genreConfidence = GenreConfidence.DERIVED,
+        )
+
     /** Lenient match so search albums credited to the seed artist are kept. */
     private fun String.matchesArtist(name: String): Boolean {
         val a = trim().lowercase()
@@ -504,5 +640,85 @@ class DiscoveryFeedUseCase @Inject constructor(
 
         /** Ceiling on how far paging widens the graph walk. */
         private const val MAX_HOPS = 5
+
+        /**
+         * How long a shelf may spend on the chart before it settles for the
+         * search. Longer than the search budget because it buys something
+         * better, and because a cold resolve cache is the expensive case — once
+         * warm, neighbouring shelves answer from memory well inside this.
+         */
+        private const val CHART_BUDGET_MS = 9_000L
+
+        /**
+         * Below this many resolved tracks a chart is not worth showing as one.
+         * A row of three is not a shelf, and the search — for all its faults —
+         * will at least fill it, so the honest trade at that depth is to fall
+         * back and label it rather than to show a stub.
+         */
+        private const val MIN_CHART_TRACKS = 6
     }
 }
+
+/**
+ * Whether this record is only in the results because it says the genre's name.
+ *
+ * The catalogue search is a title/album match, so asking it for a genre returns
+ * two kinds of thing: records that *are* the genre, and records that merely
+ * *mention* it — "Hardstyle Fish", "I'm so lucky! - Hardstyle", and the endless
+ * compilations called "Techno 2024". The second kind wins the ranking, because
+ * putting the genre in the title is exactly how you get found by someone
+ * searching for the genre.
+ *
+ * The test is deliberately one-directional: the genre's name appearing in the
+ * title or the album title is suspicious, the track's title appearing in the
+ * genre's name is not (a track really called "Techno" by a techno artist is a
+ * normal record). Callers pair this with artist evidence and let confirmed
+ * artists through regardless, so a genre's own defining track is never dropped
+ * for being named after it.
+ *
+ * Matching is on whole words, so "Trance" does not fire on "Entrance" and
+ * punctuation differences don't matter.
+ */
+internal fun echoesGenreName(
+    title: String,
+    albumTitle: String?,
+    genreNames: List<String>,
+): Boolean {
+    val haystacks = listOfNotNull(
+        foldWhole(title).takeIf { it.isNotEmpty() },
+        albumTitle?.let { foldWhole(it) }?.takeIf { it.isNotEmpty() },
+    )
+    if (haystacks.isEmpty()) return false
+
+    return genreNames.any { raw ->
+        val needle = foldWhole(raw)
+        needle.isNotEmpty() && haystacks.any { it.containsWords(needle) }
+    }
+}
+
+/**
+ * Lowercase alphanumerics and single spaces, keeping the *whole* string.
+ *
+ * Deliberately not [normalizeForMatch], which drops bracketed suffixes and
+ * everything after " - " so that two services can agree a record is the same
+ * record. Here that folding would erase the evidence: "I'm so lucky! -
+ * Hardstyle" folds to "im so lucky" under it, and the genre echo — the entire
+ * thing being tested for — disappears along with the dash. Bracketed text is
+ * kept for the same reason, so "(Hardstyle Remix)" still counts.
+ */
+private fun foldWhole(raw: String): String = buildString {
+    for (ch in raw.lowercase()) {
+        if (ch.isLetterOrDigit()) append(ch)
+        else if (isNotEmpty() && last() != ' ') append(' ')
+    }
+}.trim()
+
+/**
+ * Whether [words] appears in this string as a run of whole words.
+ *
+ * Both sides are already folded to lowercase alphanumerics separated by single
+ * spaces, so padding with spaces turns a substring test into a word-boundary
+ * one without a regex.
+ */
+private fun String.containsWords(words: String): Boolean =
+    " $this ".contains(" $words ")

--- a/app/src/main/java/tf/monochrome/android/domain/usecase/GenreChartUseCase.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/usecase/GenreChartUseCase.kt
@@ -111,6 +111,19 @@ class GenreChartUseCase @Inject constructor(
         const val CROSS_CHECK_BUDGET_MS = 4_000L
     }
 
+    /**
+     * Catalogue answers for chart rows, hits and misses alike. Held for the
+     * process rather than expired: a chart row is a fixed pair of strings and
+     * the catalogue's answer for it does not change while the app is open.
+     *
+     * Declared here, above every use, rather than beside [resolve] at the foot
+     * of the class. Nothing constructs this use case and immediately resolves,
+     * so the late declaration was harmless — but it is the same shape that took
+     * DiscoverViewModel down, and the fix costs nothing.
+     */
+    private val resolved = mutableMapOf<String, UnifiedTrack?>()
+    private val resolveMutex = Mutex()
+
     suspend fun chart(
         genreId: String,
         window: ChartWindow,
@@ -360,14 +373,6 @@ class GenreChartUseCase @Inject constructor(
         resolveMutex.withLock { resolved[key] = track }
         return track
     }
-
-    /**
-     * Catalogue answers for chart rows, hits and misses alike. Held for the
-     * process rather than expired: a chart row is a fixed pair of strings and
-     * the catalogue's answer for it does not change while the app is open.
-     */
-    private val resolved = mutableMapOf<String, UnifiedTrack?>()
-    private val resolveMutex = Mutex()
 }
 
 /**

--- a/app/src/main/java/tf/monochrome/android/domain/usecase/GenreChartUseCase.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/usecase/GenreChartUseCase.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import tf.monochrome.android.data.charts.ChartEntry
 import tf.monochrome.android.data.charts.ChartSource
@@ -50,10 +52,32 @@ class GenreChartUseCase @Inject constructor(
 
         /**
          * How much of a chart to turn into a play queue. Deep enough to be a
-         * listening session, shallow enough that building it is a manageable
-         * number of catalogue lookups.
+         * listening session, and no longer bounded by how many catalogue
+         * lookups a caller can afford to wait through — resolution runs
+         * concurrently and is cached, so this is a depth rather than a budget.
          */
-        const val POOL_DEPTH = 30
+        const val POOL_DEPTH = 60
+
+        /**
+         * How many catalogue lookups to have in flight while turning chart rows
+         * into playable tracks. Same reasoning as [VERIFY_CONCURRENCY]: enough
+         * to hide the latency, few enough to arrive as a stream and not a burst.
+         *
+         * This is also the early-stop granularity — a pool that has already
+         * filled stops after the batch that filled it rather than resolving the
+         * whole chart and discarding the tail.
+         */
+        const val RESOLVE_CONCURRENCY = 8
+
+        /**
+         * How much deeper than the requested pool to read the chart.
+         *
+         * Not every charted track is in the catalogue, and an entry that isn't
+         * resolves to nothing rather than to something near it. Reading twice
+         * the depth means an ordinary miss rate still fills the pool without a
+         * second chart request.
+         */
+        const val RESOLVE_OVERREAD = 2
 
         /**
          * How far down a tag chart to verify artists. Each new artist costs a
@@ -277,14 +301,34 @@ class GenreChartUseCase @Inject constructor(
      * Entries that can't be found in the catalogue are dropped, so the result
      * may be shorter than [depth] — a short list of the real thing beats a full
      * one padded with near-misses.
+     *
+     * [skip] takes the pool from further down the same chart, which is what
+     * makes a genre pageable: page two is the next stretch of the ranking, not
+     * the head again in a different order.
      */
     suspend fun playablePool(
         genreId: String,
         window: ChartWindow = ChartWindow.ALL_TIME,
         depth: Int = POOL_DEPTH,
+        skip: Int = 0,
     ): List<UnifiedTrack> {
-        val entries = chart(genreId, window, limit = depth).entries
-        return entries.mapNotNull { resolve(it) }.distinctBy { it.id }
+        if (depth <= 0) return emptyList()
+        val wanted = (skip + depth) * RESOLVE_OVERREAD
+        val entries = chart(genreId, window, limit = wanted).entries.drop(skip)
+        if (entries.isEmpty()) return emptyList()
+
+        // Resolved in bounded parallel batches, stopping as soon as the pool is
+        // full. Sequentially this was one network round trip per row — thirty of
+        // them back to back, which is why only "play this genre" could afford to
+        // call it and the feed could not.
+        val pool = LinkedHashMap<String, UnifiedTrack>(depth)
+        for (batch in entries.chunked(RESOLVE_CONCURRENCY)) {
+            coroutineScope { batch.map { async { resolve(it) } }.awaitAll() }
+                .filterNotNull()
+                .forEach { track -> if (!pool.containsKey(track.id)) pool[track.id] = track }
+            if (pool.size >= depth) break
+        }
+        return pool.values.take(depth)
     }
 
     /**
@@ -297,13 +341,33 @@ class GenreChartUseCase @Inject constructor(
      * and title, and if none does this returns null rather than the closest
      * thing to hand. Playing the wrong track is worse than playing nothing:
      * silence is legible, a wrong record looks like the chart is nonsense.
+     *
+     * Memoised on [ChartEntry.matchKey], misses included. A genre and its
+     * neighbours overlap heavily — the same record charts under techno, hard
+     * techno and industrial techno — so on a feed that builds six shelves at
+     * once most rows are already answered. Remembering the misses matters as
+     * much as the hits: a track the catalogue simply does not carry would
+     * otherwise be re-searched once per shelf, forever.
      */
     suspend fun resolve(entry: ChartEntry): UnifiedTrack? {
-        val result = music.searchQobuz(entry.matchQuery).getOrNull() ?: return null
-        return result.tracks
-            .firstOrNull { agrees(entry, it.artists.firstOrNull()?.name ?: "", it.title) }
+        val key = entry.matchKey
+        resolveMutex.withLock { if (resolved.containsKey(key)) return resolved[key] }
+
+        val track = music.searchQobuz(entry.matchQuery).getOrNull()?.tracks
+            ?.firstOrNull { agrees(entry, it.artists.firstOrNull()?.name ?: "", it.title) }
             ?.toQobuzUnifiedTrack()
+
+        resolveMutex.withLock { resolved[key] = track }
+        return track
     }
+
+    /**
+     * Catalogue answers for chart rows, hits and misses alike. Held for the
+     * process rather than expired: a chart row is a fixed pair of strings and
+     * the catalogue's answer for it does not change while the app is open.
+     */
+    private val resolved = mutableMapOf<String, UnifiedTrack?>()
+    private val resolveMutex = Mutex()
 }
 
 /**

--- a/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverShelfScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverShelfScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -26,6 +27,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -119,8 +122,24 @@ fun DiscoverShelfScreen(
             )
         }
 
+        val gridState = rememberLazyGridState()
+        // Reaching the bottom asks the shelf's genre for another page, the same
+        // way the feed asks for another row of shelves (DiscoverScreen.kt:147).
+        // Re-armed on the item count so a page that lands while sitting at the
+        // end doesn't read as "no change" and stall at page two.
+        LaunchedEffect(gridState, shelfId, shelf?.items?.size) {
+            snapshotFlow {
+                val info = gridState.layoutInfo
+                val last = info.visibleItemsInfo.lastOrNull()?.index ?: 0
+                info.totalItemsCount > 0 && last >= info.totalItemsCount - 1
+            }
+                .distinctUntilChanged()
+                .collect { atEnd -> if (atEnd) viewModel.loadMoreInShelf(shelfId) }
+        }
+
         when {
             shelf != null -> LazyVerticalGrid(
+                state = gridState,
                 columns = GridCells.Adaptive(MonoDimens.coverCard),
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(16.dp, 8.dp, 16.dp, 160.dp),

--- a/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverViewModel.kt
@@ -454,6 +454,11 @@ class DiscoverViewModel @Inject constructor(
         page = 0
         _exhausted.value = false
         _loadingMore.value = false
+        // Per-shelf paging state belongs to the feed that was on screen. Left
+        // behind, a rebuilt feed that happens to reuse a shelf id would inherit
+        // the old one's "nothing more to give".
+        shelvesLoadingMore.clear()
+        exhaustedShelves.clear()
         feedJob = viewModelScope.launch {
             _loading.value = true
             _shelves.value = emptyList()
@@ -561,6 +566,58 @@ class DiscoverViewModel @Inject constructor(
             _loadingMore.value = false
         }
     }
+
+    /**
+     * Deepen one shelf in place, rather than adding another shelf below it.
+     *
+     * This is what the See All grid reaches for. [loadMore] widens the *feed* —
+     * more genres — which is the wrong answer when someone has opened a single
+     * genre and scrolled to the bottom of it: they have asked for more of this,
+     * not for something adjacent. Only genre-backed shelves can grow; the rest
+     * have no page two to fetch and say so by doing nothing.
+     */
+    fun loadMoreInShelf(shelfId: String) {
+        if (shelfId in shelvesLoadingMore || shelfId in exhaustedShelves) return
+        val shelf = _shelves.value.firstOrNull { it.id == shelfId } ?: return
+        val genreId = shelf.genreId ?: return
+
+        shelvesLoadingMore += shelfId
+        viewModelScope.launch {
+            val next = shelf.depth + 1
+            val more = try {
+                discoveryFeed.moreForGenre(genreId, page = next, limit = SHELF_SIZE)
+            } catch (cancelled: CancellationException) {
+                shelvesLoadingMore -= shelfId
+                throw cancelled
+            } catch (_: Exception) {
+                emptyList()
+            }
+
+            // Keyed dedup against what the shelf already holds: the chart pool
+            // and the catalogue search can both hand back a record that page
+            // one already showed, and a repeated key crashes the lazy grid.
+            val known = shelf.items.map { it.key }.toSet()
+            val fresh = more.distinctBy { it.key }.filterNot { it.key in known }
+            if (fresh.isEmpty()) {
+                exhaustedShelves += shelfId
+            } else {
+                _shelves.value = _shelves.value.map { candidate ->
+                    if (candidate.id == shelfId) {
+                        candidate.copy(items = candidate.items + fresh, depth = next)
+                    } else {
+                        candidate
+                    }
+                }
+            }
+            shelvesLoadingMore -= shelfId
+        }
+    }
+
+    /** Shelves with a deepening request in flight, so a fast scroll fires once. */
+    private val shelvesLoadingMore = mutableSetOf<String>()
+
+    /** Shelves whose genre has no more to give, so the grid stops asking. */
+    private val exhaustedShelves = mutableSetOf<String>()
 
     /**
      * One page of whichever category is showing.
@@ -792,7 +849,13 @@ class DiscoverViewModel @Inject constructor(
     }
 
     private companion object {
-        const val SHELF_SIZE = 12
+        /**
+         * Cards per shelf. Also what "See All" opens onto, which is why it is
+         * not smaller: twelve was a comfortable carousel and a disappointing
+         * grid, and it capped a genre at twelve tracks in total because nothing
+         * could page past the first shelf.
+         */
+        const val SHELF_SIZE = 20
 
         /** Genre tracks played ahead of a station, to anchor it in the genre. */
         const val RADIO_OPENING = 6

--- a/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/discover/DiscoverViewModel.kt
@@ -302,6 +302,23 @@ class DiscoverViewModel @Inject constructor(
     private var page = 0
     private var moreJob: Job? = null
 
+    /** Shelves with a deepening request in flight, so a fast scroll fires once. */
+    private val shelvesLoadingMore = mutableSetOf<String>()
+
+    /** Shelves whose genre has no more to give, so the grid stops asking. */
+    private val exhaustedShelves = mutableSetOf<String>()
+
+    // Everything above is read *synchronously* by [rebuild], which the init
+    // block below calls during construction, so it has to be declared above
+    // that init — Kotlin runs initializers in declaration order, and a field
+    // declared later is still null when the constructor reaches it. These two
+    // sets were originally written down beside loadMoreInShelf, at the bottom
+    // of the class, and every launch of Discover died on `.clear()` here. The
+    // compiler can't see it: the read happens through a method call. State that
+    // rebuild only touches inside its `viewModelScope.launch` is exempt — that
+    // body resumes after construction has finished — which is why the older
+    // fields further down the file get away with it.
+
     /**
      * The feed with dismissals applied. Everything on screen reads this rather
      * than [_shelves], so waving a card away takes effect everywhere at once —
@@ -612,12 +629,6 @@ class DiscoverViewModel @Inject constructor(
             shelvesLoadingMore -= shelfId
         }
     }
-
-    /** Shelves with a deepening request in flight, so a fast scroll fires once. */
-    private val shelvesLoadingMore = mutableSetOf<String>()
-
-    /** Shelves whose genre has no more to give, so the grid stops asking. */
-    private val exhaustedShelves = mutableSetOf<String>()
 
     /**
      * One page of whichever category is showing.

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -298,13 +298,15 @@ private fun EqualizerTab(
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        // Navigate straight to the tool. These used to re-enter Settings on a
+        // hardcoded `settings?tab=4` first, to force Back to land on this tab
+        // — which broke both buttons twice over. The rewritten Settings entry
+        // was not RESUMED yet when navigateTool ran, so its isSettled() guard
+        // swallowed the second call and the EQ page never opened; and tab 4 is
+        // Downloads now, not Equalizer. Nothing is lost by dropping it: the
+        // pager state is saveable, so Back restores the tab you left from.
         OutlinedButton(
-            onClick = {
-                navController.navigate("settings?tab=4") {
-                    popUpTo("settings?tab={tab}") { inclusive = true }
-                }
-                navController.navigateTool(Screen.Equalizer)
-            },
+            onClick = { navController.navigateTool(Screen.Equalizer) },
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Open Precision AutoEQ")
@@ -313,12 +315,7 @@ private fun EqualizerTab(
         Spacer(modifier = Modifier.height(8.dp))
 
         OutlinedButton(
-            onClick = {
-                navController.navigate("settings?tab=4") {
-                    popUpTo("settings?tab={tab}") { inclusive = true }
-                }
-                navController.navigateTool(Screen.ParametricEq)
-            },
+            onClick = { navController.navigateTool(Screen.ParametricEq) },
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Open Parametric EQ")

--- a/app/src/test/java/tf/monochrome/android/domain/usecase/GenreShelfFilterTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/usecase/GenreShelfFilterTest.kt
@@ -1,0 +1,78 @@
+package tf.monochrome.android.domain.usecase
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The filter that keeps a genre shelf from filling up with records that are
+ * only there because they say the genre's name.
+ *
+ * Every "drops" case below is a real shape the catalogue search returns for a
+ * genre query, and every "keeps" case is a real record that a careless version
+ * of this filter would throw away.
+ */
+class GenreShelfFilterTest {
+
+    private val hardstyle = listOf("Hardstyle")
+
+    @Test
+    fun `a track with the genre bolted onto its name is dropped`() {
+        assertTrue(echoesGenreName("Hardstyle Fish", null, hardstyle))
+    }
+
+    @Test
+    fun `a genre used as a dashed suffix is dropped`() {
+        // The case that motivates foldWhole. normalizeForMatch cuts everything
+        // after " - ", so folding this the chart matcher's way would leave
+        // "im so lucky" and the echo would vanish before it could be caught.
+        assertTrue(echoesGenreName("I'm so lucky! - Hardstyle", null, hardstyle))
+    }
+
+    @Test
+    fun `a genre inside brackets is dropped`() {
+        assertTrue(echoesGenreName("Sandstorm (Hardstyle Remix)", null, hardstyle))
+    }
+
+    @Test
+    fun `a compilation named after the genre is dropped on its album title`() {
+        assertTrue(echoesGenreName("Track Four", "Techno 2024", listOf("Techno")))
+    }
+
+    @Test
+    fun `an alias counts as the genre's name`() {
+        // node.queries() is the name plus every alias, and filler is written
+        // against whichever spelling people search for.
+        assertTrue(echoesGenreName("DnB Anthems Vol 3", null, listOf("Drum & Bass", "DnB")))
+    }
+
+    @Test
+    fun `punctuation and case do not hide an echo`() {
+        assertTrue(echoesGenreName("HARD-STYLE!!", null, listOf("hard style")))
+    }
+
+    @Test
+    fun `a record that simply is the genre is kept`() {
+        assertFalse(echoesGenreName("Gasolina", "Barrio Fino", listOf("Reggaeton")))
+    }
+
+    @Test
+    fun `the genre's name inside a longer word is not an echo`() {
+        // Substring matching would drop "Entrance" from every trance shelf.
+        assertFalse(echoesGenreName("Entrance", null, listOf("Trance")))
+        assertFalse(echoesGenreName("Housework", null, listOf("House")))
+    }
+
+    @Test
+    fun `only part of a multi word genre is not an echo`() {
+        // "Hard Times" shares a word with hard techno and is not filler for it.
+        assertFalse(echoesGenreName("Hard Times", null, listOf("Hard Techno")))
+    }
+
+    @Test
+    fun `an empty title or genre list is not an echo`() {
+        assertFalse(echoesGenreName("", null, hardstyle))
+        assertFalse(echoesGenreName("Hardstyle Fish", null, emptyList()))
+        assertFalse(echoesGenreName("Hardstyle Fish", null, listOf("", "  ")))
+    }
+}


### PR DESCRIPTION
Both buttons re-entered Settings on a hardcoded settings?tab=4 before
navigating to the tool, so Back would land on the Equalizer tab. That
rewrite is what broke them: the new Settings entry isn't RESUMED yet when
navigateTool runs, so its isSettled() guard swallowed the call and the
button did nothing but bounce you back to Settings. The literal index was
stale on top of that — tab 4 is Downloads now, Equalizer is 2.

Navigate straight to the tool instead, the way the player-side call sites
already do. The tab is a saveable pager state, so Back restores it
without any help.