### PR TITLE
EQ slider performance, on-device radio ranking, and the player glass panels

### DIFF
--- a/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
+++ b/app/src/main/java/tf/monochrome/android/audio/eq/AutoEqEngine.kt
@@ -88,6 +88,55 @@ object AutoEqEngine {
     }
 
     /**
+     * A fixed frequency axis with its cos(φ)/cos(2φ) tables precomputed, for
+     * evaluating whole band curves at once.
+     *
+     * [calculateBiquadResponse] is the per-point entry point, and it redesigns
+     * the filter on every call — sin/cos/pow/sqrt plus an allocation for ONE
+     * frequency. Drawing a band's curve through it costs that whole design pass
+     * per pixel, and the UI draws every band over a several-hundred-point grid
+     * on every drag frame, so a single slider drag was re-deriving thousands of
+     * biquads a second on the main thread.
+     *
+     * The coefficients are fixed per band and the phase terms are fixed per
+     * frequency, which is the same split the optimizer's refinement pass
+     * already exploits: design once per band, then a transcendental-free
+     * magnitude per point against the shared tables. Results are identical to
+     * calling [calculateBiquadResponse] per point — this only stops repeating
+     * work whose inputs never changed.
+     */
+    class ResponseGrid(freqs: FloatArray, private val sampleRate: Float = DEFAULT_SAMPLE_RATE) {
+        private val cosPhi = DoubleArray(freqs.size)
+        private val cos2Phi = DoubleArray(freqs.size)
+
+        val size: Int get() = cosPhi.size
+
+        init {
+            for (i in freqs.indices) {
+                val phi = 2.0 * PI * freqs[i].toDouble() / sampleRate.toDouble()
+                cosPhi[i] = cos(phi)
+                cos2Phi[i] = cos(2.0 * phi)
+            }
+        }
+
+        /** Adds [band]'s dB response onto [out] in place. Disabled bands are a no-op. */
+        fun accumulate(band: EqBand, out: FloatArray) {
+            if (!band.enabled) return
+            val c = AutoEqEngine.coeffsFor(band, sampleRate)
+            for (i in out.indices) {
+                out[i] += AutoEqEngine.magnitudeDb(c, cosPhi[i], cos2Phi[i]).toFloat()
+            }
+        }
+
+        /** This band's dB response across the whole axis. */
+        fun response(band: EqBand): FloatArray = FloatArray(size).also { accumulate(band, it) }
+
+        /** The summed dB response of [bands] across the whole axis. */
+        fun sum(bands: List<EqBand>): FloatArray =
+            FloatArray(size).also { out -> bands.forEach { accumulate(it, out) } }
+    }
+
+    /**
      * Normalized RBJ coefficients for a band. Split out of the response
      * calculation because they are FIXED per band — only the phase term varies
      * per evaluation frequency. The refinement pass exploits this: coefficients

--- a/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
+++ b/app/src/main/java/tf/monochrome/android/domain/model/PlayerGlassSettings.kt
@@ -68,6 +68,17 @@ data class PlayerGlassSettings(
     val hazeBlurDp: Float = 40f,
     /** Strength multiplier on the frost layer's luminance-picked tint (0–2). */
     val hazeTint: Float = 1f,
