### PR TITLE
Cut the mixer strips from the app's own glass

### DIFF
--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -352,7 +352,19 @@ fun FLChannelStrip(
         )
 
         // ── Mute / Solo ───────────────────────────────────────────────────
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        // Stacked, not side by side, and that is the only arrangement that
+        // fits. Each button carries the 48dp accessibility minimum, so a row of
+        // two wants 100dp; a bus strip is 60dp wide and offers 52dp of content.
+        // Row measures its children in order against what is left, so Mute took
+        // 48, the gap took 4, and Solo was measured against nothing and never
+        // drawn — the mixer had no way to solo a bus at all, and it read as
+        // deliberate because master legitimately shows one button. The tell was
+        // that master's circle sat centred while every bus's sat left of centre,
+        // parked at the start of a 52dp band.
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
             Box(
                 modifier = Modifier
                     .minimumInteractiveComponentSize()
@@ -399,6 +411,13 @@ fun FLChannelStrip(
                         color = if (bus.soloed) onAccent else colors.onSurfaceVariant
                     )
                 }
+            } else {
+                // Master has nothing to solo, but it still holds the space, so
+                // all five strips are the same height and their faders stay
+                // level. Same modifiers as the button rather than a hardcoded
+                // height, so it reserves exactly what the button would measure
+                // whether or not the touch-target minimum is being enforced.
+                Spacer(modifier = Modifier.minimumInteractiveComponentSize().size(26.dp))
             }
         }
     }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -1,5 +1,6 @@
 package tf.monochrome.android.ui.mixer
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -19,10 +20,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
@@ -34,18 +37,49 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import tf.monochrome.android.audio.dsp.model.BusConfig
 import tf.monochrome.android.audio.dsp.model.BusLevels