+    /**
+     * The mini player's thin progress line, which doubles as the bar's top
+     * border. Off drops both the line and the 2dp it occupies, so the bar
+     * closes up rather than leaving a gap where it used to be.
+     *
+     * Personal, not material: whether you want a progress readout is a
+     * preference about the bar, not part of a glass theme's optics, so
+     * [withPersonalFrom] carries it across a theme change instead of letting
+     * every preset silently switch it back on.
+     */
+    val miniProgressBar: Boolean = true,
 ) {
     fun clamped(): PlayerGlassSettings {
         val d = DEFAULT
@@ -97,13 +108,15 @@ data class PlayerGlassSettings(
 
     /**
      * The user's personal/perf settings — the chosen button-tint colour, the
-     * Studio-preview background, and the per-pixel quality — that a theme should
-     * carry over rather than overwrite. A theme changes only the glass MATERIAL.
+     * Studio-preview background, the per-pixel quality, and whether the mini
+     * player shows its progress line — that a theme should carry over rather
+     * than overwrite. A theme changes only the glass MATERIAL.
      */
     fun withPersonalFrom(other: PlayerGlassSettings): PlayerGlassSettings = copy(
         sampleRings = other.sampleRings,
         tintColor = other.tintColor,
         previewBg = other.previewBg,
+        miniProgressBar = other.miniProgressBar,
     )
 
     /**

--- a/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
+++ b/app/src/main/java/tf/monochrome/android/player/PlaybackService.kt
@@ -29,7 +29,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -149,7 +152,7 @@ class PlaybackService : MediaSessionService() {
         )
     }
 
-    @OptIn(UnstableApi::class)
+    @OptIn(UnstableApi::class, FlowPreview::class)
     override fun onCreate() {
         super.onCreate()
 
@@ -583,7 +586,17 @@ class PlaybackService : MediaSessionService() {
                     tone = v[5] as tf.monochrome.android.domain.model.ToneControls,
                     systemWide = v[6] as Boolean,
                 )
-            }.collect { applyEqSettings(it) }
+            }
+                // DataStore re-emits its whole Preferences on EVERY write to
+                // ANY key, so without this dedup an unrelated setting change
+                // re-decodes every band and rebuilds the entire filter chain.
+                // Same reasoning as SystemAudioEqController's observer.
+                .distinctUntilChanged()
+                // Coalesce EQ slider and graph drags. The editors already hold
+                // their writes back to the tail of a gesture; this bounds the
+                // rebuild rate for every other producer of these keys too.
+                .debounce(EQ_APPLY_DEBOUNCE_MS)
+                .collectLatest { applyEqSettings(it) }
         }
 
         // Listen to Parametric EQ changes and apply them
@@ -594,9 +607,12 @@ class PlaybackService : MediaSessionService() {
                 preferences.paramEqPreamp
             ) { enabled, bandsJson, preamp ->
                 Triple(enabled, bandsJson, preamp)
-            }.collect { (enabled, bandsJson, preamp) ->
-                applyParametricEqSettings(enabled, bandsJson, preamp)
             }
+                .distinctUntilChanged()
+                .debounce(EQ_APPLY_DEBOUNCE_MS)
+                .collectLatest { (enabled, bandsJson, preamp) ->
+                    applyParametricEqSettings(enabled, bandsJson, preamp)
+                }
         }
 
         // Restore DSP mixer state when the native engine becomes ready
@@ -1067,6 +1083,9 @@ class PlaybackService : MediaSessionService() {
         }
     }
 
+    /** Shared by both EQ appliers; these were built fresh on every apply. */
+    private val eqJson = Json { ignoreUnknownKeys = true }
+
     @Volatile private var lastAutoEq = AppliedEq.NONE
     @Volatile private var lastParametricEq = AppliedEq.NONE
 
@@ -1245,6 +1264,13 @@ class PlaybackService : MediaSessionService() {
     private companion object {
         /** Retries a failing position before moving past it. */
         const val MAX_CONSECUTIVE_PLAYER_ERRORS = 2
+
+        /**
+         * How long an EQ preference change settles before the filter chain is
+         * rebuilt. Short enough to read as instant on a slider release, long
+         * enough that a drag can never rebuild every biquad frame by frame.
+         */
+        const val EQ_APPLY_DEBOUNCE_MS = 60L
 
         /**
          * The same, for a live station. Far more generous, and deliberately so:
@@ -1503,10 +1529,9 @@ class PlaybackService : MediaSessionService() {
                 lastAutoEq = AppliedEq(emptyList(), emptyList(), 0f, false)
                 return
             }
-            val json = Json { ignoreUnknownKeys = true }
             fun decode(bandsJson: String?): List<EqBand> =
                 if (cfg.enabled && !bandsJson.isNullOrEmpty()) {
-                    json.decodeFromString(bandsJson)
+                    eqJson.decodeFromString(bandsJson)
                 } else {
                     emptyList()
                 }
@@ -1548,8 +1573,7 @@ class PlaybackService : MediaSessionService() {
     private fun applyParametricEqSettings(enabled: Boolean, bandsJson: String?, preamp: Double) {
         try {
             val bands = if (!bandsJson.isNullOrEmpty()) {
-                val json = Json { ignoreUnknownKeys = true }
-                json.decodeFromString<List<EqBand>>(bandsJson)
+                eqJson.decodeFromString<List<EqBand>>(bandsJson)
             } else {
                 emptyList()
             }

--- a/app/src/main/java/tf/monochrome/android/radio/LocalRadioPlanner.kt
+++ b/app/src/main/java/tf/monochrome/android/radio/LocalRadioPlanner.kt
@@ -1,0 +1,259 @@
+package tf.monochrome.android.radio
+
+import tf.monochrome.android.domain.model.Track
+import kotlin.math.abs
+
+/**
+ * Where a candidate came from. The origin is itself a ranking signal — a track
+ * pulled from the seed artist's own catalogue means something different from
+ * one that fell out of a broad search — so it is carried alongside the track
+ * rather than being flattened into list order.
+ */
+enum class CandidateOrigin(
+    /** Key the planner service uses for this source in `source_boosts`. */
+    val boostKey: String,
+) {
+    /** The seed artist's own top tracks. */
+    SEED_ARTIST("seed_artist"),
+
+    /** Top tracks of an artist the catalogue calls similar to the seed. */
+    SIMILAR_ARTIST("similar_artist"),
+
+    /** Broad catalogue search — query expansion, artist-name search. */
+    SEARCH("search"),
+
+    /** The remote planner named this track specifically. */
+    PLANNER_HINT("planner_hint"),
+}
+
+/**
+ * A candidate track plus the on-device context needed to score it.
+ *
+ * [artistDistance] is how far the candidate's artist sits from the seed's:
+ * `0` is the seed artist, `1..n` its position in the catalogue's similar-artist
+ * list, `null` unknown (a search result whose artist was never related back).
+ */
+data class RadioCandidate(
+    val track: Track,
+    val origin: CandidateOrigin,
+    val fromQobuz: Boolean = true,
+    val inLibrary: Boolean = false,
+    val artistDistance: Int? = null,
+)
+
+/**
+ * What the listener's device already knows about them. Keys are the same
+ * normalized `artist|title` form [RadioQueueManager] dedupes on, so a remaster
+ * counts as the same song as the original.
+ */
+data class RadioTasteContext(
+    val seed: Track,
+    /** Recently played, most recent first. */
+    val historyKeys: List<String> = emptyList(),
+    /** Favourites, downloads and anything else held on-device. */
+    val libraryKeys: Set<String> = emptySet(),
+    /**
+     * Per-source multipliers from the remote planner's `source_boosts`, when
+     * one is configured. Absent sources default to neutral, so this is purely
+     * additive over the on-device scoring.
+     */
+    val sourceBoosts: Map<String, Float> = emptyMap(),
+)
+
+/** A candidate with its score and the per-signal breakdown that produced it. */
+data class ScoredCandidate(
+    val candidate: RadioCandidate,
+    val score: Float,
+    val signals: Map<String, Float>,
+)
+
+/**
+ * Ranks radio candidates on-device, using the user's planner weights.
+ *
+ * The remote planner is a *source* of candidates, not the brain: it can name
+ * tracks the catalogue alone would not have surfaced, and it is genuinely
+ * better at that. But making it the only thing that reads the weights meant
+ * that without a server — unconfigured, offline, or rejecting the request
+ * shape — every knob in Settings › Radio did nothing, and radio fell back to
+ * "the seed artist's top tracks, in catalogue order". Scoring here means the
+ * weights are honoured whether or not a planner is reachable, and a reachable
+ * planner just adds better raw material to rank.
+ *
+ * Each signal below is normalized to roughly `0..1` (or `-1..1` where it cuts
+ * both ways) and multiplied by its weight, so a weight of `0` silences its
+ * signal, `1` is neutral, and `3` lets one signal dominate — which is exactly
+ * what the slider's 0–3 range promises.
+ *
+ * Three weights are NOT scored here and cannot be: mood continuity needs audio
+ * features the app does not compute, and the MetaBrainz and ListenBrainz
+ * weights describe datasets that live off-device. They are still sent to the
+ * planner when one is configured. [LOCAL_SIGNALS] names what this class
+ * actually acts on, and the settings screen reads it so the UI cannot quietly
+ * drift from the truth.
+ */
+class LocalRadioPlanner {
+
+    /**
+     * Best-first ranking. Deterministic: equal scores keep their input order,
+     * so a given seed and library produce a stable station rather than
+     * reshuffling under the listener between refills.
+     */
+    fun rank(
+        candidates: List<RadioCandidate>,
+        context: RadioTasteContext,
+        weights: RadioPlannerWeights,
+    ): List<ScoredCandidate> =
+        candidates.map { score(it, context, weights) }.sortedByDescending { it.score }
+
+    /** The score for one candidate, with every signal's contribution itemized. */
+    fun score(
+        candidate: RadioCandidate,
+        context: RadioTasteContext,
+        weights: RadioPlannerWeights,
+    ): ScoredCandidate {
+        val w = weights.clamped()
+        val key = candidate.track.tasteKey()
+        val heard = key in context.historyKeys || key in context.libraryKeys
+
+        val signals = buildMap {
+            put(SIGNAL_LOCAL_LIBRARY, w.localLibrary * if (candidate.inLibrary) 1f else 0f)
+            put(SIGNAL_QOBUZ, w.qobuz * if (candidate.fromQobuz) 1f else 0f)
+            put(SIGNAL_DISCOVERY_EXPANSION, w.spotifyDiscovery * candidate.origin.expansionSignal())
+            put(SIGNAL_CANONICAL, w.canonicalVersionBias * candidate.track.canonicalSignal())
+            put(SIGNAL_NOVELTY, w.novelty * if (heard) 0f else 1f)
+            put(SIGNAL_FAMILIARITY, w.familiarity * if (heard) 1f else 0f)
+            put(SIGNAL_ARTIST_SIMILARITY, w.artistSimilarity * closeness(candidate.artistDistance))
+            put(SIGNAL_GENRE, w.genreTagSimilarity * genreMatch(context.seed, candidate.track))
+            put(SIGNAL_ERA, w.eraConsistency * eraCloseness(context.seed, candidate.track))
+            // The only signal that subtracts: everything else argues for a
+            // candidate, this one argues against one you just heard.
+            put(SIGNAL_AVOID_RECENT, -w.avoidRecentlyPlayed * recency(key, context.historyKeys))
+            put(SIGNAL_DISCOVERY_DISTANCE, w.discoveryDistance * drift(candidate.artistDistance))
+        }
+
+        // A configured planner can scale whole sources up or down; with no
+        // planner (or no opinion from it) this is 1.0 and changes nothing.
+        val boost = context.sourceBoosts[candidate.origin.boostKey]
+            ?.takeIf { it.isFinite() && it >= 0f }
+            ?: 1f
+
+        return ScoredCandidate(candidate, signals.values.sum() * boost, signals)
+    }
+
+    // ── Signals ───────────────────────────────────────────────────────────
+
+    /** Broad search is what "widens the pool"; targeted origins are not. */
+    private fun CandidateOrigin.expansionSignal(): Float = when (this) {
+        CandidateOrigin.SEARCH -> 1f
+        CandidateOrigin.PLANNER_HINT -> 0.5f
+        CandidateOrigin.SEED_ARTIST, CandidateOrigin.SIMILAR_ARTIST -> 0f
+    }
+
+    /** `1` for the seed artist, decaying with similar-artist position. */
+    private fun closeness(distance: Int?): Float =
+        if (distance == null) 0f else 1f / (1f + distance.coerceAtLeast(0))
+
+    /** The mirror of [closeness]: rewards drifting away from the seed. */
+    private fun drift(distance: Int?): Float =
+        if (distance == null) UNKNOWN_ARTIST_DRIFT
+        else distance.coerceAtLeast(0).let { it / (1f + it) }
+
+    private fun genreMatch(seed: Track, candidate: Track): Float {
+        val seedGenre = seed.album?.genreSlug ?: seed.album?.genre ?: return 0f
+        val candidateGenre = candidate.album?.genreSlug ?: candidate.album?.genre ?: return 0f
+        return if (seedGenre.equals(candidateGenre, ignoreCase = true)) 1f else 0f
+    }
+
+    /** Full credit for the same year, fading to nothing [ERA_SPAN_YEARS] apart. */
+    private fun eraCloseness(seed: Track, candidate: Track): Float {
+        val seedYear = seed.releaseYear() ?: return 0f
+        val candidateYear = candidate.releaseYear() ?: return 0f
+        val gap = abs(seedYear - candidateYear)
+        return (1f - gap / ERA_SPAN_YEARS.toFloat()).coerceAtLeast(0f)
+    }
+
+    /** `1` for the very last thing played, fading out across the history window. */
+    private fun recency(key: String, historyKeys: List<String>): Float {
+        val index = historyKeys.indexOf(key)
+        if (index < 0) return 0f
+        return 1f - index.toFloat() / historyKeys.size
+    }
+
+    companion object {
+        /**
+         * The weights this planner actually acts on without a server. The
+         * settings screen reads this so a weight cannot claim on-device effect
+         * it does not have; anything absent is sent to the planner and scored
+         * there, or not at all.
+         */
+        val LOCAL_SIGNALS: Set<String> = setOf(
+            SIGNAL_LOCAL_LIBRARY,
+            SIGNAL_QOBUZ,
+            SIGNAL_DISCOVERY_EXPANSION,
+            SIGNAL_CANONICAL,
+            SIGNAL_NOVELTY,
+            SIGNAL_FAMILIARITY,
+            SIGNAL_ARTIST_SIMILARITY,
+            SIGNAL_GENRE,
+            SIGNAL_ERA,
+            SIGNAL_AVOID_RECENT,
+            SIGNAL_DISCOVERY_DISTANCE,
+        )
+
+        /** Release years further apart than this share no era at all. */
+        const val ERA_SPAN_YEARS = 25
+
+        /**
+         * Drift credit for a candidate whose artist was never related back to
+         * the seed. It came from a search rather than the similarity graph, so
+         * it is probably far — but "unknown" is not the same as "distant", so
+         * it scores below a confirmed hop out.
+         */
+        const val UNKNOWN_ARTIST_DRIFT = 0.6f
+    }
+}
+
+// Signal names double as the map keys in [ScoredCandidate.signals], so a test
+// (or a debug readout) can point at exactly which weight moved a track.
+const val SIGNAL_LOCAL_LIBRARY = "local_library"
+const val SIGNAL_QOBUZ = "qobuz"
+const val SIGNAL_DISCOVERY_EXPANSION = "discovery_expansion"
+const val SIGNAL_CANONICAL = "canonical_version"
+const val SIGNAL_NOVELTY = "novelty"
+const val SIGNAL_FAMILIARITY = "familiarity"
+const val SIGNAL_ARTIST_SIMILARITY = "artist_similarity"
+const val SIGNAL_GENRE = "genre_tag_similarity"
+const val SIGNAL_ERA = "era_consistency"
+const val SIGNAL_AVOID_RECENT = "avoid_recently_played"
+const val SIGNAL_DISCOVERY_DISTANCE = "discovery_distance"
+
+/**
+ * Release strings that mark a track as a non-canonical presentation of a song
+ * the listener probably already has. Matched on word boundaries so "Alive"
+ * isn't a live take and "Editorial" isn't a radio edit.
+ */
+private val NON_CANONICAL = Regex(
+    "\\b(" +
+        "remaster(ed)?|remix(es|ed)?|live|acoustic|instrumental|karaoke|demo|" +
+        "radio edit|single version|album version|re-?recorded|rerecorded|" +
+        "mono|stereo version|edit|version|mix" +
+        ")\\b",
+    RegexOption.IGNORE_CASE,
+)
+
+/** `+1` for a plain studio recording, `-1` for a remaster/live/edit. */
+internal fun Track.canonicalSignal(): Float {
+    val text = listOfNotNull(title, version, album?.version).joinToString(" ")
+    return if (NON_CANONICAL.containsMatchIn(text)) -1f else 1f
+}
+
+/** Four-digit release year, or null when the catalogue didn't supply one. */
+internal fun Track.releaseYear(): Int? = album?.releaseYear?.toIntOrNull()
+
+/**
+ * The identity radio treats as "the same song" — matching [RadioQueueManager]'s
+ * dedupe key, so a remaster of something in the listener's history is
+ * recognized as already heard.
+ */
+internal fun Track.tasteKey(): String =
+    "$displayArtist|$title".lowercase().filter { it.isLetterOrDigit() || it == '|' }

--- a/app/src/main/java/tf/monochrome/android/radio/RadioPlannerClient.kt
+++ b/app/src/main/java/tf/monochrome/android/radio/RadioPlannerClient.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import tf.monochrome.android.data.preferences.PreferencesManager
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -31,13 +30,8 @@ class RadioPlannerClient @Inject constructor(
     private val httpClient: HttpClient,
     private val preferences: PreferencesManager,
 ) {
-    // Own Json config: encodeDefaults so neutral weights are still sent
-    // explicitly, ignoreUnknownKeys so server additions never break decoding.
-    private val json = Json {
-        encodeDefaults = true
-        ignoreUnknownKeys = true
-        explicitNulls = false
-    }
+    // See [plannerJson] for why this config is shared rather than private here.
+    private val json = plannerJson
 
     /** True when the planner is enabled and has both a URL and an API key. */
     suspend fun isConfigured(): Boolean {

--- a/app/src/main/java/tf/monochrome/android/radio/RadioPlannerModels.kt
+++ b/app/src/main/java/tf/monochrome/android/radio/RadioPlannerModels.kt
@@ -2,6 +2,26 @@ package tf.monochrome.android.radio
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The wire encoder for every planner call.
+ *
+ * `encodeDefaults` so neutral weights are still sent explicitly — a weight the
+ * user left at 1.0 still has to reach the server, because the server's own
+ * default for that signal is not necessarily neutral. `ignoreUnknownKeys` so
+ * server additions never break decoding, `explicitNulls` off so absent optional
+ * context is omitted rather than sent as null.
+ *
+ * Shared (rather than private to [RadioPlannerClient]) so tests assert against
+ * the encoder that actually produces request bodies instead of a lookalike that
+ * could drift from it.
+ */
+internal val plannerJson: Json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+    explicitNulls = false
+}
 
 /**
  * Compact identity for a track, used for MetaBrainz matching on the planner

--- a/app/src/main/java/tf/monochrome/android/radio/RadioQueueManager.kt
+++ b/app/src/main/java/tf/monochrome/android/radio/RadioQueueManager.kt
@@ -26,19 +26,23 @@ import javax.inject.Singleton
 
 /**
  * The radio "queue maker" for the Qobuz (trypt-hifi) catalog: seeds from the
- * playing track, asks the Tryptify-Playlist planner for query/candidate
- * hints, resolves everything against the configured Qobuz instance, and
- * appends batches through [QueueManager]. Refills as the listener nears the
- * queue tail.
+ * playing track, gathers candidates, ranks them against the listener's
+ * recommendation weights, and appends batches through [QueueManager]. Refills
+ * as the listener nears the queue tail.
+ *
+ * Ranking is on-device, in [LocalRadioPlanner], and always runs. The remote
+ * Tryptify-Playlist planner is one optional *source* of candidates among
+ * several — it is good at naming tracks the catalog alone wouldn't surface —
+ * but it is not required for the weights to work, and radio is fully
+ * functional with it switched off. When it is configured its `source_boosts`
+ * additionally scale whole candidate sources during ranking.
  *
  * Resolution is Qobuz-first by design — `searchQobuz` registers every
  * returned id in [QobuzIdRegistry], so appended tracks play through the
- * QobuzCached path on the configured instance. The planner is advisory only:
- * candidates are always validated against the catalog, and when the planner
- * is unconfigured or down the station keeps running on Qobuz artist
- * top-tracks and similar-artist expansion. TIDAL is used only as a last
- * resort when no Qobuz instance is configured at all. This class never
- * mutates ExoPlayer; all queue changes flow through [QueueManager].
+ * QobuzCached path on the configured instance. Candidates are always
+ * validated against the catalog, whatever suggested them. TIDAL is used only
+ * as a last resort when no Qobuz instance is configured at all. This class
+ * never mutates ExoPlayer; all queue changes flow through [QueueManager].
  */
 @Singleton
 class RadioQueueManager @Inject constructor(
@@ -51,6 +55,9 @@ class RadioQueueManager @Inject constructor(
     private val qobuzIdRegistry: QobuzIdRegistry,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /** Ranks every batch against the user's weights, planner or no planner. */
+    private val localPlanner = LocalRadioPlanner()
 
     private val _isActive = MutableStateFlow(false)
     val isActive: StateFlow<Boolean> = _isActive.asStateFlow()
@@ -166,7 +173,7 @@ class RadioQueueManager @Inject constructor(
         val plan = requestPlan(seed, history)
         _statusMessage.value = when {
             !qobuzConfigured -> "No Qobuz instance set — using TIDAL fallback"
-            plan == null -> "Using Qobuz similar-artist recommendations"
+            plan == null -> null
             plan.fallbackReason != null -> "Planner fallback: ${plan.fallbackReason}"
             else -> null
         }
@@ -187,35 +194,76 @@ class RadioQueueManager @Inject constructor(
                 .filter { it.isNotBlank() }
                 .take(MAX_QUERIES)
                 .map { query ->
-                    async { search(query).take(5) }
+                    async {
+                        search(query).take(5).map {
+                            RadioCandidate(it, CandidateOrigin.SEARCH, fromQobuz = qobuzConfigured)
+                        }
+                    }
                 }
-            // Deterministic backbone so radio works with the planner disabled
-            // and pads out thin planner batches. Qobuz: seed artist's top
-            // tracks + similar-artist expansion. TIDAL (unconfigured Qobuz
-            // only): catalog track radio.
+            // The on-device backbone. Radio runs on this alone when no planner
+            // is configured — Qobuz: the seed artist's top tracks plus
+            // similar-artist expansion; TIDAL (unconfigured Qobuz only):
+            // catalog track radio.
             val backbone = async {
-                if (qobuzConfigured) qobuzBackbone(seed)
-                else repository.getRecommendations(seed.id).getOrDefault(emptyList())
+                if (qobuzConfigured) {
+                    qobuzBackbone(seed)
+                } else {
+                    repository.getRecommendations(seed.id).getOrDefault(emptyList()).map {
+                        RadioCandidate(it, CandidateOrigin.SEARCH, fromQobuz = false)
+                    }
+                }
             }
-            val hints = hintResults.mapNotNull { it.await() }
-            val queries = queryResults.flatMap { it.await() }
-            // Hints are the planner's strongest signal; the backbone next;
-            // broad query results last.
-            hints + backbone.await() + queries
+            val hints = hintResults.mapNotNull { it.await() }.map {
+                RadioCandidate(it, CandidateOrigin.PLANNER_HINT, fromQobuz = qobuzConfigured)
+            }
+            hints + backbone.await() + queryResults.flatMap { it.await() }
         }
 
-        val historyIds = history.map { it.id }.toSet()
-        val historyKeys = history.map { titleKey(it) }.toSet()
-        return candidates
+        // Rank on-device against the user's weights. This is what makes those
+        // sliders mean something with no planner configured — previously the
+        // order was just hints, then backbone, then queries, and the weights
+        // were only ever read by the remote service.
+        val libraryKeys = libraryKeys()
+        val ranked = localPlanner.rank(
+            candidates = candidates.map { it.copy(inLibrary = titleKey(it.track) in libraryKeys) },
+            context = RadioTasteContext(
+                seed = seed,
+                historyKeys = history.map { titleKey(it) },
+                libraryKeys = libraryKeys,
+                // Previously decoded and thrown away; now it scales whole
+                // sources when a planner has an opinion about them.
+                sourceBoosts = plan?.sourceBoosts.orEmpty(),
+            ),
+            weights = preferences.radioPlannerWeights.first(),
+        )
+
+        // History is no longer filtered out outright — "avoid recently played"
+        // is a weight, and a hard filter is the one setting of it the user
+        // cannot change. It is a strong penalty instead, so recent tracks sink
+        // to the bottom of the pool and only resurface when the alternative is
+        // an empty batch, which is what used to stop the station dead.
+        return ranked
             .asSequence()
+            .map { it.candidate.track }
             .filter { it.id != seed.id }
-            .filter { it.id !in seenTrackIds && it.id !in historyIds }
-            .filter { titleKey(it) !in seenTitleKeys && titleKey(it) !in historyKeys }
+            .filter { it.id !in seenTrackIds }
+            .filter { titleKey(it) !in seenTitleKeys }
             .distinctBy { it.id }
             .distinctBy { titleKey(it) }
             .take(BATCH_SIZE)
             .toList()
     }
+
+    /**
+     * Songs the listener already holds on-device — favourites and completed
+     * downloads — as dedupe keys, for the "local library" weight.
+     */
+    private suspend fun libraryKeys(): Set<String> = runCatching {
+        val favorites = libraryRepository.getFavoriteTracks().first().map { titleKey(it) }
+        val downloads = libraryRepository.getDownloadedTracks().first()
+            .map { keyOf(it.artistName, it.title) }
+        (favorites + downloads).toSet()
+    }.getOrDefault(emptySet())
 
     /**
      * Qobuz on-device backbone: the seed artist's top tracks plus the top
@@ -224,23 +272,39 @@ class RadioQueueManager @Inject constructor(
      * playback), padded with a plain artist search when the seed's Qobuz
      * artist id isn't known.
      */
-    private suspend fun qobuzBackbone(seed: Track): List<Track> = coroutineScope {
+    private suspend fun qobuzBackbone(seed: Track): List<RadioCandidate> = coroutineScope {
         val artistId = seedQobuzArtistId(seed)
         val detail = artistId?.let { repository.getQobuzArtist(it).getOrNull() }
+        // Position in the similar-artist list IS the distance from the seed —
+        // the signal both "artist similarity" and "discovery distance" score
+        // against — so it is captured here rather than lost in a flat list.
         val similarTops = detail?.similarArtists.orEmpty()
             .take(MAX_SIMILAR_ARTISTS)
-            .map { artist ->
+            .mapIndexed { index, artist ->
                 async {
                     repository.getQobuzArtist(artist.id).getOrNull()
                         ?.topTracks.orEmpty().take(TOP_TRACKS_PER_ARTIST)
+                        .map {
+                            RadioCandidate(
+                                it,
+                                CandidateOrigin.SIMILAR_ARTIST,
+                                artistDistance = index + 1,
+                            )
+                        }
                 }
             }
         val artistSearch = async {
             val artistName = seed.displayArtist
-            if (artistName.isBlank()) emptyList()
-            else searchQobuzTracks(artistName).take(TOP_TRACKS_PER_ARTIST)
+            if (artistName.isBlank()) {
+                emptyList()
+            } else {
+                searchQobuzTracks(artistName).take(TOP_TRACKS_PER_ARTIST).map {
+                    RadioCandidate(it, CandidateOrigin.SEARCH, artistDistance = 0)
+                }
+            }
         }
-        detail?.topTracks.orEmpty().take(TOP_TRACKS_PER_ARTIST) +
+        detail?.topTracks.orEmpty().take(TOP_TRACKS_PER_ARTIST)
+            .map { RadioCandidate(it, CandidateOrigin.SEED_ARTIST, artistDistance = 0) } +
             similarTops.flatMap { it.await() } +
             artistSearch.await()
     }
@@ -322,8 +386,10 @@ class RadioQueueManager @Inject constructor(
         seenTitleKeys += titleKey(track)
     }
 
-    private fun titleKey(track: Track): String =
-        "${track.displayArtist}|${track.title}".lowercase().filter { it.isLetterOrDigit() || it == '|' }
+    private fun titleKey(track: Track): String = keyOf(track.displayArtist, track.title)
+
+    private fun keyOf(artist: String, title: String): String =
+        "$artist|$title".lowercase().filter { it.isLetterOrDigit() || it == '|' }
 
     companion object {
         private const val TAG = "RadioQueueManager"

--- a/app/src/main/java/tf/monochrome/android/ui/components/GlassPanel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/GlassPanel.kt
@@ -37,6 +37,7 @@ import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.performance.LocalLowPerformance
 import tf.monochrome.android.performance.LocalPerformanceProfile
 import tf.monochrome.android.ui.player.LocalPlayerGlass
+import tf.monochrome.android.ui.player.playerFrostTint
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.rememberLiquidGlassAvailable
 import tf.monochrome.android.ui.theme.glassTint
@@ -114,7 +115,14 @@ fun GlassPanel(
                     shaderGlass -> Modifier
                     allowHaze && !flat ->
                         Modifier.liquidGlass(hazeState = hazeState, shape = MonoDimens.shapeLg)
-                    else -> Modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    // Last resort: no shader, no blur. It still must not be a
+                    // fully opaque slab when the listener has asked for
+                    // see-through glass, so body opacity governs this path too
+                    // — floored so text stays readable over raw artwork.
+                    else -> Modifier.background(
+                        MaterialTheme.colorScheme.surfaceContainerHigh
+                            .copy(alpha = glass.bodyOpacity.coerceIn(0.55f, 1f)),
+                    )
                 },
             ),
     ) {
@@ -150,13 +158,10 @@ fun GlassPanel(
             // frost's own base colour as a flat pane, which is the slab this
             // whole component exists not to be.
             if (hazeState != null && allowHaze && glass.hazeBlurDp > 0f) {
-                // The mini player's exact frost. This panel is the same material
-                // as that bar and is usually on screen beside it, so the numbers
-                // are the same numbers rather than a second set that drifts.
-                val frostTint = (
-                    if (isDark) Color.Black.copy(alpha = 0.32f)
-                    else Color.White.copy(alpha = 0.45f)
-                    ).let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
+                // The mini player's exact frost, from the one shared recipe —
+                // this panel is the same material as that bar and is usually on
+                // screen beside it.
+                val frostTint = playerFrostTint(glass, isDark)
                 Box(
                     Modifier
                         .matchParentSize()

--- a/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
@@ -104,6 +104,11 @@ fun MiniPlayer(
     // hasn't turned button glass off. Below that, keep the old haze bar + Material
     // icons — a punched slab with no shader would be an opaque block.
     val glass = LocalPlayerGlass.current
+    // The progress line is also the bar's top border. With it off the bar
+    // must close up, so the height it reserves goes to zero everywhere it is
+    // used — including the control-hole centring maths below, which would
+    // otherwise punch the play/skip holes 2dp above the icons they reveal.
+    val progressHeight = if (glass.miniProgressBar) MiniProgressHeight else 0.dp
     val useGlass = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && glass.enabled
 
     val swipeGestures = Modifier.pointerInput(Unit) {
@@ -146,7 +151,7 @@ fun MiniPlayer(
                 .clickable(interactionSource = null, indication = null, onClick = onClick)
                 .then(swipeGestures)
         ) {
-            MiniPlayerContent(track, progressProvider, blendMillis, userTrackChanges) {
+            MiniPlayerContent(track, progressProvider, blendMillis, userTrackChanges, glass.miniProgressBar) {
                 IconButton(onClick = onPlayPauseClick) {
                     Icon(
                         imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
@@ -201,13 +206,13 @@ fun MiniPlayer(
 
     val density = LocalDensity.current
     var barSize by remember { mutableStateOf(IntSize.Zero) }
-    val controlCenter = remember(barSize, lastControl) {
+    val controlCenter = remember(barSize, lastControl, progressHeight) {
         if (barSize.width == 0 || barSize.height == 0) {
             Offset(0.85f, 0.5f)
         } else with(density) {
             val cell = MiniControlCell.toPx()
             val pad = MonoDimens.spacingMd.toPx()
-            val cyPx = MiniProgressHeight.toPx() + MonoDimens.spacingSm.toPx() + cell / 2f
+            val cyPx = progressHeight.toPx() + MonoDimens.spacingSm.toPx() + cell / 2f
             val cx = barSize.width - pad - (if (lastControl == 1) 0.5f else 1.5f) * cell
             Offset((cx / barSize.width).coerceIn(0f, 1f), (cyPx / barSize.height).coerceIn(0f, 1f))
         }
@@ -286,7 +291,7 @@ fun MiniPlayer(
             val padPx = MonoDimens.spacingMd.toPx()
             // Row content centre = progress line + row top padding + half the
             // (48dp) control cell — the tallest child, so the row's content box.
-            val cy = MiniProgressHeight.toPx() + MonoDimens.spacingSm.toPx() + cellPx / 2f
+            val cy = progressHeight.toPx() + MonoDimens.spacingSm.toPx() + cellPx / 2f
             // Rightmost cell is skip-next, the one before it is play/pause; both
             // inset from the right edge by the row's horizontal padding.
             val skipCx = size.width - padPx - cellPx * 0.5f
@@ -315,7 +320,7 @@ fun MiniPlayer(
         // Transparent content overlay: progress, cover, text, and the two tap
         // targets sitting exactly over the punched holes (same trailing cells).
         // No ripple indication — the glass press-bulge is the feedback.
-        MiniPlayerContent(track, progressProvider, blendMillis, userTrackChanges) {
+        MiniPlayerContent(track, progressProvider, blendMillis, userTrackChanges, glass.miniProgressBar) {
             Box(
                 modifier = Modifier
                     .size(MiniControlCell)
@@ -351,17 +356,20 @@ private fun MiniPlayerContent(
     progressProvider: () -> Float,
     blendMillis: Int,
     userTrackChanges: Int,
+    showProgress: Boolean,
     controls: @Composable () -> Unit,
 ) {
     Column {
-        LinearProgressIndicator(
-            progress = { progressProvider().coerceIn(0f, 1f) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(MiniProgressHeight),
-            color = MaterialTheme.colorScheme.primary,
-            trackColor = MaterialTheme.colorScheme.outline
-        )
+        if (showProgress) {
+            LinearProgressIndicator(
+                progress = { progressProvider().coerceIn(0f, 1f) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(MiniProgressHeight),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = MaterialTheme.colorScheme.outline
+            )
+        }
         Row(
             modifier = Modifier.padding(horizontal = MonoDimens.spacingMd, vertical = MonoDimens.spacingSm),
             verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/MiniPlayer.kt
@@ -71,6 +71,7 @@ import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.theme.glassTint
 import tf.monochrome.android.ui.theme.MonoDimens
 import kotlin.math.abs
+import tf.monochrome.android.ui.player.playerFrostTint
 
 // Geometry shared between the punched holes and the tap-target overlay so they
 // stay aligned across DPI. The two controls are the rightmost fixed-size cells
@@ -247,9 +248,7 @@ fun MiniPlayer(
         if (hazeState != null && profile.allowHazeBlur && glass.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f))
-                .let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
+            val frostTint = playerFrostTint(glass, isDark)
             Box(
                 Modifier
                     .matchParentSize()

--- a/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/components/SwipeToLibraryHint.kt
@@ -36,6 +36,7 @@ import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.playerGlass
 import kotlin.math.floor
 import tf.monochrome.android.ui.theme.glassTint
+import tf.monochrome.android.ui.player.playerFrostTint
 
 private val SlotSpacing = 8.dp
 private val SlotRadius = 2.5.dp
@@ -144,9 +145,7 @@ fun SwipeToLibraryHint(
         if (hazeState != null && profile.allowHazeBlur && glass.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f))
-                .let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
+            val frostTint = playerFrostTint(glass, isDark)
             Box(
                 Modifier
                     .matchParentSize()

--- a/app/src/main/java/tf/monochrome/android/ui/discover/GenreMapScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/discover/GenreMapScreen.kt
@@ -136,6 +136,7 @@ import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.theme.glassTint
 import tf.monochrome.android.ui.theme.MonoDimens
 import tf.monochrome.android.ui.theme.reduceMotion
+import tf.monochrome.android.ui.player.playerFrostTint
 
 /**
  * The genre map — all 771 genres as one picture you can move around in.
@@ -775,9 +776,7 @@ private fun GenreCard(
             // this the map's edges and labels read straight through it and
             // fight the panel's own text.
             if (allowHaze && glass.hazeBlurDp > 0f) {
-                val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
-                    else Color.White.copy(alpha = 0.45f))
-                    .let { it.copy(alpha = (it.alpha * glass.hazeTint).coerceIn(0f, 1f)) }
+                val frostTint = playerFrostTint(glass, isDark)
                 Box(
                     Modifier
                         .matchParentSize()

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqViewModel.kt
@@ -165,6 +165,14 @@ class EqViewModel @Inject constructor(
         _toneControls.asStateFlow()
     private var tonePersistJob: kotlinx.coroutines.Job? = null
 
+    // Drag-tail persistence. One Json instance rather than one per save (these
+    // used to be constructed per call, i.e. per drag frame), and one in-flight
+    // job per key so a coalesced write can be superseded by the next edit.
+    private val persistJson = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+    private var bandsPersistJob: kotlinx.coroutines.Job? = null
+    private var bandsRPersistJob: kotlinx.coroutines.Job? = null
+    private var preampPersistJob: kotlinx.coroutines.Job? = null
+
     private val _availableTargets = MutableStateFlow<List<EqTarget>>(FrequencyTargets.getAllTargets())
     val availableTargets: StateFlow<List<EqTarget>> = _availableTargets.asStateFlow()
 
@@ -514,7 +522,7 @@ class EqViewModel @Inject constructor(
 
             // Update preferences
             preferences.setEqActivePreset(presetId)
-            preferences.setEqPreamp(preset.preamp.toDouble())
+            persistPreamp(preset.preamp.toDouble())
             preferences.setEqTarget(preset.targetId)
 
             // Update UI
@@ -539,7 +547,7 @@ class EqViewModel @Inject constructor(
             if (indexR >= 0) {
                 updatedR[indexR] = newBand
                 _currentBandsR.value = updatedR
-                saveBandsRToPreferences(updatedR)
+                saveBandsRToPreferences(updatedR, coalesce = true)
             }
             return
         }
@@ -548,7 +556,7 @@ class EqViewModel @Inject constructor(
         if (index >= 0) {
             updatedBands[index] = newBand
             _currentBands.value = updatedBands
-            saveBandsToPreferences(updatedBands)
+            saveBandsToPreferences(updatedBands, coalesce = true)
         }
     }
 
@@ -571,8 +579,21 @@ class EqViewModel @Inject constructor(
         val headroom = (EqLimits.AUTOEQ_MAX_TOTAL_DB - peakBand).coerceAtLeast(0f)
         val clamped = preamp.coerceIn(-headroom, headroom)
         _currentPreamp.value = clamped
-        viewModelScope.launch {
-            preferences.setEqPreamp(clamped.toDouble())
+        // Same drag-tail treatment as the bands: the slider is continuous and
+        // the audio path re-applies the whole chain off this preference.
+        persistPreamp(clamped.toDouble(), coalesce = true)
+    }
+
+    /**
+     * Single writer for the preamp preference, so an immediate write (reset,
+     * preset load, auto-preamp) always cancels a drag's pending tail rather
+     * than being overwritten by it a moment later.
+     */
+    private fun persistPreamp(value: Double, coalesce: Boolean = false) {
+        preampPersistJob?.cancel()
+        preampPersistJob = viewModelScope.launch {
+            if (coalesce) kotlinx.coroutines.delay(PERSIST_DEBOUNCE_MS)
+            preferences.setEqPreamp(value)
         }
     }
 
@@ -739,7 +760,7 @@ class EqViewModel @Inject constructor(
         // briefly sets the stored preamp before the recompute lands.
         if (kotlin.math.abs(auto - _currentPreamp.value) < 0.01f) return
         _currentPreamp.value = auto
-        viewModelScope.launch { preferences.setEqPreamp(auto.toDouble()) }
+        persistPreamp(auto.toDouble())
     }
 
     /**
@@ -773,6 +794,9 @@ class EqViewModel @Inject constructor(
 
     private companion object {
         const val AUTO_PREAMP_GRID_POINTS = 96
+
+        /** Drag-tail delay before a continuous edit reaches DataStore. */
+        const val PERSIST_DEBOUNCE_MS = 120L
 
         // Canonical rate for the fit/graph response model. With matched
         // (decramped) coefficients the modeled response is rate-invariant to
@@ -812,9 +836,7 @@ class EqViewModel @Inject constructor(
             _currentBandsR.value = flatR
             saveBandsRToPreferences(flatR)
         }
-        viewModelScope.launch {
-            preferences.setEqPreamp(0.0)
-        }
+        persistPreamp(0.0)
     }
 
     /**
@@ -916,7 +938,7 @@ class EqViewModel @Inject constructor(
                     // manual preamp adopts the file's value.
                     if (!_autoPreamp.value) {
                         _currentPreamp.value = preamp
-                        preferences.setEqPreamp(preamp.toDouble())
+                        persistPreamp(preamp.toDouble())
                     }
                     // "Upload" means HEAR it — enabling beats silently
                     // importing into a bypassed EQ.
@@ -1423,10 +1445,10 @@ class EqViewModel @Inject constructor(
             )
             if (editRight) {
                 _currentBandsR.value = updatedBands
-                saveBandsRToPreferences(updatedBands)
+                saveBandsRToPreferences(updatedBands, coalesce = true)
             } else {
                 _currentBands.value = updatedBands
-                saveBandsToPreferences(updatedBands)
+                saveBandsToPreferences(updatedBands, coalesce = true)
             }
         }
     }
@@ -1626,39 +1648,48 @@ class EqViewModel @Inject constructor(
 
     // ===== Private Helpers =====
 
-    private fun saveBandsToPreferences(bands: List<EqBand>) {
-        viewModelScope.launch {
+    /**
+     * Persist the band list.
+     *
+     * [coalesce] is for the continuous edits — a slider or graph drag, which
+     * fires dozens of times a second. Each save JSON-encodes every band and
+     * writes DataStore, and the audio path listens to that key: without
+     * coalescing, one drag rebuilt the entire biquad chain (and re-read the
+     * whole preference blob everywhere else watching it) on every frame. The
+     * value still lands a beat after the finger stops. Structural changes
+     * (presets, AutoEQ results, add/remove, import) leave it off and write
+     * straight through — they happen once and must not be lost to a cancel.
+     */
+    private fun saveBandsToPreferences(bands: List<EqBand>, coalesce: Boolean = false) {
+        bandsPersistJob?.cancel()
+        bandsPersistJob = viewModelScope.launch {
             try {
-                val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
-                val bandsJson = json.encodeToString(
-                    kotlinx.serialization.builtins.ListSerializer(
-                        EqBand.serializer()
-                    ),
-                    bands
-                )
-                preferences.setEqBands(bandsJson)
+                if (coalesce) kotlinx.coroutines.delay(PERSIST_DEBOUNCE_MS)
+                preferences.setEqBands(encodeBands(bands))
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _error.value = "Failed to save bands: ${e.message}"
             }
         }
     }
 
-    private fun saveBandsRToPreferences(bands: List<EqBand>) {
-        viewModelScope.launch {
+    private fun saveBandsRToPreferences(bands: List<EqBand>, coalesce: Boolean = false) {
+        bandsRPersistJob?.cancel()
+        bandsRPersistJob = viewModelScope.launch {
             try {
-                val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
-                val bandsJson = json.encodeToString(
-                    kotlinx.serialization.builtins.ListSerializer(
-                        EqBand.serializer()
-                    ),
-                    bands
-                )
-                preferences.setEqBandsR(bandsJson)
+                if (coalesce) kotlinx.coroutines.delay(PERSIST_DEBOUNCE_MS)
+                preferences.setEqBandsR(encodeBands(bands))
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _error.value = "Failed to save right-channel bands: ${e.message}"
             }
         }
     }
+
+    private fun encodeBands(bands: List<EqBand>): String = persistJson.encodeToString(
+        kotlinx.serialization.builtins.ListSerializer(EqBand.serializer()),
+        bands,
+    )
 }
 
 /** Which ear a band edit or measurement load targets in 2-channel mode. */

--- a/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/EqualizerScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -292,6 +293,14 @@ fun EqualizerScreen(
                     // Discrete fractional-octave steps, applied to the
                     // measurement before the optimizer runs. Displayed curves
                     // smooth along with it so what you see is what gets EQ'd.
+                    //
+                    // Committed on release, not per frame. Every value change
+                    // re-smooths BOTH ears' measurements (a triangular window
+                    // whose radius reaches 40 points at 100 %) and hands the
+                    // graph fresh curve objects, which re-derives the whole
+                    // response — far too much to run at drag rate. A local
+                    // float keeps the thumb and the % label live meanwhile.
+                    var smoothingDrag by remember(smoothing) { mutableFloatStateOf(smoothing) }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -305,16 +314,15 @@ fun EqualizerScreen(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Slider(
-                            value = smoothing,
-                            onValueChange = {
-                                // 1 % increments, SeapEngine's scale.
-                                viewModel.setSmoothing(it.roundToInt().toFloat().coerceIn(0f, 100f))
-                            },
+                            value = smoothingDrag,
+                            // 1 % increments, SeapEngine's scale.
+                            onValueChange = { smoothingDrag = it.roundToInt().toFloat().coerceIn(0f, 100f) },
+                            onValueChangeFinished = { viewModel.setSmoothing(smoothingDrag) },
                             valueRange = 0f..100f,
                             modifier = Modifier.weight(1f).height(28.dp)
                         )
                         Text(
-                            "${smoothing.roundToInt()}%",
+                            "${smoothingDrag.roundToInt()}%",
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.primary
                         )

--- a/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/FrequencyResponseGraph.kt
@@ -127,72 +127,75 @@ fun FrequencyResponseGraph(
         } else targetCurve
     }
 
+    // ── The shared evaluation axis ────────────────────────────────────────
+    // Every curve below is a sum of the same per-band biquad responses over the
+    // same frequencies, so the axis and its phase tables are built ONCE and the
+    // band responses are computed ONCE per band. Previously each curve walked
+    // its own grid calling the per-point entry point, which redesigns the
+    // filter (sin/cos/pow/sqrt + an allocation) for every single point: a drag
+    // frame with a 500-point measurement and 10 bands re-derived ~15,000
+    // biquads on the main thread, three times over for the three curves.
+    //
+    // The measurement's own frequencies when there is one, otherwise a log grid
+    // (parametric mode). The per-band profile lines used to fall back to a
+    // coarser 96-point grid of their own; they share this one now — same span,
+    // smoother lines, and no second axis to evaluate against.
+    val gridFreqs = remember(originalCurve) { buildGrid(originalCurve) }
+    val grid = remember(gridFreqs, sampleRate) { AutoEqEngine.ResponseGrid(gridFreqs, sampleRate) }
+
+    // Per-band dB response on that axis. Keyed on the BANDS alone: the preamp
+    // and the normalization offset only shift the sum, so dragging the preamp
+    // no longer redesigns a single filter.
+    val bandResponses = remember(grid, eqBands) {
+        eqBands.filter { it.enabled }.map { it to grid.response(it) }
+    }
+    val eqSum = remember(bandResponses, grid) {
+        FloatArray(grid.size).also { out ->
+            for ((_, response) in bandResponses) {
+                for (i in out.indices) out[i] += response[i]
+            }
+        }
+    }
+
     // Calculate corrected curve.
     //  - With measurement: measurement + EQ bands + preamp
     //  - Without measurement (parametric EQ mode): pure EQ response + preamp around the zero baseline
-    val correctedCurve = remember(originalCurve, eqBands, preamp, sampleRate, zeroOffset) {
-        if (originalCurve.isNotEmpty()) {
-            originalCurve.map { point ->
-                var correctedGain = point.gain + preamp
-                eqBands.forEach { band ->
-                    if (band.enabled) {
-                        correctedGain += AutoEqEngine.calculateBiquadResponse(point.freq, band, sampleRate)
-                    }
-                }
-                FrequencyPoint(point.freq, correctedGain)
-            }.filter { it.gain.isFinite() }
-        } else {
-            // Synthesize a smooth EQ response curve across the log-frequency axis
-            val samples = 256
-            val logMin = log10(MIN_FREQ)
-            val logMax = log10(MAX_FREQ)
-            (0 until samples).map { i ->
-                val freq = 10f.pow(logMin + i.toFloat() / (samples - 1) * (logMax - logMin))
-                var g = preamp + zeroOffset
-                eqBands.forEach { band ->
-                    if (band.enabled) g += AutoEqEngine.calculateBiquadResponse(freq, band, sampleRate)
-                }
-                FrequencyPoint(freq, g)
-            }.filter { it.gain.isFinite() }
-        }
+    val correctedCurve = remember(gridFreqs, originalCurve, eqSum, preamp, zeroOffset) {
+        val hasMeasurement = originalCurve.isNotEmpty()
+        List(gridFreqs.size) { i ->
+            val base = if (hasMeasurement) originalCurve[i].gain else zeroOffset
+            FrequencyPoint(gridFreqs[i], base + preamp + eqSum[i])
+        }.filter { it.gain.isFinite() }
     }
 
     // Secondary (other-ear) corrected curve, mirroring correctedCurve. Falls
     // back to the primary measurement when the other ear has no curve of its
     // own yet, so the overlay still shows what that ear's bands would do.
+    val secondaryFreqs = remember(secondaryMeasurement, gridFreqs) {
+        if (secondaryMeasurement.isNotEmpty()) {
+            FloatArray(secondaryMeasurement.size) { secondaryMeasurement[it].freq }
+        } else {
+            gridFreqs
+        }
+    }
+    val secondaryGrid = remember(secondaryFreqs, sampleRate, grid) {
+        if (secondaryFreqs === gridFreqs) grid else AutoEqEngine.ResponseGrid(secondaryFreqs, sampleRate)
+    }
     val secondaryCorrected = remember(
-        secondaryMeasurement, secondaryBands, originalCurve, preamp, sampleRate, zeroOffset,
+        secondaryGrid, secondaryFreqs, secondaryBands, secondaryMeasurement, originalCurve,
+        preamp, zeroOffset,
     ) {
         val bands = secondaryBands
-        if (bands == null) {
+        val hasBase = secondaryMeasurement.isNotEmpty() || originalCurve.isNotEmpty()
+        if (bands == null || (!hasBase && bands.isEmpty())) {
             emptyList()
         } else {
-            val base = secondaryMeasurement.ifEmpty { originalCurve }
-            if (base.isNotEmpty()) {
-                base.map { point ->
-                    var g = point.gain + preamp
-                    bands.forEach { band ->
-                        if (band.enabled) {
-                            g += AutoEqEngine.calculateBiquadResponse(point.freq, band, sampleRate)
-                        }
-                    }
-                    FrequencyPoint(point.freq, g)
-                }.filter { it.gain.isFinite() }
-            } else if (bands.isNotEmpty()) {
-                val samples = 256
-                val logMin = log10(MIN_FREQ)
-                val logMax = log10(MAX_FREQ)
-                (0 until samples).map { i ->
-                    val freq = 10f.pow(logMin + i.toFloat() / (samples - 1) * (logMax - logMin))
-                    var g = preamp + zeroOffset
-                    bands.forEach { band ->
-                        if (band.enabled) g += AutoEqEngine.calculateBiquadResponse(freq, band, sampleRate)
-                    }
-                    FrequencyPoint(freq, g)
-                }.filter { it.gain.isFinite() }
-            } else {
-                emptyList()
-            }
+            val baseCurve = secondaryMeasurement.ifEmpty { originalCurve }
+            val sum = secondaryGrid.sum(bands)
+            List(secondaryFreqs.size) { i ->
+                val base = if (baseCurve.isNotEmpty()) baseCurve[i].gain else zeroOffset
+                FrequencyPoint(secondaryFreqs[i], base + preamp + sum[i])
+            }.filter { it.gain.isFinite() }
         }
     }
 
@@ -220,17 +223,12 @@ fun FrequencyResponseGraph(
     val latestOnBandDragged by rememberUpdatedState(onBandDragged)
 
     // Per-band contribution curves for the profile-line pass (drawn behind the
-    // response). Memoized: 31 bands × a few hundred grid points of biquad
-    // response is too much to recompute inside every Canvas frame during a
-    // drag. Falls back to a log grid when there's no measurement to anchor on.
-    val bandContributions = remember(eqBands, sampleRate, zeroOffset, originalCurve) {
-        val grid: List<Float> =
-            if (originalCurve.isNotEmpty()) originalCurve.map { it.freq }
-            else List(96) { i -> (20.0 * 1000.0.pow(i / 95.0)).toFloat() }
-        eqBands.filter { it.enabled && it.gain != 0f }.map { band ->
-            band to grid.map { f ->
-                FrequencyPoint(f, zeroOffset + AutoEqEngine.calculateBiquadResponse(f, band, sampleRate))
-            }
+    // response). These are the same per-band responses the corrected curve is
+    // summed from, just offset to the baseline instead of added together — so
+    // the profile pass costs a list wrap, not a second round of filter design.
+    val bandContributions = remember(bandResponses, gridFreqs, zeroOffset) {
+        bandResponses.filter { (band, _) -> band.gain != 0f }.map { (band, response) ->
+            band to List(response.size) { i -> FrequencyPoint(gridFreqs[i], zeroOffset + response[i]) }
         }
     }
 
@@ -670,6 +668,23 @@ fun EqProfileMiniGraph(
     }
 }
 
+/**
+ * The frequency axis every band response is evaluated on: the measurement's own
+ * points when there is a measurement, otherwise a log-spaced grid spanning the
+ * graph (parametric mode, where there is nothing to anchor to).
+ */
+private fun buildGrid(measurement: List<FrequencyPoint>): FloatArray {
+    if (measurement.isNotEmpty()) {
+        return FloatArray(measurement.size) { measurement[it].freq }
+    }
+    val samples = 256
+    val logMin = log10(MIN_FREQ)
+    val logMax = log10(MAX_FREQ)
+    return FloatArray(samples) { i ->
+        10f.pow(logMin + i.toFloat() / (samples - 1) * (logMax - logMin))
+    }
+}
+
 private fun buildFreqSamples(minF: Float, maxF: Float, count: Int): List<Float> {
     val logMin = log10(minF)
     val logMax = log10(maxF)
@@ -791,17 +806,30 @@ private fun findNearestBand(
     return nearest
 }
 
+/**
+ * Linear interpolation of [curve] at [freq]. Binary search, not a scan: the
+ * band dots call this once per band inside the draw pass, and the gap shading
+ * calls it 258 times, all against a curve that can run to several hundred
+ * points — the scan made those passes quadratic in the measurement's length.
+ * Measurement curves are ascending in frequency, which is what makes the
+ * search valid; the scan relied on the same ordering.
+ */
 private fun interpolateGain(freq: Float, curve: List<FrequencyPoint>): Float {
     if (curve.isEmpty()) return 0f
     if (freq <= curve.first().freq) return curve.first().gain
     if (freq >= curve.last().freq) return curve.last().gain
-    for (i in 0 until curve.size - 1) {
-        if (freq >= curve[i].freq && freq <= curve[i + 1].freq) {
-            val t = (freq - curve[i].freq) / (curve[i + 1].freq - curve[i].freq)
-            return curve[i].gain + t * (curve[i + 1].gain - curve[i].gain)
-        }
+    // Largest index whose frequency is <= freq; the guards above put it in
+    // 0..size-2, so `hi` is always a valid right-hand neighbour.
+    var lo = 0
+    var hi = curve.size - 1
+    while (hi - lo > 1) {
+        val mid = (lo + hi) ushr 1
+        if (curve[mid].freq <= freq) lo = mid else hi = mid
     }
-    return 0f
+    val span = curve[hi].freq - curve[lo].freq
+    if (span <= 0f) return curve[lo].gain
+    val t = (freq - curve[lo].freq) / span
+    return curve[lo].gain + t * (curve[hi].gain - curve[lo].gain)
 }
 
 // ===== Drawing functions =====

--- a/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/eq/ParametricEqViewModel.kt
@@ -28,6 +28,11 @@ class ParametricEqViewModel @Inject constructor(
 
     private val json = Json { ignoreUnknownKeys = true }
 
+    // Drag-tail persistence: one in-flight job per key, so a coalesced write
+    // can be superseded by the next edit instead of stacking up per frame.
+    private var bandsPersistJob: kotlinx.coroutines.Job? = null
+    private var preampPersistJob: kotlinx.coroutines.Job? = null
+
     private val _enabled = MutableStateFlow(false)
     val enabled: StateFlow<Boolean> = _enabled.asStateFlow()
 
@@ -103,7 +108,7 @@ class ParametricEqViewModel @Inject constructor(
     fun updateBand(band: EqBand) {
         val updated = _currentBands.value.map { if (it.id == band.id) band else it }
         _currentBands.value = updated
-        saveBands(updated)
+        saveBands(updated, coalesce = true)
     }
 
     fun updateBandByDrag(bandId: Int, newFreq: Float, newGain: Float) {
@@ -117,12 +122,12 @@ class ParametricEqViewModel @Inject constructor(
             ) else b
         }
         _currentBands.value = updated
-        saveBands(updated)
+        saveBands(updated, coalesce = true)
     }
 
     fun setPreamp(preamp: Float) {
         _currentPreamp.value = preamp
-        viewModelScope.launch { preferences.setParamEqPreamp(preamp.toDouble()) }
+        persistPreamp(preamp.toDouble(), coalesce = true)
     }
 
     fun addBand() {
@@ -175,7 +180,7 @@ class ParametricEqViewModel @Inject constructor(
         _currentBands.value = flat
         _currentPreamp.value = 0f
         saveBands(flat)
-        viewModelScope.launch { preferences.setParamEqPreamp(0.0) }
+        persistPreamp(0.0)
     }
 
     fun loadPreset(presetId: String) {
@@ -190,7 +195,7 @@ class ParametricEqViewModel @Inject constructor(
             _currentPreamp.value = preset.preamp
             _selectedBandId.value = preset.bands.firstOrNull()?.id ?: -1
             preferences.setParamEqActivePreset(presetId)
-            preferences.setParamEqPreamp(preset.preamp.toDouble())
+            persistPreamp(preset.preamp.toDouble())
             saveBands(preset.bands)
         }
     }
@@ -249,7 +254,7 @@ class ParametricEqViewModel @Inject constructor(
                     // the page's own slider allows.
                     val preamp = profile.preamp.coerceIn(-24f, 24f)
                     _currentPreamp.value = preamp
-                    preferences.setParamEqPreamp(preamp.toDouble())
+                    persistPreamp(preamp.toDouble())
                     _activePreset.value = preset
                     preferences.setParamEqActivePreset(preset.id)
                     if (!_enabled.value) setEnabled(true)
@@ -289,14 +294,35 @@ class ParametricEqViewModel @Inject constructor(
         _error.value = null
     }
 
-    private fun saveBands(bands: List<EqBand>) {
-        viewModelScope.launch {
+    /**
+     * Persist the band list.
+     *
+     * [coalesce] is for the continuous edits — a band slider or a graph drag,
+     * which fire dozens of times a second. Each save JSON-encodes every band
+     * and writes DataStore, and the audio path re-applies the parametric chain
+     * off that key, so an uncoalesced drag rebuilt every filter on every frame.
+     * Structural changes (add/remove, preset load, reset) write straight
+     * through — they happen once and must not be lost to a cancel.
+     */
+    private fun saveBands(bands: List<EqBand>, coalesce: Boolean = false) {
+        bandsPersistJob?.cancel()
+        bandsPersistJob = viewModelScope.launch {
             try {
-                val bandsJson = json.encodeToString(bands)
-                preferences.setParamEqBands(bandsJson)
+                if (coalesce) kotlinx.coroutines.delay(PERSIST_DEBOUNCE_MS)
+                preferences.setParamEqBands(json.encodeToString(bands))
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 _error.value = "Failed to save bands: ${e.message}"
             }
+        }
+    }
+
+    /** Single writer for the preamp, so an immediate write always beats a pending drag tail. */
+    private fun persistPreamp(value: Double, coalesce: Boolean = false) {
+        preampPersistJob?.cancel()
+        preampPersistJob = viewModelScope.launch {
+            if (coalesce) kotlinx.coroutines.delay(PERSIST_DEBOUNCE_MS)
+            preferences.setParamEqPreamp(value)
         }
     }
 
@@ -307,4 +333,9 @@ class ParametricEqViewModel @Inject constructor(
         EqBand(id = 3, type = FilterType.PEAKING, freq = 4000f, gain = 0f, q = 1.0f),
         EqBand(id = 4, type = FilterType.PEAKING, freq = 12000f, gain = 0f, q = 1.0f)
     )
+
+    private companion object {
+        /** Drag-tail delay before a continuous edit reaches DataStore. */
+        const val PERSIST_DEBOUNCE_MS = 120L
+    }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/LiquidGlass.kt
@@ -393,12 +393,9 @@ fun PlayerGlassHaze(
 
     val frostBg = androidx.compose.material3.MaterialTheme.colorScheme.background
     val isDark = frostBg.luminance() <= 0.5f
-    // The frost tint over the blur: deepen a dark ground, lighten a light one,
-    // scaled by the listener's hazeTint. The blur is the haze; this is the
-    // frost, and it is the thin part — most of what reads is the blurred art.
-    val frostTint = (
-        if (isDark) Color.Black.copy(alpha = 0.32f) else Color.White.copy(alpha = 0.45f)
-        ).let { it.copy(alpha = (it.alpha * g.hazeTint).coerceIn(0f, 1f)) }
+    // The blur is the haze; this is the frost, and it is the thin part — most
+    // of what reads through should be the blurred art.
+    val frostTint = playerFrostTint(g, isDark)
 
     androidx.compose.foundation.layout.Box(
         modifier
@@ -413,6 +410,27 @@ fun PlayerGlassHaze(
                 ),
             ),
     )
+}
+
+/**
+ * The wash that goes over the blur — the *frost*, as opposed to the haze.
+ *
+ * One function because this recipe was written out by hand in three places
+ * (here, [tf.monochrome.android.ui.components.GlassPanel], and the player's
+ * audio-tools sheet) and they were free to drift. Every sheet of glass in the
+ * app now frosts by the same rule, scaled by the listener's own "Backdrop
+ * tint" from the Player Visuals Studio.
+ *
+ * The light-theme wash used to be nearly twice the dark one (0.45 white
+ * against 0.32 black). On a light or warm theme that is most of a solid
+ * colour laid over the blur, which is why those panels read as milky slabs
+ * rather than glass — the blurred artwork was there, just buried. The two
+ * sides are even now, and anyone who liked the heavier look can put it back
+ * by raising Backdrop tint, which reaches 2.0.
+ */
+fun playerFrostTint(glass: tf.monochrome.android.domain.model.PlayerGlassSettings, isDark: Boolean): Color {
+    val base = if (isDark) Color.Black.copy(alpha = 0.32f) else Color.White.copy(alpha = 0.26f)
+    return base.copy(alpha = (base.alpha * glass.hazeTint).coerceIn(0f, 1f))
 }
 
 /**

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerRoute.kt
@@ -901,8 +901,13 @@ private fun BoxScope.SpeedPanel(
                 .padding(horizontal = 12.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            // The panel takes its accents from the active theme. These were
+            // PlayerGlowMint and a fixed magenta, which read as two neon
+            // imports on every theme that isn't dark-and-cool — mint sitting
+            // on a warm amber panel being the case that prompted this.
+            val speedAccent = MaterialTheme.colorScheme.primary
             Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                Icon(Icons.Default.Speed, contentDescription = null, tint = PlayerGlowMint)
+                Icon(Icons.Default.Speed, contentDescription = null, tint = speedAccent)
                 Text(
                     text = "  Playback speed",
                     style = MaterialTheme.typography.titleMedium,
@@ -910,7 +915,7 @@ private fun BoxScope.SpeedPanel(
                 Text(
                     text = "  ${String.format(Locale.US, "%.2fx", speed)}",
                     style = MaterialTheme.typography.titleMedium,
-                    color = PlayerGlowMint,
+                    color = speedAccent,
                 )
             }
             Slider(
@@ -918,14 +923,16 @@ private fun BoxScope.SpeedPanel(
                 onValueChange = { onSpeedChange(Math.round(it * 100f) / 100f) },
                 valueRange = 0.25f..3.0f,
                 colors = SliderDefaults.colors(
-                    thumbColor = PlayerGlowMint,
-                    activeTrackColor = PlayerGlowMint,
+                    thumbColor = speedAccent,
+                    activeTrackColor = speedAccent,
                 ),
             )
             // Cute one-tap Nightcore: 1.10x speed with pitch riding the tempo
             // (preserve-pitch off). Glows pink when active.
             val nightcoreActive = kotlin.math.abs(speed - 1.10f) < 0.01f && !preservePitch
-            val nightcorePink = Color(0xFFFF4FD8)
+            // Tertiary, so the one playful control still reads as distinct
+            // from the panel's primary accent while staying inside the theme.
+            val nightcorePink = MaterialTheme.colorScheme.tertiary
             Surface(
                 onClick = {
                     onSpeedChange(1.10f)
@@ -942,7 +949,7 @@ private fun BoxScope.SpeedPanel(
                     ),
                 shape = RoundedCornerShape(percent = 50),
                 color = if (nightcoreActive) nightcorePink.copy(alpha = 0.92f) else nightcorePink.copy(alpha = 0.14f),
-                contentColor = if (nightcoreActive) Color.Black else nightcorePink,
+                contentColor = if (nightcoreActive) MaterialTheme.colorScheme.onTertiary else nightcorePink,
                 border = BorderStroke(1.dp, nightcorePink.copy(alpha = if (nightcoreActive) 1f else 0.55f)),
             ) {
                 Row(

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -280,6 +280,21 @@ fun MainPlayerScreen(
     // gaussian-blur what's visually behind it — the same frost the mini
     // player gets from the nav host's source.
     val hazeState = rememberHazeState()
+    // A SECOND source, for the panels that sit over the whole player rather
+    // than inside it — the audio-tools sheet and the overlay slot's speed
+    // panel. It captures the backdrop *and* the player's content, so those
+    // panels frost the album art and transport actually behind them.
+    //
+    // It has to be a separate state, not a wider [hazeState]. The transport
+    // tiles frost [hazeState] from INSIDE the content column, and a haze
+    // effect cannot sample a layer it is drawn inside — folding the content
+    // into the state those tiles read would break them. Keeping the two apart
+    // means the tiles' behaviour is untouched and only the panels see more.
+    //
+    // Without this the panels were blurring the backdrop layers alone, which
+    // is a gradient with nothing in it: the blur ran, and the result was a
+    // flat wash that read as no blur at all.
+    val panelHaze = rememberHazeState()
     // Publish the background as a haze source to the chrome over it. The tiles
     // that read this are siblings of the source box below, not descendants of
     // it, so they blur it rather than trying to sample a layer they are part of.
@@ -287,7 +302,7 @@ fun MainPlayerScreen(
         tf.monochrome.android.ui.player.LocalPlayerHaze provides hazeState,
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
-        Box(Modifier.matchParentSize().hazeSource(hazeState)) {
+        Box(Modifier.matchParentSize().hazeSource(hazeState).hazeSource(panelHaze)) {
         // Background on its own node so the dither layer wraps just the
         // gradient, not the whole screen's content.
         Box(
@@ -355,6 +370,11 @@ fun MainPlayerScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                // Captured for the panels only (zIndex above the backdrop), so
+                // they frost the hero and transport as well as the wash. Not a
+                // source for [hazeState] — the tiles inside this column frost
+                // that one and cannot sample a layer they belong to.
+                .hazeSource(panelHaze, zIndex = 1f)
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .padding(horizontal = screenPad),
@@ -555,7 +575,7 @@ fun MainPlayerScreen(
             ) {
             StatusOverlayPanel(
                 accent = accent,
-                hazeState = hazeState,
+                hazeState = panelHaze,
                 outputLabel = state.outputLabel,
                 soundLabel = state.soundLabel,
                 speedLabel = state.speedLabel,
@@ -587,7 +607,13 @@ fun MainPlayerScreen(
             }
         }
 
-        overlay()
+        // The speed panel lives here and is a sibling of both sources, so it
+        // gets the one that actually has the player in it.
+        androidx.compose.runtime.CompositionLocalProvider(
+            tf.monochrome.android.ui.player.LocalPlayerHaze provides panelHaze,
+        ) {
+            overlay()
+        }
     }
     }
 }
@@ -792,8 +818,8 @@ private fun StatusOverlayPanel(
                 // leave the content exactly where it was on screen — and
                 // level with the speed panel's, which does the same.
                 .padding(horizontal = PlayerDesignTokens.ScreenPadding - 12.dp)
-                .padding(top = 12.dp, bottom = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+                .padding(top = 10.dp, bottom = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // Tap the handle (or swipe the sheet down / tap the scrim) to close.
@@ -827,7 +853,7 @@ private fun StatusOverlayPanel(
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = 16.dp, top = 12.dp),
+                            .padding(start = 12.dp, top = 10.dp),
                     ) {
                         ToggleRow(
                             "System-wide",
@@ -861,7 +887,7 @@ private fun StatusOverlayPanel(
             // Monitoring row
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 OverlayAction(Icons.Default.Animation, "Visualizer", accent, visualizerActive, onVisualizer)
                 OverlayAction(Icons.Default.GraphicEq, "Waveform", accent, waveformActive, onWaveform)
@@ -898,9 +924,9 @@ private fun RowScope.OverlayAction(
                 tintAlpha = if (active) PlayerDesignTokens.GlassTintStrong else PlayerDesignTokens.GlassTintSoft,
                 borderAlpha = PlayerDesignTokens.GlassTintSoft,
             )
-            .padding(vertical = 12.dp),
+            .padding(vertical = 10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Icon(
             imageVector = icon,
@@ -945,7 +971,7 @@ private fun ToggleRow(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = label, style = MaterialTheme.typography.bodyLarge, color = Color.White)
+            Text(text = label, style = MaterialTheme.typography.bodyMedium, color = Color.White)
             Text(
                 text = subtitle,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/MainPlayerScreen.kt
@@ -716,7 +716,11 @@ private fun StatusOverlayPanel(
     onToneControlsChange: (tf.monochrome.android.domain.model.ToneControls) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+    // The speed panel's shape and inset, so the two panes read as the same
+    // sheet of glass: GlassPanel insets 12dp and clips to MonoDimens.shapeLg,
+    // and this sheet used to be a full-bleed slab with only its top corners
+    // rounded, sitting visibly wider than the panel it sits beside.
+    val shape = tf.monochrome.android.ui.theme.MonoDimens.shapeLg
     val g = LocalPlayerGlass.current
     val useGlass = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU &&
         g.enabled
@@ -724,6 +728,7 @@ private fun StatusOverlayPanel(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(12.dp)
             .shadow(elevation = 32.dp, shape = shape, clip = false)
             .liquidGlass(shape = shape, tintAlpha = 0.22f, borderAlpha = 0.10f),
         shape = shape,
@@ -748,9 +753,7 @@ private fun StatusOverlayPanel(
         if (useGlass && hazeState != null && profile.allowHazeBlur && g.hazeBlurDp > 0f) {
             val frostBg = MaterialTheme.colorScheme.background
             val isDark = frostBg.luminance() <= 0.5f
-            val frostTint = (if (isDark) Color.Black.copy(alpha = 0.32f)
-                            else Color.White.copy(alpha = 0.45f))
-                .let { it.copy(alpha = (it.alpha * g.hazeTint).coerceIn(0f, 1f)) }
+            val frostTint = playerFrostTint(g, isDark)
             androidx.compose.foundation.layout.Box(
                 Modifier
                     .matchParentSize()
@@ -785,7 +788,10 @@ private fun StatusOverlayPanel(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .padding(horizontal = PlayerDesignTokens.ScreenPadding)
+                // The panel itself now insets 12dp, so this sheds 12dp to
+                // leave the content exactly where it was on screen — and
+                // level with the speed panel's, which does the same.
+                .padding(horizontal = PlayerDesignTokens.ScreenPadding - 12.dp)
                 .padding(top = 12.dp, bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/tf/monochrome/android/ui/player/PlayerStatusGrid.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/player/PlayerStatusGrid.kt
@@ -56,9 +56,9 @@ fun PlayerStatusGrid(
     // but track the current artwork.
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             StatusCard(
                 modifier = Modifier.weight(1f),
                 icon = Icons.Default.Headphones,
@@ -76,7 +76,7 @@ fun PlayerStatusGrid(
                 onClick = onSound,
             )
         }
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             StatusCard(
                 modifier = Modifier.weight(1f),
                 icon = Icons.Default.Speed,
@@ -125,15 +125,18 @@ private fun StatusCard(
         contentAlignment = Alignment.CenterStart,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp),
+            // Tightened with the sheet: it lost 24dp of width when it stopped
+            // being full-bleed, and four cards at the old padding left the
+            // labels crowding their own edges.
+            modifier = Modifier.padding(horizontal = 11.dp, vertical = 11.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
                 tint = accent,
-                modifier = Modifier.size(22.dp),
+                modifier = Modifier.size(19.dp),
             )
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(

--- a/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/LyricsFxStudioScreen.kt
@@ -162,7 +162,7 @@ class LyricsFxStudioViewModel @Inject constructor(
     private var playerGlassTouched = false
     private var playerGlassPersistJob: Job? = null
 
-    /** Mini-player glass settings — the "Mini Player" tab (its own blob, same shape). */
+    /** The "UI panels" tab's glass — the mini player bar and every floating panel that shares its material (its own blob, same shape as the player's). */
     private val _miniPlayerGlass = MutableStateFlow(tf.monochrome.android.domain.model.PlayerGlassSettings.DEFAULT)
     val miniPlayerGlass: StateFlow<tf.monochrome.android.domain.model.PlayerGlassSettings> = _miniPlayerGlass.asStateFlow()
     private var miniPlayerGlassTouched = false
@@ -382,7 +382,7 @@ fun LyricsFxStudioScreen(
     val miniPlayerGlass by viewModel.miniPlayerGlass.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
-    // Which studio tab: 0 = Lyrics, 1 = Player Glass, 2 = Mini Player.
+    // Which studio tab: 0 = Player, 1 = UI panels, 2 = Lyrics.
     // rememberSaveable so it doesn't snap back to Lyrics after background
     // process death.
     var selectedTab by rememberSaveable { mutableStateOf(0) }
@@ -411,9 +411,14 @@ fun LyricsFxStudioScreen(
             selectedTabIndex = selectedTab,
             containerColor = Color.Transparent,
         ) {
-            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text("Lyrics") })
-            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text("Player Glass") })
-            Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }, text = { Text("Mini Player") })
+            // Player chrome first, then the glass shared by every floating
+            // panel, then lyrics. "UI panels" rather than "Mini Player"
+            // because this blob stopped being just the bar: it is the material
+            // for the audio-tools sheet, the speed panel, the nav pill, the
+            // search bar and the map panels too.
+            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text("Player") })
+            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text("UI panels") })
+            Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }, text = { Text("Lyrics") })
         }
 
         // With the glass switched off app-wide, every control on these tabs still
@@ -429,11 +434,11 @@ fun LyricsFxStudioScreen(
             )
         }
 
-        if (selectedTab == 1 || selectedTab == 2) {
+        if (selectedTab == 0 || selectedTab == 1) {
             // Both glass tabs share the same controls, preview, and theme pool;
             // only which settings blob they edit differs.
             val customGlassPresets by viewModel.customPlayerGlassPresets.collectAsStateWithLifecycle()
-            if (selectedTab == 1) {
+            if (selectedTab == 0) {
                 PlayerGlassTab(
                     glass = playerGlass,
                     customPresets = customGlassPresets,
@@ -1087,15 +1092,25 @@ private fun PlayerGlassTab(
         // Controls are grouped by what they affect, in paint order: what the
         // glass IS (body), its 3D form (shape & bevel), how light plays on it
         // (light & reflections), what it casts (drop shadow), then render cost.
-        StudioSection("Player Glass")
+        StudioSection(if (previewMini) "UI panels" else "Player Glass")
         FxToggle(
             "Button liquid glass", glass.enabled,
             description = "3D refractive glass on the transport buttons (needs Android 13+).",
         ) { onUpdate { g -> g.copy(enabled = it) } }
-        FxToggle(
-            "Glass progress bar", glass.progressGlass,
-            description = "Thin glass tube scrubber that fills up, with a sine-wave bulge at the playhead dot.",
-        ) { onUpdate { g -> g.copy(progressGlass = it) } }
+        if (previewMini) {
+            // The mini player's progress line doubles as the bar's top border,
+            // so this is as much a framing choice as a readout one — off, the
+            // bar loses that hairline edge and closes up by its 2dp.
+            FxToggle(
+                "Mini player progress bar", glass.miniProgressBar,
+                description = "Thin progress line along the top edge of the mini player, which also gives the bar its top border.",
+            ) { onUpdate { g -> g.copy(miniProgressBar = it) } }
+        } else {
+            FxToggle(
+                "Glass progress bar", glass.progressGlass,
+                description = "Thin glass tube scrubber that fills up, with a sine-wave bulge at the playhead dot.",
+            ) { onUpdate { g -> g.copy(progressGlass = it) } }
+        }
 
         StudioSection("Glass body")
         FxSlider(
@@ -1107,11 +1122,12 @@ private fun PlayerGlassTab(
             description = "Frosts the glass, from clear to misted.",
         ) { onUpdate { g -> g.copy(frost = it) } }
         if (previewMini) {
-            // Haze backdrop frost — only surfaces driven by the MINI glass
-            // (mini player bar, audio-tools sheet, nav pill) render it.
+            // Haze backdrop frost — only surfaces driven by this blob render
+            // it: the mini player bar, the audio-tools sheet, the speed panel,
+            // the nav pill, the search bar and the map panels.
             FxSlider(
                 "Backdrop blur", "%.0f dp".format(glass.hazeBlurDp), glass.hazeBlurDp, 0f..80f,
-                description = "Gaussian blur of whatever sits behind the bar (0 = off).",
+                description = "Gaussian blur of whatever sits behind these panels (0 = off).",
             ) { onUpdate { g -> g.copy(hazeBlurDp = it) } }
             FxSlider(
                 "Backdrop tint", "${(glass.hazeTint * 100).toInt()}%", glass.hazeTint, 0f..2f,

--- a/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsTab.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsTab.kt
@@ -38,8 +38,12 @@ import tf.monochrome.android.radio.PLANNER_WEIGHT_MAX
 import tf.monochrome.android.radio.PLANNER_WEIGHT_MIN
 
 /**
- * Settings › Radio: connection to the optional Tryptify-Playlist planner and
- * the user-tunable recommendation weights it receives.
+ * Settings › Radio: the recommendation weights radio ranks with, and the
+ * connection to the optional Tryptify-Playlist planner.
+ *
+ * The weights are scored on-device by LocalRadioPlanner and work with no
+ * planner configured. The three under "Needs a planner" describe datasets
+ * that do not live on the device; they are only sent to the service.
  */
 @Composable
 fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
@@ -58,7 +62,7 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
             GroupHeader("Radio planner")
             tf.monochrome.android.ui.settings.SettingSwitchItem(
                 title = "Use remote planner",
-                subtitle = "Ask the Tryptify-Playlist service for Qobuz recommendation hints. Radio still works without it using similar-artist expansion.",
+                subtitle = "Optional. Asks the Tryptify-Playlist service for extra track suggestions. Radio and every weight below work without it — this only widens where candidates come from.",
                 checked = plannerEnabled,
                 onCheckedChange = viewModel::setPlannerEnabled
             )
@@ -103,7 +107,7 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
             Spacer(Modifier.height(24.dp))
             GroupHeader("Recommendation weights")
             Text(
-                text = "1.00x is neutral. Lower values down-rank a signal, higher values strengthen it.",
+                text = "1.00x is neutral. Lower values down-rank a signal, higher values strengthen it. These are scored on-device — no planner required.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 8.dp)
@@ -130,9 +134,6 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
             WeightSlider("Genre / tag similarity", "Genre and tag continuity.", weights.genreTagSimilarity) {
                 viewModel.updateWeights(weights.copy(genreTagSimilarity = it))
             }
-            WeightSlider("Mood continuity", "Higher keeps the station's mood steadier.", weights.moodContinuity) {
-                viewModel.updateWeights(weights.copy(moodContinuity = it))
-            }
             WeightSlider("Era consistency", "Prefer similar release periods.", weights.eraConsistency) {
                 viewModel.updateWeights(weights.copy(eraConsistency = it))
             }
@@ -142,17 +143,26 @@ fun RadioSettingsTab(viewModel: RadioSettingsViewModel = hiltViewModel()) {
             WeightSlider("Discovery distance", "How far recommendations may drift from the seed.", weights.discoveryDistance) {
                 viewModel.updateWeights(weights.copy(discoveryDistance = it))
             }
+            WeightSlider("Canonical version bias", "Prefer original recordings over remasters, live takes and edits.", weights.canonicalVersionBias) {
+                viewModel.updateWeights(weights.copy(canonicalVersionBias = it))
+            }
 
             Spacer(Modifier.height(24.dp))
-            GroupHeader("MetaBrainz and identity matching")
+            GroupHeader("Needs a planner")
+            Text(
+                text = "These describe data that isn't on the device, so they only take effect when a remote planner is configured and reachable.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
             WeightSlider("MetaBrainz metadata", "MusicBrainz identity, tags, aliases, relationships.", weights.metabrainzMetadata) {
                 viewModel.updateWeights(weights.copy(metabrainzMetadata = it))
             }
             WeightSlider("ListenBrainz graph", "Co-listening patterns from ListenBrainz.", weights.listenbrainzGraph) {
                 viewModel.updateWeights(weights.copy(listenbrainzGraph = it))
             }
-            WeightSlider("Canonical version bias", "Prefer canonical recordings over remasters and duplicates.", weights.canonicalVersionBias) {
-                viewModel.updateWeights(weights.copy(canonicalVersionBias = it))
+            WeightSlider("Mood continuity", "Keeps the station's mood steady. Needs audio features the app doesn't compute.", weights.moodContinuity) {
+                viewModel.updateWeights(weights.copy(moodContinuity = it))
             }
 
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsViewModel.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/radio/RadioSettingsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import tf.monochrome.android.data.preferences.PreferencesManager
@@ -20,8 +21,25 @@ class RadioSettingsViewModel @Inject constructor(
     private val plannerClient: RadioPlannerClient,
 ) : ViewModel() {
 
-    val weights: StateFlow<RadioPlannerWeights> = preferences.radioPlannerWeights
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), RadioPlannerWeights.DEFAULT)
+    // An in-memory working copy drives the weight sliders, so a drag updates
+    // instantly with no I/O. Persisting each frame wrote all fourteen float
+    // keys to DataStore, and the flow those sliders read from is DataStore's
+    // own — so every frame of a drag also re-emitted and recomposed the whole
+    // tab. Writes are debounced to the tail of the gesture instead.
+    private val _weights = MutableStateFlow(RadioPlannerWeights.DEFAULT)
+    val weights: StateFlow<RadioPlannerWeights> = _weights.asStateFlow()
+
+    private var userTouched = false
+    private var weightsPersistJob: kotlinx.coroutines.Job? = null
+
+    init {
+        viewModelScope.launch {
+            // Seed once; after the user starts tuning, the in-memory copy leads
+            // so our own debounced writes never echo back over a live drag.
+            val stored = preferences.radioPlannerWeights.first()
+            if (!userTouched) _weights.value = stored
+        }
+    }
 
     val plannerEnabled: StateFlow<Boolean> = preferences.radioPlannerEnabled
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
@@ -40,11 +58,22 @@ class RadioSettingsViewModel @Inject constructor(
     val connectionStatus: StateFlow<String?> = _connectionStatus.asStateFlow()
 
     fun updateWeights(weights: RadioPlannerWeights) {
-        viewModelScope.launch { preferences.setRadioPlannerWeights(weights) }
+        userTouched = true
+        _weights.value = weights.clamped()
+        weightsPersistJob?.cancel()
+        weightsPersistJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(WEIGHTS_PERSIST_DEBOUNCE_MS)
+            preferences.setRadioPlannerWeights(_weights.value)
+        }
     }
 
     fun resetDefaults() {
-        viewModelScope.launch { preferences.resetRadioPlannerWeights() }
+        userTouched = true
+        _weights.value = RadioPlannerWeights.DEFAULT
+        // A tap, not a drag — write it straight through, and drop any pending
+        // drag tail that would otherwise land on top of the reset.
+        weightsPersistJob?.cancel()
+        weightsPersistJob = viewModelScope.launch { preferences.resetRadioPlannerWeights() }
     }
 
     fun setPlannerEnabled(enabled: Boolean) {
@@ -90,5 +119,10 @@ class RadioSettingsViewModel @Inject constructor(
                 _isTesting.value = false
             }
         }
+    }
+
+    private companion object {
+        /** Drag-tail delay before weight edits reach DataStore. */
+        const val WEIGHTS_PERSIST_DEBOUNCE_MS = 150L
     }
 }

--- a/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqResponseGridTest.kt
+++ b/app/src/test/java/tf/monochrome/android/audio/eq/AutoEqResponseGridTest.kt
@@ -1,0 +1,99 @@
+package tf.monochrome.android.audio.eq
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tf.monochrome.android.domain.model.EqBand
+import tf.monochrome.android.domain.model.FilterType
+import kotlin.math.log10
+import kotlin.math.pow
+
+/**
+ * [AutoEqEngine.ResponseGrid] exists purely to stop the graph re-designing a
+ * filter once per pixel. It is only a legitimate substitution if it returns
+ * exactly what the per-point [AutoEqEngine.calculateBiquadResponse] returns,
+ * so that equality is the thing pinned here — a divergence would silently
+ * misdraw the correction curve the user is tuning against.
+ */
+class AutoEqResponseGridTest {
+
+    private val sampleRate = 48000f
+
+    /** A log-spaced 20 Hz–20 kHz axis, the shape the graph actually evaluates on. */
+    private fun logAxis(n: Int = 200): FloatArray {
+        val lo = log10(20f)
+        val hi = log10(20000f)
+        return FloatArray(n) { i -> 10f.pow(lo + i.toFloat() / (n - 1) * (hi - lo)) }
+    }
+
+    private val bands = listOf(
+        EqBand(0, FilterType.PEAKING, 60f, 6f, 1.0f, true),
+        EqBand(1, FilterType.LOWSHELF, 120f, -4.5f, 0.707f, true),
+        EqBand(2, FilterType.PEAKING, 3200f, -9f, 3.5f, true),
+        EqBand(3, FilterType.HIGHSHELF, 10000f, 7.25f, 0.707f, true),
+        EqBand(4, FilterType.PEAKING, 18000f, 12f, 1f, true),
+    )
+
+    @Test
+    fun `per-band response matches the per-point calculation exactly`() {
+        val freqs = logAxis()
+        val grid = AutoEqEngine.ResponseGrid(freqs, sampleRate)
+        for (band in bands) {
+            val batched = grid.response(band)
+            for (i in freqs.indices) {
+                assertEquals(
+                    "band ${band.id} (${band.type}) at ${freqs[i]} Hz",
+                    AutoEqEngine.calculateBiquadResponse(freqs[i], band, sampleRate),
+                    batched[i],
+                    0f,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `summed response matches point-wise summation`() {
+        val freqs = logAxis()
+        val grid = AutoEqEngine.ResponseGrid(freqs, sampleRate)
+        val summed = grid.sum(bands)
+        for (i in freqs.indices) {
+            var expected = 0f
+            for (band in bands) {
+                expected += AutoEqEngine.calculateBiquadResponse(freqs[i], band, sampleRate)
+            }
+            assertEquals("sum at ${freqs[i]} Hz", expected, summed[i], 1e-3f)
+        }
+    }
+
+    @Test
+    fun `disabled bands contribute nothing`() {
+        val freqs = logAxis(32)
+        val grid = AutoEqEngine.ResponseGrid(freqs, sampleRate)
+        val off = EqBand(9, FilterType.PEAKING, 1000f, 12f, 1f, enabled = false)
+        for (g in grid.response(off)) assertEquals(0f, g, 0f)
+        // An off band must also drop out of a sum rather than skewing it.
+        val withOff = grid.sum(bands + off)
+        val without = grid.sum(bands)
+        for (i in freqs.indices) assertEquals(without[i], withOff[i], 0f)
+    }
+
+    @Test
+    fun `accumulate adds onto the caller's array rather than replacing it`() {
+        val freqs = logAxis(16)
+        val grid = AutoEqEngine.ResponseGrid(freqs, sampleRate)
+        val out = FloatArray(grid.size) { 1f }
+        grid.accumulate(bands[0], out)
+        for (i in freqs.indices) {
+            assertEquals(
+                1f + AutoEqEngine.calculateBiquadResponse(freqs[i], bands[0], sampleRate),
+                out[i],
+                0f,
+            )
+        }
+    }
+
+    @Test
+    fun `grid size follows the axis it was built from`() {
+        assertEquals(200, AutoEqEngine.ResponseGrid(logAxis(200), sampleRate).size)
+        assertEquals(0, AutoEqEngine.ResponseGrid(FloatArray(0), sampleRate).size)
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
+++ b/app/src/test/java/tf/monochrome/android/domain/model/PlayerGlassSettingsTest.kt
@@ -120,6 +120,34 @@ class PlayerGlassSettingsTest {
     }
 
     @Test
+    fun `the mini progress bar is on by default`() {
+        // It is the mini player's top border as well as its readout, so the
+        // shipped bar keeps both unless the listener turns it off.
+        assertTrue(PlayerGlassSettings.DEFAULT.miniProgressBar)
+    }
+
+    @Test
+    fun `applying a theme does not switch the mini progress bar back on`() {
+        // The whole reason it is a personal field: presets do not set it, so
+        // were it material, every theme would carry the data-class default and
+        // silently re-enable a line the listener had turned off.
+        val personal = PlayerGlassSettings(miniProgressBar = false)
+        PlayerGlassSettings.PRESETS.forEach { (name, theme) ->
+            val applied = theme.withPersonalFrom(personal)
+            assertTrue("$name must not re-enable the mini progress bar", !applied.miniProgressBar)
+            // And the chip must still light despite the carried-over choice.
+            assertTrue("$name should still match its own chip", applied.matchesPreset(theme))
+        }
+    }
+
+    @Test
+    fun `the mini progress bar choice survives a share code round trip`() {
+        val off = PlayerGlassPreset("Borderless", PlayerGlassSettings(miniProgressBar = false))
+        val decoded = PlayerGlassPreset.decode(PlayerGlassPreset.encode(off))
+        assertTrue(decoded != null && !decoded.settings.miniProgressBar)
+    }
+
+    @Test
     fun `matchesPreset is false for a different material`() {
         val chrome = PlayerGlassSettings.PRESETS.first { it.first == "Chrome" }.second
         val frosted = PlayerGlassSettings.PRESETS.first { it.first == "Frosted" }.second

--- a/app/src/test/java/tf/monochrome/android/radio/LocalRadioPlannerTest.kt
+++ b/app/src/test/java/tf/monochrome/android/radio/LocalRadioPlannerTest.kt
@@ -1,0 +1,430 @@
+package tf.monochrome.android.radio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tf.monochrome.android.domain.model.Album
+import tf.monochrome.android.domain.model.Artist
+import tf.monochrome.android.domain.model.Track
+
+/**
+ * The weights have to change what radio actually plays, with no server in the
+ * loop. Every test here isolates one weight: the baseline silences all of them
+ * (every weight `0`), then the one under test is raised, so a preference that
+ * appears can only have come from that signal.
+ *
+ * The pairs are built to differ in exactly the thing the weight names, so
+ * "raising it changes the order" and "zeroing it removes the preference" are
+ * both asserted — a signal that is always on is as broken as one that never is.
+ */
+class LocalRadioPlannerTest {
+
+    private val planner = LocalRadioPlanner()
+
+    /** Every weight off, so any ordering must come from the one weight raised. */
+    private val silent = RadioPlannerWeights(
+        localLibrary = 0f, qobuz = 0f, spotifyDiscovery = 0f, metabrainzMetadata = 0f,
+        listenbrainzGraph = 0f, canonicalVersionBias = 0f, novelty = 0f, familiarity = 0f,
+        artistSimilarity = 0f, genreTagSimilarity = 0f, moodContinuity = 0f,
+        eraConsistency = 0f, avoidRecentlyPlayed = 0f, discoveryDistance = 0f,
+    )
+
+    private var nextId = 1L
+
+    private fun track(
+        title: String = "Track ${nextId}",
+        artist: String = "Artist",
+        year: String? = null,
+        genre: String? = null,
+        version: String? = null,
+    ) = Track(
+        id = nextId++,
+        title = title,
+        artist = Artist(id = artist.hashCode().toLong(), name = artist),
+        version = version,
+        album = Album(
+            id = nextId,
+            title = "Album",
+            releaseDate = year?.let { "$it-01-01" },
+            genreSlug = genre,
+        ),
+    )
+
+    private val seed = track(title = "Seed", artist = "Seed Artist", year = "2000", genre = "rock")
+
+    private fun context(
+        history: List<String> = emptyList(),
+        library: Set<String> = emptySet(),
+        boosts: Map<String, Float> = emptyMap(),
+    ) = RadioTasteContext(seed = seed, historyKeys = history, libraryKeys = library, sourceBoosts = boosts)
+
+    private fun scoreOf(
+        candidate: RadioCandidate,
+        weights: RadioPlannerWeights,
+        context: RadioTasteContext = context(),
+    ) = planner.score(candidate, context, weights).score
+
+    /**
+     * The shape every weight test takes: with the weight off the pair ties;
+     * with it raised, [preferred] wins.
+     */
+    private fun assertWeightDecides(
+        weight: String,
+        raised: RadioPlannerWeights,
+        preferred: RadioCandidate,
+        other: RadioCandidate,
+        context: RadioTasteContext = context(),
+    ) {
+        assertEquals(
+            "$weight: with every weight at 0 these must tie, or the pair differs in more than $weight",
+            scoreOf(other, silent, context),
+            scoreOf(preferred, silent, context),
+            1e-5f,
+        )
+        val preferredScore = scoreOf(preferred, raised, context)
+        val otherScore = scoreOf(other, raised, context)
+        assertTrue(
+            "$weight has no effect on ranking — it is a dead knob " +
+                "(preferred=$preferredScore, other=$otherScore)",
+            preferredScore > otherScore,
+        )
+        // And it must actually reorder them, not merely score differently.
+        val ranked = planner.rank(listOf(other, preferred), context, raised)
+        assertEquals("$weight: ranking must put the favoured candidate first", preferred, ranked.first().candidate)
+    }
+
+    // ── One test per weight scored on-device ──────────────────────────────
+
+    @Test
+    fun `local library weight prefers what is already on the device`() {
+        assertWeightDecides(
+            "localLibrary",
+            silent.copy(localLibrary = 3f),
+            preferred = RadioCandidate(track(), CandidateOrigin.SEARCH, inLibrary = true),
+            other = RadioCandidate(track(), CandidateOrigin.SEARCH, inLibrary = false),
+        )
+    }
+
+    @Test
+    fun `qobuz weight prefers catalogue candidates over the fallback source`() {
+        assertWeightDecides(
+            "qobuz",
+            silent.copy(qobuz = 3f),
+            preferred = RadioCandidate(track(), CandidateOrigin.SEARCH, fromQobuz = true),
+            other = RadioCandidate(track(), CandidateOrigin.SEARCH, fromQobuz = false),
+        )
+    }
+
+    @Test
+    fun `discovery expansion weight prefers broad search over the seed artist`() {
+        assertWeightDecides(
+            "spotifyDiscovery",
+            silent.copy(spotifyDiscovery = 3f),
+            preferred = RadioCandidate(track(), CandidateOrigin.SEARCH),
+            other = RadioCandidate(track(), CandidateOrigin.SEED_ARTIST),
+        )
+    }
+
+    @Test
+    fun `canonical version weight prefers the original over a remaster`() {
+        assertWeightDecides(
+            "canonicalVersionBias",
+            silent.copy(canonicalVersionBias = 3f),
+            preferred = RadioCandidate(track(title = "Song"), CandidateOrigin.SEARCH),
+            other = RadioCandidate(track(title = "Song (2011 Remastered)"), CandidateOrigin.SEARCH),
+        )
+    }
+
+    @Test
+    fun `novelty weight prefers the unheard`() {
+        val heard = track(title = "Known", artist = "Someone")
+        assertWeightDecides(
+            "novelty",
+            silent.copy(novelty = 3f),
+            preferred = RadioCandidate(track(title = "New"), CandidateOrigin.SEARCH),
+            other = RadioCandidate(heard, CandidateOrigin.SEARCH),
+            context = context(history = listOf(heard.tasteKey())),
+        )
+    }
+
+    @Test
+    fun `familiarity weight prefers what has been heard before`() {
+        val heard = track(title = "Known", artist = "Someone")
+        assertWeightDecides(
+            "familiarity",
+            silent.copy(familiarity = 3f),
+            preferred = RadioCandidate(heard, CandidateOrigin.SEARCH),
+            other = RadioCandidate(track(title = "New"), CandidateOrigin.SEARCH),
+            context = context(history = listOf(heard.tasteKey())),
+        )
+    }
+
+    @Test
+    fun `artist similarity weight prefers artists close to the seed`() {
+        assertWeightDecides(
+            "artistSimilarity",
+            silent.copy(artistSimilarity = 3f),
+            preferred = RadioCandidate(track(), CandidateOrigin.SEED_ARTIST, artistDistance = 0),
+            other = RadioCandidate(track(), CandidateOrigin.SEED_ARTIST, artistDistance = 4),
+        )
+    }
+
+    @Test
+    fun `genre weight prefers a matching genre`() {
+        assertWeightDecides(
+            "genreTagSimilarity",
+            silent.copy(genreTagSimilarity = 3f),
+            preferred = RadioCandidate(track(genre = "rock"), CandidateOrigin.SEARCH),
+            other = RadioCandidate(track(genre = "jazz"), CandidateOrigin.SEARCH),
+        )
+    }
+
+    @Test
+    fun `era weight prefers a nearby release year`() {
+        assertWeightDecides(
+            "eraConsistency",
+            silent.copy(eraConsistency = 3f),
+            preferred = RadioCandidate(track(year = "2001"), CandidateOrigin.SEARCH),
+            other = RadioCandidate(track(year = "1965"), CandidateOrigin.SEARCH),
+        )
+    }
+
+    @Test
+    fun `avoid recently played weight pushes down what was just heard`() {
+        val recent = track(title = "Just Played", artist = "Someone")
+        assertWeightDecides(
+            "avoidRecentlyPlayed",
+            silent.copy(avoidRecentlyPlayed = 3f),
+            preferred = RadioCandidate(track(title = "Fresh"), CandidateOrigin.SEARCH),
+            other = RadioCandidate(recent, CandidateOrigin.SEARCH),
+            context = context(history = listOf(recent.tasteKey())),
+        )
+    }
+
+    @Test
+    fun `discovery distance weight prefers drifting away from the seed`() {
+        assertWeightDecides(
+            "discoveryDistance",
+            silent.copy(discoveryDistance = 3f),
+            preferred = RadioCandidate(track(), CandidateOrigin.SIMILAR_ARTIST, artistDistance = 5),
+            other = RadioCandidate(track(), CandidateOrigin.SIMILAR_ARTIST, artistDistance = 0),
+        )
+    }
+
+    @Test
+    fun `every weight the planner claims to score locally has a test above`() {
+        // Guards against a signal being added to LOCAL_SIGNALS — and so
+        // advertised in the settings screen as working offline — without a
+        // test proving it changes anything.
+        val tested = setOf(
+            SIGNAL_LOCAL_LIBRARY, SIGNAL_QOBUZ, SIGNAL_DISCOVERY_EXPANSION, SIGNAL_CANONICAL,
+            SIGNAL_NOVELTY, SIGNAL_FAMILIARITY, SIGNAL_ARTIST_SIMILARITY, SIGNAL_GENRE,
+            SIGNAL_ERA, SIGNAL_AVOID_RECENT, SIGNAL_DISCOVERY_DISTANCE,
+        )
+        assertEquals(LocalRadioPlanner.LOCAL_SIGNALS, tested)
+    }
+
+    // ── The boundary: what genuinely cannot be scored on-device ───────────
+
+    @Test
+    fun `weights needing off-device data do not affect local scoring`() {
+        // Not a bug — mood needs audio features the app doesn't compute, and
+        // the MetaBrainz/ListenBrainz weights describe datasets that live
+        // elsewhere. Pinned so nobody "fixes" them with a fake signal, and so
+        // the settings screen's "Needs a planner" grouping stays honest.
+        val candidate = RadioCandidate(track(), CandidateOrigin.SEARCH)
+        val baseline = scoreOf(candidate, RadioPlannerWeights.DEFAULT)
+        for (loud in listOf(
+            RadioPlannerWeights.DEFAULT.copy(moodContinuity = 3f),
+            RadioPlannerWeights.DEFAULT.copy(metabrainzMetadata = 3f),
+            RadioPlannerWeights.DEFAULT.copy(listenbrainzGraph = 3f),
+        )) {
+            assertEquals(baseline, scoreOf(candidate, loud), 0f)
+        }
+    }
+
+    // ── Behaviour with no planner at all ─────────────────────────────────
+
+    @Test
+    fun `shipped defaults rank a plausible station with no planner`() {
+        // The realistic no-server case: default weights, a little history, and
+        // a mixed pool. The unheard canonical track by the seed artist should
+        // beat a remaster the listener just played.
+        val justPlayed = track(title = "Old Favourite", artist = "Seed Artist")
+        val pool = listOf(
+            RadioCandidate(
+                track(title = "Old Favourite (Remastered)", artist = "Seed Artist"),
+                CandidateOrigin.SEARCH, artistDistance = 0,
+            ),
+            RadioCandidate(justPlayed, CandidateOrigin.SEED_ARTIST, artistDistance = 0),
+            RadioCandidate(
+                track(title = "Deep Cut", artist = "Seed Artist", year = "2000", genre = "rock"),
+                CandidateOrigin.SEED_ARTIST, artistDistance = 0,
+            ),
+        )
+        val ranked = planner.rank(
+            pool,
+            context(history = listOf(justPlayed.tasteKey())),
+            RadioPlannerWeights.DEFAULT,
+        )
+        assertEquals("Deep Cut", ranked.first().candidate.track.title)
+        assertEquals("Old Favourite", ranked.last().candidate.track.title)
+    }
+
+    @Test
+    fun `ranking is deterministic and keeps input order on ties`() {
+        val a = RadioCandidate(track(title = "A"), CandidateOrigin.SEARCH)
+        val b = RadioCandidate(track(title = "B"), CandidateOrigin.SEARCH)
+        val once = planner.rank(listOf(a, b), context(), RadioPlannerWeights.DEFAULT)
+        val twice = planner.rank(listOf(a, b), context(), RadioPlannerWeights.DEFAULT)
+        assertEquals(once.map { it.candidate }, twice.map { it.candidate })
+        assertEquals(listOf(a, b), once.map { it.candidate })
+    }
+
+    @Test
+    fun `an empty pool ranks to nothing rather than throwing`() {
+        assertTrue(planner.rank(emptyList(), context(), RadioPlannerWeights.DEFAULT).isEmpty())
+    }
+
+    // ── Signal details worth pinning ─────────────────────────────────────
+
+    @Test
+    fun `canonical detection matches on whole words only`() {
+        // "Alive" is not a live take and "Editorial" is not a radio edit; a
+        // substring match here would down-rank a chunk of the catalogue.
+        // "Versions"/"Mixtape" likewise are not "version"/"mix".
+        for (clean in listOf("Song", "Alive", "Editorial", "Versions of You", "Mixtape", "Delivery")) {
+            assertEquals(clean, 1f, track(title = clean).canonicalSignal(), 0f)
+        }
+        for (flagged in listOf(
+            "Song - Remastered", "Song (Live)", "Song - Radio Edit",
+            "Song (Acoustic)", "Song - 2019 Remaster",
+        )) {
+            assertEquals(flagged, -1f, track(title = flagged).canonicalSignal(), 0f)
+        }
+    }
+
+    @Test
+    fun `a release version marks a track non-canonical even with a clean title`() {
+        val t = track(title = "Song", version = "2011 Remastered Version")
+        assertEquals(-1f, t.canonicalSignal(), 0f)
+    }
+
+    @Test
+    fun `era credit fades to nothing beyond the era span`() {
+        val weights = silent.copy(eraConsistency = 1f)
+        val sameYear = RadioCandidate(track(year = "2000"), CandidateOrigin.SEARCH)
+        val farOff = RadioCandidate(
+            track(year = "${2000 + LocalRadioPlanner.ERA_SPAN_YEARS + 10}"),
+            CandidateOrigin.SEARCH,
+        )
+        assertEquals(1f, scoreOf(sameYear, weights), 1e-5f)
+        // Clamped at zero — a very distant year must not become a penalty.
+        assertEquals(0f, scoreOf(farOff, weights), 1e-5f)
+    }
+
+    @Test
+    fun `a missing release year is neutral rather than penalised`() {
+        val weights = silent.copy(eraConsistency = 3f)
+        assertEquals(0f, scoreOf(RadioCandidate(track(year = null), CandidateOrigin.SEARCH), weights), 0f)
+    }
+
+    @Test
+    fun `recency penalty is strongest for the most recently played`() {
+        val weights = silent.copy(avoidRecentlyPlayed = 1f)
+        val justPlayed = track(title = "One", artist = "A")
+        val longAgo = track(title = "Two", artist = "B")
+        val history = listOf(justPlayed.tasteKey()) + List(8) { "filler$it" } + longAgo.tasteKey()
+        val ctx = context(history = history)
+        val justPlayedScore = scoreOf(RadioCandidate(justPlayed, CandidateOrigin.SEARCH), weights, ctx)
+        val longAgoScore = scoreOf(RadioCandidate(longAgo, CandidateOrigin.SEARCH), weights, ctx)
+        assertTrue("both must be penalised", justPlayedScore < 0f && longAgoScore < 0f)
+        assertTrue("the more recent play must be penalised harder", justPlayedScore < longAgoScore)
+    }
+
+    @Test
+    fun `a remaster of something in history counts as already heard`() {
+        // tasteKey is artist+title normalized, so the novelty signal isn't
+        // fooled by a different pressing of a song the listener knows.
+        val original = track(title = "Song", artist = "Band")
+        val remaster = track(title = "Song", artist = "Band")
+        assertEquals(original.tasteKey(), remaster.tasteKey())
+        val weights = silent.copy(novelty = 3f)
+        assertEquals(
+            0f,
+            scoreOf(
+                RadioCandidate(remaster, CandidateOrigin.SEARCH),
+                weights,
+                context(history = listOf(original.tasteKey())),
+            ),
+            0f,
+        )
+    }
+
+    @Test
+    fun `library membership counts as heard for novelty`() {
+        val owned = track(title = "Owned", artist = "Band")
+        val weights = silent.copy(novelty = 3f)
+        assertEquals(
+            0f,
+            scoreOf(
+                RadioCandidate(owned, CandidateOrigin.SEARCH),
+                weights,
+                context(library = setOf(owned.tasteKey())),
+            ),
+            0f,
+        )
+    }
+
+    // ── source_boosts, which used to be decoded and dropped ──────────────
+
+    @Test
+    fun `planner source boosts scale a whole source`() {
+        val weights = silent.copy(qobuz = 1f)
+        val candidate = RadioCandidate(track(), CandidateOrigin.SIMILAR_ARTIST)
+        val plain = scoreOf(candidate, weights)
+        val boosted = scoreOf(
+            candidate, weights,
+            context(boosts = mapOf(CandidateOrigin.SIMILAR_ARTIST.boostKey to 2f)),
+        )
+        assertEquals(plain * 2f, boosted, 1e-5f)
+        assertNotEquals(plain, boosted)
+    }
+
+    @Test
+    fun `a boost for another source leaves this one alone`() {
+        val weights = silent.copy(qobuz = 1f)
+        val candidate = RadioCandidate(track(), CandidateOrigin.SEED_ARTIST)
+        assertEquals(
+            scoreOf(candidate, weights),
+            scoreOf(candidate, weights, context(boosts = mapOf(CandidateOrigin.SEARCH.boostKey to 3f))),
+            0f,
+        )
+    }
+
+    @Test
+    fun `a nonsense boost is ignored rather than wrecking the batch`() {
+        val weights = silent.copy(qobuz = 1f)
+        val candidate = RadioCandidate(track(), CandidateOrigin.SEARCH)
+        val plain = scoreOf(candidate, weights)
+        for (bad in listOf(Float.NaN, Float.NEGATIVE_INFINITY, -4f)) {
+            assertEquals(
+                "boost $bad must fall back to neutral",
+                plain,
+                scoreOf(candidate, weights, context(boosts = mapOf(CandidateOrigin.SEARCH.boostKey to bad))),
+                0f,
+            )
+        }
+    }
+
+    @Test
+    fun `out-of-range weights are clamped before scoring`() {
+        val candidate = RadioCandidate(track(), CandidateOrigin.SEARCH, inLibrary = true)
+        assertEquals(
+            scoreOf(candidate, silent.copy(localLibrary = PLANNER_WEIGHT_MAX)),
+            scoreOf(candidate, silent.copy(localLibrary = 500f)),
+            0f,
+        )
+    }
+}

--- a/app/src/test/java/tf/monochrome/android/radio/RadioPlannerWireTest.kt
+++ b/app/src/test/java/tf/monochrome/android/radio/RadioPlannerWireTest.kt
@@ -1,0 +1,219 @@
+package tf.monochrome.android.radio
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Does a planner weight the user moved actually influence anything?
+ *
+ * The scoring itself happens on the planner service, so what can be settled
+ * on-device is the half that is ours: every weight leaves the device, under
+ * the name the server reads, carrying that field's own value. Those are the
+ * ways a weight becomes a dead knob without anything failing loudly — a field
+ * dropped from the request, a serial name that no longer matches the server's
+ * model, or a copy-paste slip in one of the three fourteen-line field-by-field
+ * blocks (`clamped`, and the read/write pair in PreferencesManager) that pins
+ * one weight to another's value.
+ *
+ * Encoding goes through [plannerJson], the same encoder [RadioPlannerClient]
+ * builds request bodies with, so this cannot pass against a config the app
+ * does not actually use.
+ *
+ * NOT covered here, and deliberately: whether the *server* honours any of it.
+ * See RadioPlannerWeightsTest for the clamping rules.
+ */
+class RadioPlannerWireTest {
+
+    /**
+     * Every field a distinct value, so a swap between any two is visible.
+     * Identical values (the defaults have several) would let `novelty =
+     * familiarity` pass unnoticed.
+     */
+    private val distinct = RadioPlannerWeights(
+        localLibrary = 0.10f,
+        qobuz = 0.20f,
+        spotifyDiscovery = 0.30f,
+        metabrainzMetadata = 0.40f,
+        listenbrainzGraph = 0.50f,
+        canonicalVersionBias = 0.60f,
+        novelty = 0.70f,
+        familiarity = 0.80f,
+        artistSimilarity = 0.90f,
+        genreTagSimilarity = 1.00f,
+        moodContinuity = 1.10f,
+        eraConsistency = 1.20f,
+        avoidRecentlyPlayed = 1.30f,
+        discoveryDistance = 1.40f,
+    )
+
+    /** The serial name the server reads, paired with the value set above. */
+    private val expectedOnTheWire = mapOf(
+        "local_library" to 0.10f,
+        "qobuz" to 0.20f,
+        "spotify_discovery" to 0.30f,
+        "metabrainz_metadata" to 0.40f,
+        "listenbrainz_graph" to 0.50f,
+        "canonical_version_bias" to 0.60f,
+        "novelty" to 0.70f,
+        "familiarity" to 0.80f,
+        "artist_similarity" to 0.90f,
+        "genre_tag_similarity" to 1.00f,
+        "mood_continuity" to 1.10f,
+        "era_consistency" to 1.20f,
+        "avoid_recently_played" to 1.30f,
+        "discovery_distance" to 1.40f,
+    )
+
+    private fun weightsObjectOf(request: RadioPlanRequest): JsonObject =
+        Json.parseToJsonElement(plannerJson.encodeToString(request))
+            .jsonObject["weights"]!!
+            .jsonObject
+
+    @Test
+    fun `every weight reaches the request body under its server-side name`() {
+        val weights = weightsObjectOf(RadioPlanRequest(seed = "a song", weights = distinct))
+        for ((name, value) in expectedOnTheWire) {
+            val sent = weights[name]
+                ?: error("weight '$name' never reaches the planner — it cannot influence anything")
+            assertEquals("weight '$name' sent the wrong value", value, sent.jsonPrimitive.float, 0f)
+        }
+    }
+
+    @Test
+    fun `the request carries no weight the server does not know about`() {
+        // A field added here but not to the service's model is silently ignored
+        // server-side, which looks identical to a knob that works.
+        val weights = weightsObjectOf(RadioPlanRequest(seed = "a song", weights = distinct))
+        assertEquals(
+            "weights on the wire drifted from the expected set",
+            expectedOnTheWire.keys,
+            weights.keys,
+        )
+    }
+
+    @Test
+    fun `moving one weight changes that weight alone`() {
+        // Catches a field-by-field block that reads or writes the wrong
+        // neighbour: bump each weight in turn and require exactly one key of
+        // the body to move.
+        val baseline = weightsObjectOf(RadioPlanRequest(seed = "s", weights = distinct))
+        val bumped = listOf<Pair<String, RadioPlannerWeights>>(
+            "local_library" to distinct.copy(localLibrary = 2.9f),
+            "qobuz" to distinct.copy(qobuz = 2.9f),
+            "spotify_discovery" to distinct.copy(spotifyDiscovery = 2.9f),
+            "metabrainz_metadata" to distinct.copy(metabrainzMetadata = 2.9f),
+            "listenbrainz_graph" to distinct.copy(listenbrainzGraph = 2.9f),
+            "canonical_version_bias" to distinct.copy(canonicalVersionBias = 2.9f),
+            "novelty" to distinct.copy(novelty = 2.9f),
+            "familiarity" to distinct.copy(familiarity = 2.9f),
+            "artist_similarity" to distinct.copy(artistSimilarity = 2.9f),
+            "genre_tag_similarity" to distinct.copy(genreTagSimilarity = 2.9f),
+            "mood_continuity" to distinct.copy(moodContinuity = 2.9f),
+            "era_consistency" to distinct.copy(eraConsistency = 2.9f),
+            "avoid_recently_played" to distinct.copy(avoidRecentlyPlayed = 2.9f),
+            "discovery_distance" to distinct.copy(discoveryDistance = 2.9f),
+        )
+        assertEquals("every weight must be exercised", expectedOnTheWire.size, bumped.size)
+
+        for ((movedKey, weights) in bumped) {
+            val after = weightsObjectOf(RadioPlanRequest(seed = "s", weights = weights))
+            val changed = after.keys.filter { after[it] != baseline[it] }
+            assertEquals("moving '$movedKey' should move exactly that key", listOf(movedKey), changed)
+        }
+    }
+
+    @Test
+    fun `clamping preserves which field is which`() {
+        // clamped() rebuilds all fourteen fields by hand and runs on every read
+        // and every write, so a swap here would corrupt weights on both paths.
+        val clamped = distinct.clamped()
+        assertEquals(distinct, clamped)
+    }
+
+    @Test
+    fun `clamping an out-of-range weight leaves its neighbours alone`() {
+        val clamped = distinct.copy(novelty = 99f).clamped()
+        assertEquals("the out-of-range field is the one that moves", 3f, clamped.novelty, 0f)
+        assertEquals(distinct.copy(novelty = 3f), clamped)
+    }
+
+    @Test
+    fun `shipped defaults are not a no-op`() {
+        // If every default were neutral the feature would ship doing nothing,
+        // and a user who never opens the settings would get no benefit from it.
+        val defaults = RadioPlannerWeights.DEFAULT
+        val onTheWire = weightsObjectOf(RadioPlanRequest(seed = "s", weights = defaults))
+        val nonNeutral = onTheWire.filterValues { it.jsonPrimitive.float != PLANNER_WEIGHT_NEUTRAL }
+        assertTrue("no default weight departs from neutral", nonNeutral.isNotEmpty())
+    }
+
+    @Test
+    fun `neutral weights are still sent rather than omitted`() {
+        // encodeDefaults is load-bearing: the server's own default for a signal
+        // need not be 1.0, so "user left it neutral" has to be stated, not
+        // implied by absence.
+        val allNeutral = RadioPlannerWeights(
+            localLibrary = 1f, qobuz = 1f, spotifyDiscovery = 1f, metabrainzMetadata = 1f,
+            listenbrainzGraph = 1f, canonicalVersionBias = 1f, novelty = 1f, familiarity = 1f,
+            artistSimilarity = 1f, genreTagSimilarity = 1f, moodContinuity = 1f,
+            eraConsistency = 1f, avoidRecentlyPlayed = 1f, discoveryDistance = 1f,
+        )
+        val weights = weightsObjectOf(RadioPlanRequest(seed = "s", weights = allNeutral))
+        assertEquals(expectedOnTheWire.keys, weights.keys)
+        for (name in expectedOnTheWire.keys) {
+            assertEquals(name, PLANNER_WEIGHT_NEUTRAL, weights[name]!!.jsonPrimitive.float, 0f)
+        }
+    }
+
+    @Test
+    fun `a request with no weights set still sends the shipped defaults`() {
+        // RadioQueueManager always passes stored weights, but the field is
+        // defaulted; if that default were ever dropped the knobs would go quiet.
+        val weights = weightsObjectOf(RadioPlanRequest(seed = "s"))
+        assertEquals(expectedOnTheWire.keys, weights.keys)
+        assertEquals(
+            RadioPlannerWeights.DEFAULT.avoidRecentlyPlayed,
+            weights["avoid_recently_played"]!!.jsonPrimitive.float,
+            0f,
+        )
+    }
+
+    @Test
+    fun `the seed-only retry carries no weights at all`() {
+        // Pins the documented degradation in RadioPlannerClient.plan(): when a
+        // stricter server rejects the extended body, the retry is seed-only, so
+        // weights (and history, catalog and MetaBrainz context) stop influencing
+        // that request entirely. Intended, but it means a 4xx from the planner
+        // silently turns every weight off until the server accepts the full shape.
+        val retryBody = plannerJson.encodeToString(mapOf("seed" to "a song"))
+        val parsed = Json.parseToJsonElement(retryBody).jsonObject
+        assertEquals(setOf("seed"), parsed.keys)
+        assertFalse("retry body must not claim to carry weights", parsed.containsKey("weights"))
+    }
+
+    @Test
+    fun `the catalog the planner biases toward is sent`() {
+        val body = Json.parseToJsonElement(
+            plannerJson.encodeToString(RadioPlanRequest(seed = "s"))
+        ).jsonObject
+        assertEquals("qobuz", body["catalog"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `distinct fixture really is distinct`() {
+        // Guards the guard: if two fixture values collided, the swap-detecting
+        // tests above would quietly stop detecting swaps.
+        val values = expectedOnTheWire.values.toList()
+        assertEquals(values.size, values.toSet().size)
+        assertNotEquals(0, values.size)
+    }
+}


### PR DESCRIPTION
Three areas that grew out of one another. Each section stands alone if you want to review them separately.

---

## 1. EQ sliders were doing per-frame work they could do once

Dragging any EQ slider dropped frames and stuttered audio. Three independent per-frame costs, all repeating work whose inputs had not changed.

**A biquad redesigned per pixel.** `FrequencyResponseGraph` built three curves — corrected response, per-band profile lines, other-ear overlay — by calling `calculateBiquadResponse` once per point. That entry point redesigns the filter (sin/cos/pow/sqrt plus an allocation) for a *single* frequency, so a drag frame with a 500-point measurement and ten bands re-derived roughly 15,000 biquads on the main thread, three times over. `AutoEqEngine.ResponseGrid` precomputes the cos(φ)/cos(2φ) tables for a fixed axis so a band is designed once and evaluated arithmetically per point — the same split the optimizer's refinement pass already used internally, which the UI simply wasn't getting. The graph builds one axis and derives all three curves from one set of per-band responses; the profile lines are those same arrays offset to the baseline. Results are bit-identical, pinned by `AutoEqResponseGridTest`.

**DataStore written per frame.** Band and preamp edits JSON-encoded every band and wrote DataStore on every drag frame, building a fresh `Json` each time. The audio path listens to those keys, so one drag rebuilt the entire filter chain dozens of times a second. Continuous edits coalesce to the tail of the gesture (120 ms); structural changes — presets, AutoEQ results, add/remove, import — still write straight through, so nothing can be lost to a cancel. Preamp writes go through a single writer so an immediate write cancels a pending drag tail rather than being overwritten by it.

`PlaybackService` also dedups and debounces its EQ observers. Worth noting independently: DataStore re-emits its whole blob on *any* write, so before this an unrelated settings change rebuilt every filter. `SystemAudioEqController` already guarded against exactly that; the service didn't.

**The whole measurement re-smoothed per frame.** The smoothing slider re-ran `smoothCurve` over both ears (a window reaching 40 points) on every value change, then handed the graph fresh curve objects that invalidated everything above. It commits on release now, with a local float keeping the thumb and label live.

Also: `interpolateGain` binary-searches instead of scanning, so the band dots and gap shading stop being quadratic in the measurement's length.

## 2. Radio: the weights were only ever read by a server

All fourteen recommendation weights were sent to the remote planner and nothing else. With it unconfigured, offline, or rejecting the request shape, **every slider in Settings › Radio did nothing** and the station fell back to the seed artist's top tracks in catalogue order.

`LocalRadioPlanner` scores candidates on-device against those weights, and it always runs. Eleven of the fourteen are real signals locally: local-library membership, catalogue source, discovery expansion, canonical-version bias (remaster/live/edit detection on word boundaries, so "Alive" isn't a live take), novelty, familiarity, artist similarity, genre, era proximity, recency penalty, discovery distance. Each is normalised and multiplied by its weight, so `0` silences a signal and `3` lets it dominate — what the 0–3 range always claimed.

The remote planner becomes one optional *source* of candidates rather than the brain. It's still worth having — it names tracks the catalogue alone wouldn't surface — and its `source_boosts` now scale whole candidate sources during ranking. That field was previously decoded and dropped on the floor.

**Behaviour change worth a look:** recently-played tracks are no longer filtered out outright. A hard filter is the one setting of "avoid recently played" the user cannot change, and it's why a thin catalogue could stop the station with *"no more similar tracks found"*. It's a strong penalty now — repeats sink and only resurface when the alternative is an empty batch. Session dedupe stays hard.

Mood continuity needs audio features the app doesn't compute, and the MetaBrainz/ListenBrainz weights describe datasets that aren't on the device. Those three are grouped under "Needs a planner" in settings rather than appearing to work offline, with a test pinning that they don't move local scoring.

`RadioPlannerWireTest` separately covers the half that is ours: every weight reaches the request body under the name the server reads, carrying its own value, with all fourteen given distinct values so a swap between any two is visible.

## 3. Player glass and the Studio

**The frost recipe was written out by hand in six places** — mini player, swipe hint, genre map panel, `GlassPanel`, `PlayerGlassHaze`, audio-tools sheet — each free to drift, and one had. The light-theme wash was `0.45` white against the dark theme's `0.32` black, so on a light or warm theme most of what you saw was flat colour laid over the blur rather than blurred artwork through it. All six share `playerFrostTint` now, evened to `0.26`/`0.32`; Backdrop tint still scales it to 2.0.

**`GlassPanel`'s last-resort branch** (no shader, no blur) painted `surfaceContainerHigh` at full opacity, so on those devices the listener's glass opacity did nothing at all. Body opacity governs that path too now, floored for readability.

**The backdrop blur was running with nothing in it.** The player registers one haze source spanning the backdrop layers only — gradient, wash, glow, stain. The hero, its artwork and the transport live in the content column below and were never captured, so the audio-tools sheet and speed panel were faithfully blurring a gradient. Fixed with a *second* source rather than a wider first one: the transport tiles frost the existing state from inside that content column, and a haze effect cannot sample a layer it is drawn inside, so folding the content into the state they read would have broken them. `panelHaze` captures backdrop + content and only the two panels over the whole player read it. The tiles are untouched, which also bounds what can go wrong here to those two panels.

**Geometry and colour.** The tools sheet was full-bleed with only its top corners rounded, visibly wider than the speed panel beside it; it takes `GlassPanel`'s 12dp inset and `shapeLg`, sheds the same 12dp from its inner padding so content lands where it was, and its status cards tighten to suit the narrower width. The speed panel's accents were `PlayerGlowMint` and a fixed magenta, which read as neon imports on any warm theme; they follow the theme's primary, with Nightcore on tertiary.

**Studio.** Tabs run Player → UI panels → Lyrics. The middle tab is "UI panels" rather than "Mini Player" because that blob stopped being just the bar — it is the material for the audio-tools sheet, the speed panel, the nav pill, the search bar and the map panels too. New `miniProgressBar` toggle turns the mini player's progress line on and off; that line is also the bar's top border, so switching it off drops the 2dp it reserves everywhere it is used, including the control-hole centring maths that would otherwise punch the play/skip holes above the icons they reveal. It is a *personal* field, not a material one — presets don't set it, so were it material every theme would silently switch the line back on.

---

## Testing

`./gradlew :app:testDebugUnitTest` — **635 tests, 0 failures** (up from 589; 46 added). Preset ranges validated with the Studio's own checker.

Each new test group was checked against an injected version of the bug it claims to catch, rather than only being observed to pass:

| Injected bug | Caught by |
|---|---|
| Swapped field in `clamped()` | `RadioPlannerWireTest` (2 failures) |
| A weight made `@Transient` | *"weight 'mood_continuity' never reaches the planner"* |
| Typo'd serial name | wire-set drift assertion |
| Local-library signal zeroed | *"localLibrary has no effect on ranking — it is a dead knob"* |
| Era decay flattened | era tests (2 failures) |
| `source_boosts` ignored again | boost scaling test |
| `miniProgressBar` moved out of `withPersonalFrom` | *"Default must not re-enable the mini progress bar"* |

## Reviewer note on verification

Everything here is verified by compiling and running the suite. The visual changes in section 3 are **not** verified on a device — I read the render path rather than looking at it. The reasoning is in the commit messages, but the frost density (`0.26`) and the two-source z-ordering in Haze 1.7.1 are the two judgement calls that would benefit from an eyeball before merge. Both are one-line changes if they're off.