+import tf.monochrome.android.domain.model.PlayerGlassSettings
+import tf.monochrome.android.performance.LocalLowPerformance
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.components.toggleSemantics
+import tf.monochrome.android.ui.navigation.LocalMiniPlayerGlass
+import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerDesignTokens
+import tf.monochrome.android.ui.player.playerGlass
+import tf.monochrome.android.ui.player.rememberLiquidGlassAvailable
 
 /** Fixed fader travel so strips stay compact instead of stretching the whole
  *  screen height; the strip is centred in its row and the meters match it. */
 private val FaderTravel = 280.dp
 
 /**
- * Compact DAW channel strip styled to match the main player: a solid glass
- * panel, theme-driven accents, a weighted fader cap and clean VU metering.
+ * Compact DAW channel strip cut from the app's own liquid glass: the AGSL
+ * `playerGlass` slab, theme-driven accents, a weighted fader cap and clean VU
+ * metering.
+ *
+ * The material is the **UI panels** blob from the Player Visuals Studio
+ * ([LocalMiniPlayerGlass]) — the same glass the mini player, the search bars and
+ * the map panels are cut from — so a listener who tunes that one material gets
+ * the mixer with it instead of a console that stayed opaque while every other
+ * floating panel turned to glass. It is published as [LocalPlayerGlass] for the
+ * shader (and anything inside the strip that reads it), exactly as `GlassPanel`
+ * does with the settings it is handed.
+ *
+ * Three tiers, per `docs/ui-invariants.md`:
+ *  - shader available → a **solid** accent slab relit by `playerGlass`. Solid is
+ *    the point: the shader builds its bevel and rim from the alpha heightfield
+ *    beneath it, and body opacity is what makes the strip see-through.
+ *  - glass on but no shader (below API 33, or a driver that will not compile it)
+ *    → the app's plain glassmorphism over the near-opaque channel gradient,
+ *    which is the look this strip had before.
+ *  - glass switched off → that gradient alone, so a low-tier device still gets a
+ *    readable strip rather than controls floating on nothing.
+ *
+ * No haze pane goes under the slab. The strips are permanent chrome standing on
+ * the mixer's own backdrop — a vertical wash plus one soft album glow — and a
+ * gaussian blur of that is the same wash again, so five blur passes per frame
+ * would buy nothing and an opaque frosted pane under a see-through slab is the
+ * flat-slab failure that invariant exists to prevent.
  */
 @Composable
 fun FLChannelStrip(
@@ -54,6 +88,13 @@ fun FLChannelStrip(
     modifier: Modifier = Modifier,
     levels: BusLevels = BusLevels(),
     accentColor: Color = MaterialTheme.colorScheme.primary,
+    /**
+     * The glass material. The UI-panels settings by default: this strip is a
+     * floating panel like the rest, not player chrome, so reading
+     * [LocalPlayerGlass] here would hand it the untouched defaults on the mixer
+     * route and nothing tuned in the Studio would ever reach it.
+     */
+    glass: PlayerGlassSettings = LocalMiniPlayerGlass.current,
     onSelect: () -> Unit,
     onGainChange: (Float) -> Unit,
     onPanChange: (Float) -> Unit,
@@ -67,8 +108,9 @@ fun FLChannelStrip(
     val accent = if (isMaster) colors.primary else accentColor
     val onAccent = if (accent.luminance() > 0.55f) Color.Black else Color.White
 
-    // Near-opaque panel so the album glow sits BEHIND the strip instead of
-    // washing through it. A faint accent tint up top gives each channel life.
+    // Fallback panel for the two tiers without the shader: near-opaque so the
+    // album glow sits BEHIND the strip instead of washing through it, with a
+    // faint accent tint up top to give each channel life.
     val panelTop = lerp(colors.surfaceContainerHigh, accent, if (isSelected) 0.16f else 0.07f)
     val panelBottom = lerp(colors.surface, Color.Black, 0.28f)
     val stripBrush = Brush.verticalGradient(
@@ -81,7 +123,20 @@ fun FLChannelStrip(
     val meterWidth = 7.dp
     val inactiveButton = colors.surfaceContainerHighest.copy(alpha = 0.88f)
 
-    Column(
+    // The pane's own colour. A tint chosen in the Studio wins, as it does on
+    // every other panel; with none set each channel keeps its own accent, which
+    // is the only thing telling five identical strips apart at a glance.
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
+    val flat = LocalLowPerformance.current.disableLiquidGlass
+
+    CompositionLocalProvider(LocalPlayerGlass provides glass) {
+    // Asks whether the shader is really coming (it reads the settings provided
+    // just above), so the slab is never drawn faint "just in case" — a hedged
+    // fill leaves the shader almost no heightfield to bevel and comes out a
+    // smudge, while an unshaded solid fill would be an opaque rectangle.
+    val shaded = rememberLiquidGlassAvailable()
+
+    Box(
         modifier = modifier
             .width(stripWidth)
             .shadow(
@@ -89,19 +144,57 @@ fun FLChannelStrip(
                 shape = stripShape,
                 clip = false
             )
-            .background(stripBrush, stripShape)
-            .liquidGlass(
-                shape = stripShape,
-                tintAlpha = PlayerDesignTokens.GlassTintSoft,
-                borderAlpha = if (isSelected) 0.16f else 0.06f,
-                showRefraction = isSelected
-            )
+            .clip(stripShape)
             .border(
                 width = if (isSelected) 1.5.dp else 1.dp,
                 color = if (isSelected) accent.copy(alpha = 0.70f) else colors.outline.copy(alpha = 0.14f),
                 shape = stripShape
             )
+            // On the pane rather than on the controls, so a tap presses the
+            // whole sheet of glass and not just the labels standing on it. Still
+            // an ancestor of the fader and the knob, exactly as before, so their
+            // drags claim the gesture first.
             .bounceClick(onClick = onSelect)
+    ) {
+        // ── The pane, behind the controls ─────────────────────────────────
+        // Its own node so the glass is relit on its own layer and the fader,
+        // meters and labels on top stay crisp instead of being refracted.
+        if (shaded) {
+            Canvas(
+                modifier = Modifier
+                    .matchParentSize()
+                    .playerGlass(tint = tint)
+            ) {
+                val r = PlayerDesignTokens.GlassCornerSmall.toPx()
+                drawRoundRect(color = tint, cornerRadius = CornerRadius(r, r))
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(stripBrush, stripShape)
+                    .then(
+                        // liquidGlass drops itself on LOW-tier devices; the
+                        // `flat` check is the listener's own "off" switch.
+                        if (flat) {
+                            Modifier
+                        } else {
+                            Modifier.liquidGlass(
+                                shape = stripShape,
+                                tintAlpha = PlayerDesignTokens.GlassTintSoft,
+                                borderAlpha = if (isSelected) 0.16f else 0.06f,
+                                showRefraction = isSelected
+                            )
+                        }
+                    )
+            )
+        }
+
+    // The sizing child: the pane layers above match ITS height, so the glass is
+    // exactly as tall as the controls standing on it.
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
             .padding(horizontal = 4.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(6.dp)
@@ -253,5 +346,7 @@ fun FLChannelStrip(
                 }
             }
         }
+    }
+    }
     }
 }

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/FLChannelStrip.kt
@@ -35,16 +35,22 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+import dev.chrisbanes.haze.hazeEffect
 import tf.monochrome.android.audio.dsp.model.BusConfig
 import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.domain.model.PlayerGlassSettings
 import tf.monochrome.android.performance.LocalLowPerformance
+import tf.monochrome.android.performance.LocalPerformanceProfile
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
 import tf.monochrome.android.ui.components.toggleSemantics
 import tf.monochrome.android.ui.navigation.LocalMiniPlayerGlass
 import tf.monochrome.android.ui.player.LocalPlayerGlass
 import tf.monochrome.android.ui.player.PlayerDesignTokens
+import tf.monochrome.android.ui.player.playerFrostTint
 import tf.monochrome.android.ui.player.playerGlass
 import tf.monochrome.android.ui.player.rememberLiquidGlassAvailable
 
@@ -65,21 +71,22 @@ private val FaderTravel = 280.dp
  * shader (and anything inside the strip that reads it), exactly as `GlassPanel`
  * does with the settings it is handed.
  *
- * Three tiers, per `docs/ui-invariants.md`:
- *  - shader available → a **solid** accent slab relit by `playerGlass`. Solid is
- *    the point: the shader builds its bevel and rim from the alpha heightfield
- *    beneath it, and body opacity is what makes the strip see-through.
+ * All three layers of the app's glass are here, per `docs/ui-invariants.md`:
+ * the **haze** blurs [hazeState] — the mixer's backdrop, which is the blurred
+ * album art when that switch is on — the **frost** tints that blur by the shared
+ * [playerFrostTint] recipe, and the **shader slab** is drawn at full tint
+ * opacity and relit by `playerGlass`. The frost is thin on purpose: most of what
+ * reads through a strip should be the artwork behind it.
+ *
+ * Three tiers:
+ *  - shader available → haze + frost + the **solid** slab. Solid is the point:
+ *    the shader builds its bevel and rim from the alpha heightfield beneath it,
+ *    and body opacity is what makes the strip see-through.
  *  - glass on but no shader (below API 33, or a driver that will not compile it)
- *    → the app's plain glassmorphism over the near-opaque channel gradient,
- *    which is the look this strip had before.
+ *    → the app's plain glassmorphism, blurring the same backdrop, over the
+ *    near-opaque channel gradient — the look this strip had before.
  *  - glass switched off → that gradient alone, so a low-tier device still gets a
  *    readable strip rather than controls floating on nothing.
- *
- * No haze pane goes under the slab. The strips are permanent chrome standing on
- * the mixer's own backdrop — a vertical wash plus one soft album glow — and a
- * gaussian blur of that is the same wash again, so five blur passes per frame
- * would buy nothing and an opaque frosted pane under a see-through slab is the
- * flat-slab failure that invariant exists to prevent.
  */
 @Composable
 fun FLChannelStrip(
@@ -88,6 +95,13 @@ fun FLChannelStrip(
     modifier: Modifier = Modifier,
     levels: BusLevels = BusLevels(),
     accentColor: Color = MaterialTheme.colorScheme.primary,
+    /**
+     * The backdrop to frost. Null when the caller has none, and the strip then
+     * takes the plain translucent glass rather than asking haze to blur a
+     * source that was never fed — which paints its base colour and reads as a
+     * solid container.
+     */
+    hazeState: HazeState? = null,
     /**
      * The glass material. The UI-panels settings by default: this strip is a
      * floating panel like the rest, not player chrome, so reading
@@ -124,10 +138,22 @@ fun FLChannelStrip(
     val inactiveButton = colors.surfaceContainerHighest.copy(alpha = 0.88f)
 
     // The pane's own colour. A tint chosen in the Studio wins, as it does on
-    // every other panel; with none set each channel keeps its own accent, which
-    // is the only thing telling five identical strips apart at a glance.
-    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else accent
+    // every other panel; with none set the channel accent tints it — that
+    // colour is most of what tells five identical strips apart at a glance.
+    //
+    // Pulled well back toward the surface rather than used neat. The mini
+    // player wears its accent at full strength across a 64dp bar; a channel
+    // strip is a 60x600dp column, and the same colour over that much area
+    // stopped reading as tinted glass and started reading as a painted plastic
+    // panel — five of them side by side, each a different flat colour. The
+    // selected one carries more of it, which is the same "this one is live"
+    // signal its badge and border already give.
+    val paneAccent = lerp(colors.surfaceContainerHigh, accent, if (isSelected) 0.5f else 0.3f)
+    val tint = if (glass.tintColor != 0) Color(glass.tintColor) else paneAccent
     val flat = LocalLowPerformance.current.disableLiquidGlass
+    val allowHaze = LocalPerformanceProfile.current.allowHazeBlur
+    val frostBg = colors.background
+    val isDark = frostBg.luminance() <= 0.5f
 
     CompositionLocalProvider(LocalPlayerGlass provides glass) {
     // Asks whether the shader is really coming (it reads the settings provided
@@ -160,6 +186,27 @@ fun FLChannelStrip(
         // Its own node so the glass is relit on its own layer and the fader,
         // meters and labels on top stay crisp instead of being refracted.
         if (shaded) {
+            // Haze first: the real gaussian blur of the backdrop, which is what
+            // you see *through* the strip. Without it the artwork reads sharp
+            // through a 0.2-opacity body and fights the fader and the labels.
+            if (hazeState != null && allowHaze && glass.hazeBlurDp > 0f) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .hazeEffect(
+                            state = hazeState,
+                            style = HazeStyle(
+                                backgroundColor = frostBg,
+                                blurRadius = glass.hazeBlurDp.dp,
+                                // The app's one frost recipe, scaled by the
+                                // listener's Backdrop tint. Thin on purpose:
+                                // most of what reads through should be the art.
+                                tints = listOf(HazeTint(playerFrostTint(glass, isDark))),
+                                noiseFactor = 0f,
+                            )
+                        )
+                )
+            }
             Canvas(
                 modifier = Modifier
                     .matchParentSize()
@@ -176,6 +223,14 @@ fun FLChannelStrip(
                     .then(
                         // liquidGlass drops itself on LOW-tier devices; the
                         // `flat` check is the listener's own "off" switch.
+                        //
+                        // Deliberately NOT handed the haze source. This tier
+                        // stands on the near-opaque channel gradient, and a
+                        // blur pane draws OVER that fill rather than through
+                        // it — the gradient would be hidden and the strip left
+                        // with only frost to be legible against. The blurred
+                        // artwork belongs to the shader tier, where the slab is
+                        // see-through by design.
                         if (flat) {
                             Modifier
                         } else {

--- a/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/mixer/MixerScreen.kt
@@ -7,7 +7,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
@@ -75,6 +77,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -83,10 +88,15 @@ import tf.monochrome.android.audio.dsp.model.BusLevels
 import tf.monochrome.android.audio.dsp.model.MixPreset
 import tf.monochrome.android.ui.components.bounceClick
 import tf.monochrome.android.ui.components.liquidGlass
+import tf.monochrome.android.ui.player.AlbumColors
 import tf.monochrome.android.ui.player.DynamicAlbumGlow
+import tf.monochrome.android.ui.player.PlayerBlurredArtBackground
 import tf.monochrome.android.ui.player.PlayerDesignTokens
+import tf.monochrome.android.ui.player.PlayerViewModel
 import tf.monochrome.android.ui.player.dithered
 import tf.monochrome.android.ui.player.dynamicPlayerBackground
+import tf.monochrome.android.ui.player.rememberAlbumColors
+import tf.monochrome.android.ui.theme.ColorBlend
 import tf.monochrome.android.ui.theme.MonoDimens
 
 /** Curated per-bus channel colours (master keeps the album-derived primary).
@@ -125,7 +135,13 @@ private fun busAccent(dynamic: Boolean, base: Color, index: Int): Color =
 @Composable
 fun MixerScreen(
     navController: NavController,
-    viewModel: MixerViewModel
+    viewModel: MixerViewModel,
+    /**
+     * Only for what is playing — the cover the backdrop blurs, the palette it
+     * darkens with, and the two settings that govern both. The console itself
+     * is driven entirely by [viewModel].
+     */
+    playerViewModel: PlayerViewModel
 ) {
     // Frame-synced meter/tap polling: one native read per display frame, so
     // the VU meters and FX visuals update at the panel's native refresh rate
@@ -159,6 +175,40 @@ fun MixerScreen(
 
     var showInsertRack by remember { mutableStateOf(false) }
     var showResetConfirm by remember { mutableStateOf(false) }
+
+    // ── The backdrop the console's glass stands on ──────────────────────
+    // The same blurred, stretched album art the player shows, behind the same
+    // Appearance switch: a mixer full of glass with nothing but a flat wash
+    // behind it has nothing to be glass *of*.
+    val currentTrack by playerViewModel.currentTrack.collectAsStateWithLifecycle()
+    val blurredBackground by playerViewModel.playerBlurredBackground.collectAsStateWithLifecycle()
+    val dynamicColors by playerViewModel.dynamicColors.collectAsStateWithLifecycle()
+    val playerDynamicColor by playerViewModel.playerDynamicColor.collectAsStateWithLifecycle()
+    // The player's own rule for whether artwork is allowed to colour anything:
+    // both the master switch and the player-specific one. With either off the
+    // scrim over the art takes the theme accent, like the rest of this screen.
+    val artColors = if (dynamicColors && playerDynamicColor) {
+        rememberAlbumColors(currentTrack?.coverUrl)
+    } else {
+        AlbumColors(dominant = accent, vibrant = accent)
+    }
+    // The cover dissolves between tracks over the listener's own blend length,
+    // so the mixer's backdrop changes track at the speed the player's does.
+    val blendSeconds by playerViewModel.crossfadeDuration.collectAsStateWithLifecycle()
+    val colorTransitionMs by playerViewModel.colorTransitionMs.collectAsStateWithLifecycle()
+    val colorBlendMs = tf.monochrome.android.ui.theme.motionMillis(
+        ColorBlend.millisFor(blendSeconds, colorTransitionMs)
+    )
+    val blurBgAlpha by animateFloatAsState(
+        targetValue = if (blurredBackground) 1f else 0f,
+        animationSpec = tween(durationMillis = 400),
+        label = "mixerBlurredBg"
+    )
+    // What the console's glass blurs. The backdrop below is marked as the
+    // source and everything else on this screen is a SIBLING above it — a haze
+    // effect cannot sample a layer it is drawn inside, and one that tries
+    // paints the source's flat colour instead of a blur.
+    val mixerHaze = rememberHazeState()
 
     // ── Mixer ⇆ DSP-canvas drag-to-reveal transition ────────────────────
     // progress 0 = mixer fully shown, 1 = canvas fully shown. The two pages
@@ -259,15 +309,27 @@ fun MixerScreen(
             .fillMaxSize()
             .onSizeChanged { heightPx = it.height.toFloat() }
     ) {
-        // Background on its own node so the dither layer wraps just the
-        // gradient, not the whole screen's content.
-        Box(
-            Modifier
-                .matchParentSize()
-                .dithered()
-                .background(dynamicPlayerBackground(accent)),
-        )
-        DynamicAlbumGlow(accent)
+        // The whole backdrop — wash, artwork and glow — as one haze source, so a
+        // strip blurs all three together instead of one of them.
+        Box(Modifier.matchParentSize().hazeSource(mixerHaze)) {
+            // Background on its own node so the dither layer wraps just the
+            // gradient, not the whole screen's content.
+            Box(
+                Modifier
+                    .matchParentSize()
+                    .dithered()
+                    .background(dynamicPlayerBackground(accent)),
+            )
+            if (blurBgAlpha > 0.001f) {
+                PlayerBlurredArtBackground(
+                    coverUrl = currentTrack?.coverUrl,
+                    albumColors = artColors,
+                    blendMillis = colorBlendMs,
+                    alpha = { blurBgAlpha },
+                )
+            }
+            DynamicAlbumGlow(accent)
+        }
         if (composeCanvas) {
             // ── DSP Canvas View (slides down from the top) ───────────────
             Box(
@@ -465,6 +527,7 @@ fun MixerScreen(
                         selectedBusIndex = selectedBusIndex,
                         accent = accent,
                         channelDynamicColor = channelDynamicColor,
+                        hazeState = mixerHaze,
                         onSelectBus = { index ->
                             viewModel.selectBus(index)
                             showInsertRack = true
@@ -633,6 +696,8 @@ private fun ChannelStripRow(
     selectedBusIndex: Int,
     accent: Color,
     channelDynamicColor: Boolean,
+    /** The screen's backdrop, for the strips to frost. */
+    hazeState: HazeState,
     onSelectBus: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -650,6 +715,7 @@ private fun ChannelStripRow(
                     isSelected = index == selectedBusIndex,
                     levels = busLevels.getOrNull(index) ?: BusLevels(),
                     accentColor = if (bus.isMaster) accent else busAccent(channelDynamicColor, accent, bus.index),
+                    hazeState = hazeState,
                     onSelect = { onSelectBus(index) },
                     onGainChange = { viewModel.setBusGain(index, it) },
                     onPanChange = { viewModel.setBusPan(index, it) },

--- a/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/navigation/MonochromeNavHost.kt
@@ -508,7 +508,8 @@ fun MonochromeNavHost(initialRoute: String? = null) {
                     tf.monochrome.android.devedit.DevEditScreen("mixer") {
                         MixerScreen(
                             navController = navController,
-                            viewModel = hiltViewModel()
+                            viewModel = hiltViewModel(),
+                            playerViewModel = playerViewModel
                         )
                     }
                 }

--- a/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/tf/monochrome/android/ui/settings/SettingsScreen.kt
@@ -1012,7 +1012,7 @@ private fun InterfaceControls(viewModel: SettingsViewModel, navController: NavCo
         )
         SettingSwitchItem(
             title = "Blurred Album Background",
-            subtitle = "Behind the lyrics (collapsed and fullscreen): the album art stretched and heavily blurred",
+            subtitle = "Behind the player and the mixer: the album art stretched and heavily blurred",
             checked = playerBlurredBackground,
             onCheckedChange = { viewModel.setPlayerBlurredBackground(it) }
         )


### PR DESCRIPTION
Every bus and the master were a near-opaque gradient with a faint
glassmorphism wash on top — the one console in the app that stayed a
slab while the mini player, the search bars and the map panels all
turned to glass. Nothing anyone tuned in the Studio ever reached them.

They now take the UI panels material (LocalMiniPlayerGlass) and publish
it as LocalPlayerGlass for the shader, the same way GlassPanel does with
the settings it is handed, in three tiers: the AGSL slab where the
shader will really run, the plain glassmorphism over the old gradient
where it will not, and that gradient alone with glass switched off, so a
low-tier device gets a readable strip rather than controls floating on
nothing. rememberLiquidGlassAvailable() answers which, so the slab is
drawn solid rather than hedged faint — a hedged fill leaves the shader
almost no heightfield to bevel and comes out a smudge with no edge.

The pane is its own node behind the controls, so the fader, the meters
and the labels standing on it stay crisp instead of being refracted, and
the press bounce moves to it so a tap presses the whole sheet. Each
channel keeps its own accent as the glass tint unless a tint is set in
the Studio, which is the only thing telling five identical strips apart.

No haze pane goes under the slab: the strips stand on the mixer's own
backdrop, a vertical wash plus one soft album glow, and a gaussian blur
of that is the same wash again — five blur passes a frame for nothing,
and an opaque frosted pane under a see-through slab is the flat-slab
failure docs/ui-invariants.md warns about.